### PR TITLE
fix: 手机端侧边栏缺少文档收集和AI助手2入口

### DIFF
--- a/src/components/layout/mobile-nav.tsx
+++ b/src/components/layout/mobile-nav.tsx
@@ -12,9 +12,10 @@ import {
   PenLine,
   Database,
   Menu,
-  X,
   Users,
   Bot,
+  Sparkles,
+  FolderInput,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -49,6 +50,11 @@ const navItems: NavItem[] = [
     icon: <FileText className="h-5 w-5" />,
   },
   {
+    title: "文档收集",
+    href: "/collections",
+    icon: <FolderInput className="h-5 w-5" />,
+  },
+  {
     title: "主数据",
     href: "/data",
     icon: <Database className="h-5 w-5" />,
@@ -67,6 +73,11 @@ const navItems: NavItem[] = [
     title: "AI 助手",
     href: "/ai-agent",
     icon: <Bot className="h-5 w-5" />,
+  },
+  {
+    title: "AI 助手 2",
+    href: "/ai-agent2",
+    icon: <Sparkles className="h-5 w-5" />,
   },
 ];
 


### PR DESCRIPTION
## Summary
- 移动端导航 (mobile-nav) 缺少「文档收集」和「AI 助手 2」两个菜单项
- 补齐与桌面端侧边栏一致的完整导航

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)