### PR TITLE
fix(agent2): 测试连接错误信息换行显示

### DIFF
--- a/src/components/agent2/model-manager.tsx
+++ b/src/components/agent2/model-manager.tsx
@@ -270,11 +270,11 @@ export function ModelManager({ settings, onUpdateSettings }: ModelManagerProps) 
             <Input type="password" placeholder="API Key (留空则不修改)" value={editForm.apiKey} onChange={e => setEditForm(f => ({ ...f, apiKey: e.target.value }))} />
           </div>
           <DialogFooter>
-            <div className="flex-1">
+            <div className="flex-1 min-w-0">
               {testResult && testResult.id === editingModel?.id && (
-                <span className={testResult.success ? "text-green-500 text-sm" : "text-destructive text-sm"}>
+                <p className={`text-sm break-all ${testResult.success ? "text-green-500" : "text-destructive"}`}>
                   {testResult.message}
-                </span>
+                </p>
               )}
             </div>
             <Button variant="outline" onClick={() => setEditOpen(false)}>取消</Button>


### PR DESCRIPTION
## Summary
- 修复测试连接错误信息超出对话框范围的问题
- 添加 break-all 让长错误信息换行显示
- 使用 p 标签替代 span 更好地处理多行文本

## Test Plan
- [ ] 添加自定义模型后编辑并测试连接
- [ ] 验证错误信息能正常换行显示在对话框内

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)