### PR TITLE
[Feature] AI Agent2 MCP 集成

### DIFF
--- a/docs/superpowers/plans/2026-04-10-ai-agent2-mcp.md
+++ b/docs/superpowers/plans/2026-04-10-ai-agent2-mcp.md
@@ -1,0 +1,1780 @@
+# AI Agent2 MCP 集成实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在 ai-agent2 上集成 MCP（Model Context Protocol）功能，允许管理员配置外部 MCP 服务器，AI 在对话时调用这些工具获取外部数据。
+
+**Architecture:** 新增 `Agent2McpServer` 数据库表存储 MCP 服务器配置，服务层处理 CRUD 和连接测试，聊天流程中通过 `@ai-sdk/mcp` 的 `createMCPClient` 连接各服务器获取工具，与内置工具合并后传给 `streamText`。前端在设置弹窗中新增 MCP 管理选项卡。
+
+**Tech Stack:** Prisma v7, Vercel AI SDK v6 (`@ai-sdk/mcp`), Zod, shadcn/ui v4, Next.js 16 Route Handlers
+
+---
+
+### Task 1: 安装 @ai-sdk/mcp 依赖
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: 安装 @ai-sdk/mcp 包**
+
+```bash
+cd /home/z/test-hub/docx-template-system && npm install @ai-sdk/mcp
+```
+
+- [ ] **Step 2: 验证安装成功**
+
+```bash
+ls node_modules/@ai-sdk/mcp/dist/index.js
+```
+
+Expected: 文件存在
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: 安装 @ai-sdk/mcp 依赖"
+```
+
+---
+
+### Task 2: Prisma Schema — 新增 McpTransportType 枚举和 Agent2McpServer 模型
+
+**Files:**
+- Modify: `prisma/schema.prisma` (文件末尾，`notifications` 模型之后)
+
+- [ ] **Step 1: 在 `prisma/schema.prisma` 末尾追加枚举和模型**
+
+在文件末尾追加以下内容（在最后一个 `}` 之后）：
+
+```prisma
+// ========== Agent2 MCP (Model Context Protocol) ==========
+
+enum McpTransportType {
+  stdio
+  sse
+  http
+}
+
+model Agent2McpServer {
+  id            String            @id @default(cuid())
+  name          String            @unique
+  description   String?
+  transportType McpTransportType
+  config        Json
+  enabled       Boolean           @default(true)
+  createdAt     DateTime          @default(now())
+  updatedAt     DateTime          @updatedAt
+}
+```
+
+- [ ] **Step 2: 推送 schema 到数据库**
+
+```bash
+npx prisma db push
+```
+
+Expected: 成功，无报错
+
+- [ ] **Step 3: 重新生成 Prisma Client**
+
+```bash
+npx prisma generate
+```
+
+Expected: 成功，输出中包含 `Agent2McpServer` 和 `McpTransportType`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add prisma/schema.prisma src/generated/
+git commit -m "feat(agent2): 新增 McpTransportType 枚举和 Agent2McpServer 模型"
+```
+
+---
+
+### Task 3: 类型定义 — 新增 MCP 相关类型
+
+**Files:**
+- Modify: `src/types/agent2.ts` (文件末尾追加)
+
+- [ ] **Step 1: 在 `src/types/agent2.ts` 末尾追加 MCP 类型**
+
+```typescript
+// ============ MCP Server ============
+export interface Agent2McpServerItem {
+  id: string;
+  name: string;
+  description: string | null;
+  transportType: "stdio" | "sse" | "http";
+  config: McpServerConfig;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type McpServerConfig =
+  | { type: "stdio"; command: string; args?: string[]; env?: Record<string, string>; timeout?: number }
+  | { type: "sse"; url: string; headers?: Record<string, string>; timeout?: number }
+  | { type: "http"; url: string; headers?: Record<string, string>; timeout?: number };
+
+export interface McpToolInfo {
+  name: string;
+  description?: string;
+  inputSchema?: object;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/types/agent2.ts
+git commit -m "feat(agent2): 新增 MCP 服务器和工具相关类型定义"
+```
+
+---
+
+### Task 4: 验证器 — 新增 MCP 服务器校验 Schema
+
+**Files:**
+- Modify: `src/validators/agent2.ts` (文件末尾追加)
+
+- [ ] **Step 1: 在 `src/validators/agent2.ts` 末尾追加 MCP 验证器**
+
+在 `export type UpdateSettingsInput` 行之后追加：
+
+```typescript
+// ============ MCP Server ============
+export const createMcpServerSchema = z.discriminatedUnion("transportType", [
+  z.object({
+    name: z.string().min(1).max(50),
+    description: z.string().max(200).optional(),
+    transportType: z.literal("stdio"),
+    config: z.object({
+      command: z.string().min(1),
+      args: z.array(z.string()).optional(),
+      env: z.record(z.string()).optional(),
+      timeout: z.number().min(1000).max(60000).optional(),
+    }),
+  }),
+  z.object({
+    name: z.string().min(1).max(50),
+    description: z.string().max(200).optional(),
+    transportType: z.literal("sse"),
+    config: z.object({
+      url: z.string().url(),
+      headers: z.record(z.string()).optional(),
+      timeout: z.number().min(1000).max(60000).optional(),
+    }),
+  }),
+  z.object({
+    name: z.string().min(1).max(50),
+    description: z.string().max(200).optional(),
+    transportType: z.literal("http"),
+    config: z.object({
+      url: z.string().url(),
+      headers: z.record(z.string()).optional(),
+      timeout: z.number().min(1000).max(60000).optional(),
+    }),
+  }),
+]);
+
+export const updateMcpServerSchema = z.object({
+  name: z.string().min(1).max(50).optional(),
+  description: z.string().max(200).optional().nullable(),
+  enabled: z.boolean().optional(),
+  config: z
+    .object({
+      command: z.string().min(1).optional(),
+      args: z.array(z.string()).optional(),
+      env: z.record(z.string()).optional(),
+      url: z.string().url().optional(),
+      headers: z.record(z.string()).optional(),
+      timeout: z.number().min(1000).max(60000).optional(),
+    })
+    .optional(),
+});
+
+export type CreateMcpServerInput = z.infer<typeof createMcpServerSchema>;
+export type UpdateMcpServerInput = z.infer<typeof updateMcpServerSchema>;
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/validators/agent2.ts
+git commit -m "feat(agent2): 新增 MCP 服务器创建/更新校验 Schema"
+```
+
+---
+
+### Task 5: 服务层 — MCP 服务器 CRUD 服务
+
+**Files:**
+- Create: `src/lib/services/agent2-mcp.service.ts`
+
+- [ ] **Step 1: 创建 `src/lib/services/agent2-mcp.service.ts`**
+
+```typescript
+import { db } from "@/lib/db";
+import { encrypt, decrypt } from "./agent2-model.service";
+import type { Agent2McpServerItem, McpServerConfig } from "@/types/agent2";
+import type { ServiceResult } from "@/types/data-table";
+
+// ── Helpers ──
+
+type McpServerRow = {
+  id: string;
+  name: string;
+  description: string | null;
+  transportType: "stdio" | "sse" | "http";
+  config: unknown;
+  enabled: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+/**
+ * 加密 config 中的敏感字段（headers 的值、env 的值）
+ */
+function encryptConfig(
+  transportType: "stdio" | "sse" | "http",
+  rawConfig: Record<string, unknown>
+): Record<string, unknown> {
+  const config = { ...rawConfig };
+
+  if (config.headers && typeof config.headers === "object") {
+    const encryptedHeaders: Record<string, string> = {};
+    for (const [key, value] of Object.entries(
+      config.headers as Record<string, string>
+    )) {
+      encryptedHeaders[key] = encrypt(value);
+    }
+    config.headers = encryptedHeaders;
+  }
+
+  if (transportType === "stdio" && config.env && typeof config.env === "object") {
+    const encryptedEnv: Record<string, string> = {};
+    for (const [key, value] of Object.entries(
+      config.env as Record<string, string>
+    )) {
+      encryptedEnv[key] = encrypt(value);
+    }
+    config.env = encryptedEnv;
+  }
+
+  return config;
+}
+
+/**
+ * 解密 config 中的敏感字段
+ */
+function decryptConfig(
+  transportType: "stdio" | "sse" | "http",
+  rawConfig: Record<string, unknown>
+): Record<string, unknown> {
+  const config = { ...rawConfig };
+
+  if (config.headers && typeof config.headers === "object") {
+    const decryptedHeaders: Record<string, string> = {};
+    for (const [key, value] of Object.entries(
+      config.headers as Record<string, string>
+    )) {
+      try {
+        decryptedHeaders[key] = decrypt(value);
+      } catch {
+        // 如果解密失败，可能是未加密的值（向后兼容）
+        decryptedHeaders[key] = value;
+      }
+    }
+    config.headers = decryptedHeaders;
+  }
+
+  if (transportType === "stdio" && config.env && typeof config.env === "object") {
+    const decryptedEnv: Record<string, string> = {};
+    for (const [key, value] of Object.entries(
+      config.env as Record<string, string>
+    )) {
+      try {
+        decryptedEnv[key] = decrypt(value);
+      } catch {
+        decryptedEnv[key] = value;
+      }
+    }
+    config.env = decryptedEnv;
+  }
+
+  return config;
+}
+
+/**
+ * 将 config 中敏感字段掩码显示（用于 API 返回）
+ */
+function maskConfig(
+  transportType: "stdio" | "sse" | "http",
+  rawConfig: Record<string, unknown>
+): Record<string, unknown> {
+  const config = { ...rawConfig };
+
+  if (config.headers && typeof config.headers === "object") {
+    const maskedHeaders: Record<string, string> = {};
+    for (const key of Object.keys(config.headers as Record<string, string>)) {
+      maskedHeaders[key] = "••••••••";
+    }
+    config.headers = maskedHeaders;
+  }
+
+  if (transportType === "stdio" && config.env && typeof config.env === "object") {
+    const maskedEnv: Record<string, string> = {};
+    for (const key of Object.keys(config.env as Record<string, string>)) {
+      maskedEnv[key] = "••••••••";
+    }
+    config.env = maskedEnv;
+  }
+
+  return config;
+}
+
+function mapMcpServerItem(row: McpServerRow): Agent2McpServerItem {
+  const rawConfig = row.config as Record<string, unknown>;
+  rawConfig.type = row.transportType;
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    transportType: row.transportType,
+    config: maskConfig(row.transportType, rawConfig) as unknown as McpServerConfig,
+    enabled: row.enabled,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+// ── CRUD ──
+
+export async function listMcpServers(): Promise<
+  ServiceResult<Agent2McpServerItem[]>
+> {
+  const servers = await db.agent2McpServer.findMany({
+    orderBy: { createdAt: "desc" },
+  });
+
+  return {
+    success: true,
+    data: servers.map(mapMcpServerItem),
+  };
+}
+
+export async function createMcpServer(data: {
+  name: string;
+  description?: string;
+  transportType: "stdio" | "sse" | "http";
+  config: Record<string, unknown>;
+}): Promise<ServiceResult<Agent2McpServerItem>> {
+  // Check unique name
+  const existing = await db.agent2McpServer.findUnique({
+    where: { name: data.name },
+  });
+  if (existing) {
+    return {
+      success: false,
+      error: { code: "DUPLICATE_NAME", message: `MCP 服务器名称 "${data.name}" 已存在` },
+    };
+  }
+
+  const encryptedConfig = encryptConfig(data.transportType, data.config);
+
+  const server = await db.agent2McpServer.create({
+    data: {
+      name: data.name,
+      description: data.description || null,
+      transportType: data.transportType,
+      config: encryptedConfig as unknown as Record<string, unknown>,
+      enabled: true,
+    },
+  });
+
+  return {
+    success: true,
+    data: mapMcpServerItem(server as unknown as McpServerRow),
+  };
+}
+
+export async function updateMcpServer(
+  id: string,
+  data: {
+    name?: string;
+    description?: string | null;
+    enabled?: boolean;
+    config?: Record<string, unknown>;
+  }
+): Promise<ServiceResult<Agent2McpServerItem>> {
+  const existing = await db.agent2McpServer.findUnique({ where: { id } });
+  if (!existing) {
+    return {
+      success: false,
+      error: { code: "NOT_FOUND", message: "MCP 服务器不存在" },
+    };
+  }
+
+  // Check unique name if name is being changed
+  if (data.name && data.name !== existing.name) {
+    const duplicate = await db.agent2McpServer.findUnique({
+      where: { name: data.name },
+    });
+    if (duplicate) {
+      return {
+        success: false,
+        error: { code: "DUPLICATE_NAME", message: `MCP 服务器名称 "${data.name}" 已存在` },
+      };
+    }
+  }
+
+  const updateData: Record<string, unknown> = {};
+  if (data.name !== undefined) updateData.name = data.name;
+  if (data.description !== undefined) updateData.description = data.description;
+  if (data.enabled !== undefined) updateData.enabled = data.enabled;
+  if (data.config !== undefined) {
+    const transportType = existing.transportType as "stdio" | "sse" | "http";
+    updateData.config = encryptConfig(transportType, data.config);
+  }
+
+  const updated = await db.agent2McpServer.update({
+    where: { id },
+    data: updateData,
+  });
+
+  return {
+    success: true,
+    data: mapMcpServerItem(updated as unknown as McpServerRow),
+  };
+}
+
+export async function deleteMcpServer(
+  id: string
+): Promise<ServiceResult<{ id: string }>> {
+  const existing = await db.agent2McpServer.findUnique({ where: { id } });
+  if (!existing) {
+    return {
+      success: false,
+      error: { code: "NOT_FOUND", message: "MCP 服务器不存在" },
+    };
+  }
+
+  await db.agent2McpServer.delete({ where: { id } });
+
+  return {
+    success: true,
+    data: { id },
+  };
+}
+
+/**
+ * 获取已解密的配置（用于创建 MCP 客户端连接）
+ */
+export async function getDecryptedMcpServer(
+  id: string
+): Promise<
+  ServiceResult<{
+    id: string;
+    name: string;
+    transportType: "stdio" | "sse" | "http";
+    config: Record<string, unknown>;
+  }>
+> {
+  const server = await db.agent2McpServer.findUnique({ where: { id } });
+  if (!server) {
+    return {
+      success: false,
+      error: { code: "NOT_FOUND", message: "MCP 服务器不存在" },
+    };
+  }
+
+  const rawConfig = server.config as Record<string, unknown>;
+  rawConfig.type = server.transportType;
+  const decryptedConfig = decryptConfig(
+    server.transportType as "stdio" | "sse" | "http",
+    rawConfig
+  );
+
+  return {
+    success: true,
+    data: {
+      id: server.id,
+      name: server.name,
+      transportType: server.transportType as "stdio" | "sse" | "http",
+      config: decryptedConfig,
+    },
+  };
+}
+
+/**
+ * 获取所有已启用的 MCP 服务器（解密配置）
+ */
+export async function getEnabledMcpServers(): Promise<
+  ServiceResult<
+    Array<{
+      id: string;
+      name: string;
+      transportType: "stdio" | "sse" | "http";
+      config: Record<string, unknown>;
+    }>
+  >
+> {
+  const servers = await db.agent2McpServer.findMany({
+    where: { enabled: true },
+    orderBy: { createdAt: "desc" },
+  });
+
+  const result = servers.map((server) => {
+    const rawConfig = server.config as Record<string, unknown>;
+    rawConfig.type = server.transportType;
+    const decryptedConfig = decryptConfig(
+      server.transportType as "stdio" | "sse" | "http",
+      rawConfig
+    );
+    return {
+      id: server.id,
+      name: server.name,
+      transportType: server.transportType as "stdio" | "sse" | "http",
+      config: decryptedConfig,
+    };
+  });
+
+  return { success: true, data: result };
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/lib/services/agent2-mcp.service.ts
+git commit -m "feat(agent2): 新增 MCP 服务器 CRUD 服务层"
+```
+
+---
+
+### Task 6: MCP 客户端管理 — 创建连接和获取工具
+
+**Files:**
+- Create: `src/lib/agent2/mcp-client.ts`
+
+- [ ] **Step 1: 创建 `src/lib/agent2/mcp-client.ts`**
+
+```typescript
+import { createMCPClient, type MCPClient } from "@ai-sdk/mcp";
+import type { Tool } from "ai";
+import { getEnabledMcpServers } from "@/lib/services/agent2-mcp.service";
+
+interface McpToolsResult {
+  tools: Record<string, Tool>;
+  clients: MCPClient[];
+}
+
+/**
+ * 创建单个 MCP 客户端连接
+ */
+async function createMcpConnection(
+  server: {
+    name: string;
+    transportType: "stdio" | "sse" | "http";
+    config: Record<string, unknown>;
+  },
+  timeout: number = 5000
+): Promise<{ client: MCPClient; tools: Record<string, Tool> } | null> {
+  try {
+    let transport: unknown;
+
+    switch (server.transportType) {
+      case "stdio": {
+        // 动态导入 stdio 传输
+        const { Experimental_StdioMCPTransport } = await import(
+          "@ai-sdk/mcp/mcp-stdio"
+        );
+        transport = new Experimental_StdioMCPTransport({
+          command: server.config.command as string,
+          args: server.config.args as string[] | undefined,
+          env: server.config.env as Record<string, string> | undefined,
+        });
+        break;
+      }
+      case "sse": {
+        transport = {
+          type: "sse" as const,
+          url: server.config.url as string,
+          headers: server.config.headers as Record<string, string> | undefined,
+        };
+        break;
+      }
+      case "http": {
+        transport = {
+          type: "http" as const,
+          url: server.config.url as string,
+          headers: server.config.headers as Record<string, string> | undefined,
+        };
+        break;
+      }
+    }
+
+    const client = await createMCPClient({ transport });
+
+    // Set timeout for connection
+    const toolsPromise = client.tools();
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error(`MCP 服务器 "${server.name}" 连接超时 (${timeout}ms)`)),
+        timeout
+      )
+    );
+
+    const rawTools = await Promise.race([toolsPromise, timeoutPromise]);
+
+    // Prefix tool names with mcp__{serverName}__ and add description tag
+    const prefixedTools: Record<string, Tool> = {};
+    for (const [toolName, toolDef] of Object.entries(rawTools)) {
+      const prefixedName = `mcp__${server.name}__${toolName}`;
+      prefixedTools[prefixedName] = {
+        ...toolDef,
+        description: `[MCP: ${server.name}] ${(toolDef as Tool).description || toolName}`,
+      } as Tool;
+    }
+
+    return { client, tools: prefixedTools };
+  } catch (error) {
+    console.warn(
+      `[mcp-client] Failed to connect to "${server.name}":`,
+      error instanceof Error ? error.message : error
+    );
+    return null;
+  }
+}
+
+/**
+ * 获取所有已启用 MCP 服务器的工具
+ * 单个服务器连接失败不影响其他服务器
+ */
+export async function getEnabledMcpTools(): Promise<McpToolsResult> {
+  const result: McpToolsResult = {
+    tools: {},
+    clients: [],
+  };
+
+  const serversResult = await getEnabledMcpServers();
+  if (!serversResult.success || serversResult.data.length === 0) {
+    return result;
+  }
+
+  // Connect to all servers in parallel
+  const connections = await Promise.all(
+    serversResult.data.map((server) => {
+      const timeout =
+        typeof server.config.timeout === "number" ? server.config.timeout : 5000;
+      return createMcpConnection(server, timeout);
+    })
+  );
+
+  for (const connection of connections) {
+    if (connection) {
+      result.tools = { ...result.tools, ...connection.tools };
+      result.clients.push(connection.client);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * 测试 MCP 服务器连接并返回工具列表
+ */
+export async function testMcpConnection(
+  server: {
+    name: string;
+    transportType: "stdio" | "sse" | "http";
+    config: Record<string, unknown>;
+  },
+  timeout: number = 5000
+): Promise<{
+  success: boolean;
+  tools?: Array<{ name: string; description?: string; inputSchema?: unknown }>;
+  error?: string;
+}> {
+  try {
+    const connection = await createMcpConnection(server, timeout);
+    if (!connection) {
+      return { success: false, error: "连接失败" };
+    }
+
+    // Get tool info without the prefix
+    const toolList = Object.entries(connection.tools).map(([name, toolDef]) => ({
+      name: name.replace(`mcp__${server.name}__`, ""),
+      description: (toolDef as Tool).description?.replace(`[MCP: ${server.name}] `, ""),
+    }));
+
+    await connection.client.close();
+    return { success: true, tools: toolList };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "连接测试失败",
+    };
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/lib/agent2/mcp-client.ts
+git commit -m "feat(agent2): 新增 MCP 客户端管理和工具获取模块"
+```
+
+---
+
+### Task 7: API 路由 — MCP 服务器列表和添加
+
+**Files:**
+- Create: `src/app/api/agent2/admin/mcp/route.ts`
+
+- [ ] **Step 1: 创建目录结构**
+
+```bash
+mkdir -p src/app/api/agent2/admin/mcp/\[id\]/test
+```
+
+- [ ] **Step 2: 创建 `src/app/api/agent2/admin/mcp/route.ts`**
+
+遵循 `src/app/api/agent2/admin/models/route.ts` 的模式：
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { ZodError } from "zod";
+import { listMcpServers, createMcpServer } from "@/lib/services/agent2-mcp.service";
+import { createMcpServerSchema } from "@/validators/agent2";
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "未登录" } },
+      { status: 401 }
+    );
+  }
+
+  if (session.user.role !== "ADMIN") {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "需要管理员权限" } },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const result = await listMcpServers();
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+
+    return NextResponse.json({ success: true, data: result.data });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message:
+            error instanceof Error ? error.message : "加载 MCP 服务器列表失败",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "未登录" } },
+      { status: 401 }
+    );
+  }
+
+  if (session.user.role !== "ADMIN") {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "需要管理员权限" } },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const parsed = createMcpServerSchema.parse(body);
+    const result = await createMcpServer({
+      name: parsed.name,
+      description: parsed.description,
+      transportType: parsed.transportType,
+      config: parsed.config as Record<string, unknown>,
+    });
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+
+    return NextResponse.json({ success: true, data: result.data }, { status: 201 });
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "参数校验失败" } },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message:
+            error instanceof Error ? error.message : "创建 MCP 服务器失败",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/agent2/admin/mcp/route.ts
+git commit -m "feat(agent2): 新增 MCP 服务器列表和添加 API"
+```
+
+---
+
+### Task 8: API 路由 — MCP 服务器更新、删除和连接测试
+
+**Files:**
+- Create: `src/app/api/agent2/admin/mcp/[id]/route.ts`
+- Create: `src/app/api/agent2/admin/mcp/[id]/test/route.ts`
+
+- [ ] **Step 1: 创建 `src/app/api/agent2/admin/mcp/[id]/route.ts`**
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { ZodError } from "zod";
+import {
+  updateMcpServer,
+  deleteMcpServer,
+} from "@/lib/services/agent2-mcp.service";
+import { updateMcpServerSchema } from "@/validators/agent2";
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: RouteContext
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "未登录" } },
+      { status: 401 }
+    );
+  }
+
+  if (session.user.role !== "ADMIN") {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "需要管理员权限" } },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const parsed = updateMcpServerSchema.parse(body);
+    const result = await updateMcpServer(id, {
+      name: parsed.name,
+      description: parsed.description,
+      enabled: parsed.enabled,
+      config: parsed.config as Record<string, unknown> | undefined,
+    });
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+
+    return NextResponse.json({ success: true, data: result.data });
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "参数校验失败" } },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message:
+            error instanceof Error ? error.message : "更新 MCP 服务器失败",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: RouteContext
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "未登录" } },
+      { status: 401 }
+    );
+  }
+
+  if (session.user.role !== "ADMIN") {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "需要管理员权限" } },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const { id } = await params;
+    const result = await deleteMcpServer(id);
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+
+    return NextResponse.json({ success: true, data: result.data });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message:
+            error instanceof Error ? error.message : "删除 MCP 服务器失败",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}
+```
+
+- [ ] **Step 2: 创建 `src/app/api/agent2/admin/mcp/[id]/test/route.ts`**
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { getDecryptedMcpServer } from "@/lib/services/agent2-mcp.service";
+import { testMcpConnection } from "@/lib/agent2/mcp-client";
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(
+  _request: NextRequest,
+  { params }: RouteContext
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "未登录" } },
+      { status: 401 }
+    );
+  }
+
+  if (session.user.role !== "ADMIN") {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "需要管理员权限" } },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const { id } = await params;
+    const serverResult = await getDecryptedMcpServer(id);
+    if (!serverResult.success) {
+      return NextResponse.json({ error: serverResult.error }, { status: 400 });
+    }
+
+    const server = serverResult.data;
+    const timeout =
+      typeof server.config.timeout === "number" ? server.config.timeout : 5000;
+
+    const testResult = await testMcpConnection(server, timeout);
+
+    if (!testResult.success) {
+      return NextResponse.json({
+        success: false,
+        error: { code: "CONNECTION_FAILED", message: testResult.error },
+      });
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: { tools: testResult.tools },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message:
+            error instanceof Error ? error.message : "MCP 连接测试失败",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/agent2/admin/mcp/
+git commit -m "feat(agent2): 新增 MCP 服务器更新、删除和连接测试 API"
+```
+
+---
+
+### Task 9: 聊天流程集成 — 注入 MCP 工具
+
+**Files:**
+- Modify: `src/app/api/agent2/conversations/[id]/chat/route.ts`
+
+- [ ] **Step 1: 在 `chat/route.ts` 中导入 MCP 工具获取函数**
+
+在现有 import 区末尾追加：
+
+```typescript
+import { getEnabledMcpTools } from "@/lib/agent2/mcp-client";
+```
+
+- [ ] **Step 2: 在 `streamText` 调用前获取并合并 MCP 工具**
+
+在 `src/app/api/agent2/conversations/[id]/chat/route.ts` 中，找到以下行（约第 77 行）：
+
+```typescript
+    const tools = createTools(conversationId, messageId, autoConfirm);
+```
+
+在这行之后、`// Load conversation history` 注释之前，插入：
+
+```typescript
+    // Get MCP tools from enabled servers
+    const { tools: mcpTools, clients: mcpClients } = await getEnabledMcpTools();
+    const allTools = { ...tools, ...mcpTools };
+```
+
+- [ ] **Step 3: 替换 streamText 中的 tools 参数和添加 MCP 清理**
+
+找到 `const result = streamText({` 调用（约第 106 行），将 `tools,` 改为 `tools: allTools,`。
+
+然后在 `onFinish` 回调中，在 `try` 块开头（`const persistableMessages` 之前）添加 MCP 客户端关闭：
+
+```typescript
+          // Close MCP client connections
+          for (const client of mcpClients) {
+            try { await client.close(); } catch { /* best effort */ }
+          }
+```
+
+同样在 `catch (error)` 块中的 `console.error("Chat error:", error);` 之前添加：
+
+```typescript
+    // Close MCP clients on error
+    for (const client of mcpClients) {
+      try { await client.close(); } catch { /* best effort */ }
+    }
+```
+
+注意：`mcpClients` 变量需要在 try 块外部声明。在 `try` 块开始处声明 `let mcpClients: MCPClient[] = [];`，然后在赋值时改为 `const mcpResult = await getEnabledMcpTools(); mcpClients = mcpResult.clients;`。为简化，可以直接在 try 内赋值，但在 catch 中需要确保 mcpClients 已定义。
+
+实际修改方案：在 try 块最开头声明：
+
+```typescript
+  try {
+    const { id: conversationId } = await params;
+    // ... existing code ...
+```
+
+改为先声明 mcpClients：
+
+```typescript
+  let mcpClients: import("@ai-sdk/mcp").MCPClient[] = [];
+  try {
+    const { id: conversationId } = await params;
+```
+
+然后在获取 MCP 工具的地方赋值：
+
+```typescript
+    const mcpResult = await getEnabledMcpTools();
+    mcpClients = mcpResult.clients;
+    const allTools = { ...tools, ...mcpResult.tools };
+```
+
+在 catch 块添加清理：
+
+```typescript
+  } catch (error) {
+    for (const client of mcpClients) {
+      try { await client.close(); } catch { /* best effort */ }
+    }
+    // ... existing error handling ...
+```
+
+- [ ] **Step 4: 验证 TypeScript 编译**
+
+```bash
+npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: 无新增错误
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/api/agent2/conversations/
+git commit -m "feat(agent2): 聊天流程集成 MCP 工具"
+```
+
+---
+
+### Task 10: 系统提示增强 — 增加 MCP 工具说明
+
+**Files:**
+- Modify: `src/lib/agent2/context-builder.ts`
+
+- [ ] **Step 1: 在 `buildSystemPrompt()` 中添加 MCP 工具上下文**
+
+在 `src/lib/agent2/context-builder.ts` 中，修改 `buildSystemPrompt` 函数，在 `let tableContext = "";` 之后添加 MCP 上下文获取：
+
+```typescript
+  let mcpContext = "";
+
+  try {
+    const { getEnabledMcpServers } = await import("@/lib/services/agent2-mcp.service");
+    const serversResult = await getEnabledMcpServers();
+    if (serversResult.success && serversResult.data.length > 0) {
+      mcpContext = "\n## 可用的 MCP 外部工具\n";
+      mcpContext += "你还可以使用以下 MCP 外部工具来获取外部数据。工具名称格式为 `mcp__服务器名__工具名`。\n\n";
+      for (const server of serversResult.data) {
+        mcpContext += `- **${server.name}** (${server.transportType}): ${server.config.url || server.config.command || ""}\n`;
+      }
+      mcpContext += "\n提示：使用 MCP 工具前，先了解该工具的参数要求。MCP 工具名称前缀为 `mcp__`。\n";
+    }
+  } catch {
+    // MCP 上下文获取失败不影响系统提示
+  }
+```
+
+然后在最后的 `const text = ...` 模板字符串中，在 `${tableContext}` 之后插入 `${mcpContext}`：
+
+找到：
+```typescript
+	${tableContext}
+	## 回答语言
+```
+
+改为：
+```typescript
+	${tableContext}
+	${mcpContext}
+	## 回答语言
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/lib/agent2/context-builder.ts
+git commit -m "feat(agent2): 系统提示增加 MCP 外部工具说明"
+```
+
+---
+
+### Task 11: 确认机制 — 新增 MCP 工具类别
+
+**Files:**
+- Modify: `src/lib/agent2/confirm-store.ts`
+- Modify: `src/components/agent2/settings-dialog.tsx`
+
+- [ ] **Step 1: 在 `confirm-store.ts` 中注册 MCP 工具的风险消息**
+
+在 `RISK_MESSAGES` 对象（约第 18 行）中追加：
+
+```typescript
+};
+
+// MCP tool risk messages are handled dynamically — tools matching mcp__* get a generic message
+```
+
+然后在 `getRiskMessage` 函数中，在 `return RISK_MESSAGES[toolName] || "此操作需要确认";` 之前添加 MCP 工具检测：
+
+找到：
+```typescript
+export function getRiskMessage(toolName: string): string {
+  return RISK_MESSAGES[toolName] || "此操作需要确认";
+}
+```
+
+改为：
+```typescript
+export function getRiskMessage(toolName: string): string {
+  if (RISK_MESSAGES[toolName]) return RISK_MESSAGES[toolName];
+  if (toolName.startsWith("mcp__")) {
+    const serverName = toolName.split("__")[1] || "";
+    return `此操作将调用外部 MCP 服务器 "${serverName}" 的工具`;
+  }
+  return "此操作需要确认";
+}
+```
+
+- [ ] **Step 2: 在 `settings-dialog.tsx` 中添加 MCP 工具类别到自动确认列表**
+
+在 `src/components/agent2/settings-dialog.tsx` 中的 `toolCategories` 数组（约第 49 行）追加一项：
+
+```typescript
+  const toolCategories = [
+    { key: "read", label: "查询类工具", description: "搜索、查询、聚合统计" },
+    { key: "write", label: "创建类工具", description: "创建记录、生成文档" },
+    { key: "delete", label: "删除类工具", description: "删除记录" },
+    { key: "execute", label: "执行类工具", description: "代码执行" },
+    { key: "mcp", label: "MCP 外部工具", description: "调用外部 MCP 服务器工具" },
+  ]
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/agent2/confirm-store.ts src/components/agent2/settings-dialog.tsx
+git commit -m "feat(agent2): 新增 MCP 工具确认类别支持"
+```
+
+---
+
+### Task 12: 工具确认弹窗 — MCP 工具来源标记
+
+**Files:**
+- Modify: `src/components/agent2/tool-confirm-dialog.tsx`
+- Modify: `src/components/agent2/message-parts.tsx`
+
+- [ ] **Step 1: 在 `tool-confirm-dialog.tsx` 中为 MCP 工具名称添加来源标记**
+
+找到显示工具名称的地方（约第 88 行）：
+
+```typescript
+            <code className="text-sm bg-muted px-2 py-1 rounded">{toolName}</code>
+```
+
+改为：
+
+```typescript
+            <code className="text-sm bg-muted px-2 py-1 rounded">
+              {toolName.startsWith("mcp__") ? (
+                <>{toolName} <span className="text-xs text-muted-foreground">[外部工具]</span></>
+              ) : (
+                toolName
+              )}
+            </code>
+```
+
+- [ ] **Step 2: 在 `message-parts.tsx` 中为 MCP 工具添加类别检测**
+
+找到 `getToolProgressLabel` 函数中的 `default:` 分支（约第 59 行）：
+
+```typescript
+    default:
+      return "正在处理工具调用"
+```
+
+改为：
+
+```typescript
+    default:
+      if (toolName.startsWith("mcp__")) {
+        const serverName = toolName.split("__")[1] || "";
+        return `正在调用 ${serverName} 工具`;
+      }
+      return "正在处理工具调用"
+```
+
+然后在确认对话框中传递 MCP 工具的 category。找到 `toolCategory: confirmOutput.toolCategory || "execute",` 这一行（约第 277 行），改为：
+
+```typescript
+                            toolCategory: confirmOutput.toolCategory || (toolPart.toolName.startsWith("mcp__") ? "mcp" : "execute"),
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/agent2/tool-confirm-dialog.tsx src/components/agent2/message-parts.tsx
+git commit -m "feat(agent2): MCP 工具来源标记和进度显示"
+```
+
+---
+
+### Task 13: 前端组件 — MCP 服务器管理器
+
+**Files:**
+- Create: `src/components/agent2/mcp-server-manager.tsx`
+
+- [ ] **Step 1: 创建 `src/components/agent2/mcp-server-manager.tsx`**
+
+遵循 `model-manager.tsx` 的 UI 模式：
+
+```typescript
+"use client"
+
+import { useState, useEffect } from "react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog"
+import { Trash2, Plus, Pencil, Wifi, CheckCircle, XCircle, Power, PowerOff } from "lucide-react"
+import type { Agent2McpServerItem } from "@/types/agent2"
+
+function loadServers(): Promise<Agent2McpServerItem[]> {
+  return fetch("/api/agent2/admin/mcp")
+    .then(r => r.json())
+    .then(data => (data.success ? data.data : []))
+}
+
+interface AddFormState {
+  name: string
+  description: string
+  transportType: "stdio" | "sse" | "http"
+  command: string
+  args: string
+  env: string
+  url: string
+  headers: string
+  timeout: string
+}
+
+const emptyForm: AddFormState = {
+  name: "",
+  description: "",
+  transportType: "sse",
+  command: "",
+  args: "",
+  env: "",
+  url: "",
+  headers: "",
+  timeout: "5000",
+}
+
+export function McpServerManager() {
+  const [servers, setServers] = useState<Agent2McpServerItem[]>([])
+  const [addOpen, setAddOpen] = useState(false)
+  const [form, setForm] = useState<AddFormState>({ ...emptyForm })
+  const [editOpen, setEditOpen] = useState(false)
+  const [editingServer, setEditingServer] = useState<Agent2McpServerItem | null>(null)
+  const [editForm, setEditForm] = useState<AddFormState>({ ...emptyForm })
+  const [testingId, setTestingId] = useState<string | null>(null)
+  const [testResult, setTestResult] =<{
+    id: string
+    success: boolean
+    message: string
+    tools?: Array<{ name: string; description?: string }>
+  } | null>(null)
+
+  useEffect(() => {
+    loadServers().then(setServers)
+  }, [])
+
+  const buildConfig = (f: AddFormState) => {
+    const timeout = parseInt(f.timeout) || 5000
+    switch (f.transportType) {
+      case "stdio":
+        return {
+          command: f.command,
+          args: f.args ? f.args.split(" ").filter(Boolean) : undefined,
+          env: f.env ? JSON.parse(f.env) : undefined,
+          timeout,
+        }
+      case "sse":
+        return {
+          url: f.url,
+          headers: f.headers ? JSON.parse(f.headers) : undefined,
+          timeout,
+        }
+      case "http":
+        return {
+          url: f.url,
+          headers: f.headers ? JSON.parse(f.headers) : undefined,
+          timeout,
+        }
+    }
+  }
+
+  const handleAdd = async () => {
+    try {
+      const config = buildConfig(form)
+      const res = await fetch("/api/agent2/admin/mcp", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: form.name,
+          description: form.description || undefined,
+          transportType: form.transportType,
+          config,
+        }),
+      })
+      const data = await res.json()
+      if (data.success) {
+        setAddOpen(false)
+        setForm({ ...emptyForm })
+        loadServers().then(setServers)
+      } else {
+        alert(data.error?.message || "添加失败")
+      }
+    } catch (error) {
+      alert(error instanceof Error ? error.message : "添加失败")
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    if (!confirm("确定删除此 MCP 服务器？")) return
+    await fetch(`/api/agent2/admin/mcp/${id}`, { method: "DELETE" })
+    loadServers().then(setServers)
+  }
+
+  const handleToggle = async (server: Agent2McpServerItem) => {
+    await fetch(`/api/agent2/admin/mcp/${server.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled: !server.enabled }),
+    })
+    loadServers().then(setServers)
+  }
+
+  const handleEdit = (server: Agent2McpServerItem) => {
+    setEditingServer(server)
+    const config = server.config as Record<string, unknown>
+    setEditForm({
+      name: server.name,
+      description: server.description || "",
+      transportType: server.transportType,
+      command: (config.command as string) || "",
+      args: Array.isArray(config.args) ? (config.args as string[]).join(" ") : "",
+      env: config.env ? JSON.stringify(config.env) : "",
+      url: (config.url as string) || "",
+      headers: config.headers ? JSON.stringify(config.headers) : "",
+      timeout: String(config.timeout || 5000),
+    })
+    setEditOpen(true)
+  }
+
+  const handleEditSubmit = async () => {
+    if (!editingServer) return
+    try {
+      const config = buildConfig(editForm)
+      const res = await fetch(`/api/agent2/admin/mcp/${editingServer.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: editForm.name,
+          description: editForm.description || null,
+          config,
+        }),
+      })
+      const data = await res.json()
+      if (data.success) {
+        setEditOpen(false)
+        setEditingServer(null)
+        loadServers().then(setServers)
+      } else {
+        alert(data.error?.message || "更新失败")
+      }
+    } catch (error) {
+      alert(error instanceof Error ? error.message : "更新失败")
+    }
+  }
+
+  const handleTest = async (server: Agent2McpServerItem) => {
+    setTestingId(server.id)
+    setTestResult(null)
+    try {
+      const res = await fetch(`/api/agent2/admin/mcp/${server.id}/test`, {
+        method: "POST",
+      })
+      const data = await res.json()
+      if (data.success) {
+        setTestResult({
+          id: server.id,
+          success: true,
+          message: `连接成功，发现 ${data.data.tools.length} 个工具`,
+          tools: data.data.tools,
+        })
+      } else {
+        setTestResult({
+          id: server.id,
+          success: false,
+          message: data.error?.message || "连接失败",
+        })
+      }
+    } catch (error) {
+      setTestResult({
+        id: server.id,
+        success: false,
+        message: error instanceof Error ? error.message : "测试失败",
+      })
+    } finally {
+      setTestingId(null)
+    }
+  }
+
+  const renderTransportFields = (
+    f: AddFormState,
+    setF: (fn: (prev: AddFormState) => AddFormState) => void
+  ) => (
+    <>
+      <div>
+        <label className="text-sm font-medium">传输类型</label>
+        <select
+          value={f.transportType}
+          onChange={(e) => setF(prev => ({ ...prev, transportType: e.target.value as "stdio" | "sse" | "http" }))}
+          className="w-full h-8 rounded-md border bg-background px-2 text-sm mt-1"
+        >
+          <option value="stdio">Stdio（本地进程）</option>
+          <option value="sse">SSE（Server-Sent Events）</option>
+          <option value="http">HTTP（Streamable HTTP）</option>
+        </select>
+      </div>
+      {f.transportType === "stdio" && (
+        <>
+          <Input placeholder="命令 (如 npx, node, python)" value={f.command} onChange={e => setF(prev => ({ ...prev, command: e.target.value }))} />
+          <Input placeholder="参数 (空格分隔，可选)" value={f.args} onChange={e => setF(prev => ({ ...prev, args: e.target.value }))} />
+          <Input placeholder="环境变量 JSON (可选，如 {\"KEY\": \"value\"})" value={f.env} onChange={e => setF(prev => ({ ...prev, env: e.target.value }))} />
+        </>
+      )}
+      {(f.transportType === "sse" || f.transportType === "http") && (
+        <>
+          <Input placeholder="URL (如 http://localhost:3000/mcp)" value={f.url} onChange={e => setF(prev => ({ ...prev, url: e.target.value }))} />
+          <Input placeholder="请求头 JSON (可选，如 {\"Authorization\": \"Bearer xxx\"})" value={f.headers} onChange={e => setF(prev => ({ ...prev, headers: e.target.value }))} />
+        </>
+      )}
+      <Input type="number" placeholder="连接超时 (ms，默认 5000)" value={f.timeout} onChange={e => setF(prev => ({ ...prev, timeout: e.target.value }))} />
+    </>
+  )
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium">MCP 服务器</p>
+        <Button variant="ghost" size="sm" onClick={() => setAddOpen(true)}>
+          <Plus className="size-3 mr-1" /> 添加
+        </Button>
+      </div>
+      <div className="space-y-1">
+        {servers.map(server => {
+          const config = server.config as Record<string, unknown>
+          return (
+            <div key={server.id} className="p-2 rounded-md bg-muted/50 text-sm">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <span
+                    className={`size-2 rounded-full ${server.enabled ? "bg-green-500" : "bg-muted-foreground/30"}`}
+                    title={server.enabled ? "已启用" : "已禁用"}
+                  />
+                  <div>
+                    <p className="font-medium">{server.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {server.transportType.toUpperCase()} · {config.url || config.command || ""}
+                      {server.description && ` · ${server.description}`}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-1">
+                  {/* Test result */}
+                  {testResult?.id === server.id && (
+                    <span className={`text-xs ${testResult.success ? "text-green-500" : "text-destructive"}`}>
+                      {testResult.message}
+                    </span>
+                  )}
+                  <Button variant="ghost" size="icon-xs" onClick={() => handleTest(server)} disabled={testingId === server.id} title="测试连接">
+                    {testingId === server.id ? <span className="size-3 animate-spin">⟳</span> : <Wifi className="size-3" />}
+                  </Button>
+                  <Button variant="ghost" size="icon-xs" onClick={() => handleToggle(server)} title={server.enabled ? "禁用" : "启用"}>
+                    {server.enabled ? <PowerOff className="size-3" /> : <Power className="size-3" />}
+                  </Button>
+                  <Button variant="ghost" size="icon-xs" onClick={() => handleEdit(server)} title="编辑">
+                    <Pencil className="size-3" />
+                  </Button>
+                  <Button variant="ghost" size="icon-xs" onClick={() => handleDelete(server.id)} title="删除">
+                    <Trash2 className="size-3 text-destructive" />
+                  </Button>
+                </div>
+              </div>
+              {/* Show tools if test was successful */}
+              {testResult?.id === server.id && testResult.success && testResult.tools && (
+                <div className="mt-1 pl-4 text-xs text-muted-foreground">
+                  工具: {testResult.tools.map(t => t.name).join(", ")}
+                </div>
+              )}
+            </div>
+          )
+        })}
+        {servers.length === 0 && (
+          <p className="text-xs text-muted-foreground text-center py-2">暂未配置 MCP 服务器</p>
+        )}
+      </div>
+
+      {/* Add server dialog */}
+      <Dialog open={addOpen} onOpenChange={setAddOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>添加 MCP 服务器</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <Input placeholder="服务器名称" value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} />
+            <Input placeholder="描述 (可选)" value={form.description} onChange={e => setForm(f => ({ ...f, description: e.target.value }))} />
+            {renderTransportFields(form, setForm)}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setAddOpen(false)}>取消</Button>
+            <Button
+              onClick={handleAdd}
+              disabled={!form.name || (form.transportType === "stdio" ? !form.command : !form.url)}
+            >
+              添加
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit server dialog */}
+      <Dialog open={editOpen} onOpenChange={setEditOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>编辑 MCP 服务器</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <Input placeholder="服务器名称" value={editForm.name} onChange={e => setEditForm(f => ({ ...f, name: e.target.value }))} />
+            <Input placeholder="描述 (可选)" value={editForm.description} onChange={e => setEditForm(f => ({ ...f, description: e.target.value }))} />
+            {renderTransportFields(editForm, setEditForm)}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditOpen(false)}>取消</Button>
+            <Button
+              onClick={handleEditSubmit}
+              disabled={!editForm.name || (editForm.transportType === "stdio" ? !editForm.command : !editForm.url)}
+            >
+              保存
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/agent2/mcp-server-manager.tsx
+git commit -m "feat(agent2): 新增 MCP 服务器管理器组件"
+```
+
+---
+
+### Task 14: 设置弹窗 — 集成 MCP 选项卡
+
+**Files:**
+- Modify: `src/components/agent2/settings-dialog.tsx`
+
+- [ ] **Step 1: 导入 McpServerManager 组件**
+
+在 `src/components/agent2/settings-dialog.tsx` 的 import 区域追加：
+
+```typescript
+import { McpServerManager } from "./mcp-server-manager"
+```
+
+- [ ] **Step 2: 添加 MCP 选项卡触发器和内容**
+
+在 `TabsList` 中，在"显示设置"选项卡之后追加：
+
+```typescript
+            <TabsTrigger value="mcp" className="flex-1">MCP 服务器</TabsTrigger>
+```
+
+在 `TabsContent value="display"` 之后、`</Tabs>` 之前追加：
+
+```typescript
+          <TabsContent value="mcp" className="mt-4">
+            <McpServerManager />
+          </TabsContent>
+```
+
+- [ ] **Step 3: 验证构建**
+
+```bash
+npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: 无新增错误
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/agent2/settings-dialog.tsx
+git commit -m "feat(agent2): 设置弹窗新增 MCP 服务器管理选项卡"
+```
+
+---
+
+### Task 15: 端到端验证
+
+- [ ] **Step 1: 运行 TypeScript 类型检查**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: 无错误
+
+- [ ] **Step 2: 运行 ESLint**
+
+```bash
+npm run lint
+```
+
+Expected: 无新增 lint 错误
+
+- [ ] **Step 3: 运行构建**
+
+```bash
+npm run build
+```
+
+Expected: 构建成功
+
+- [ ] **Step 4: 启动开发服务器手动验证**
+
+```bash
+npm run dev
+```
+
+手动验证：
+1. 以管理员登录，打开 AI Agent2 设置弹窗
+2. 切换到 "MCP 服务器" 选项卡
+3. 添加一个 MCP 服务器（可用一个简单的 SSE 测试服务器）
+4. 测试连接
+5. 启用/禁用/编辑/删除服务器
+6. 在对话中验证 MCP 工具是否被 AI 调用

--- a/docs/superpowers/specs/2026-04-10-ai-agent2-mcp-design.md
+++ b/docs/superpowers/specs/2026-04-10-ai-agent2-mcp-design.md
@@ -1,0 +1,358 @@
+# AI Agent2 MCP 集成设计
+
+**日期**: 2026-04-10
+**状态**: Draft
+
+## 概述
+
+在 ai-agent2 上集成 Model Context Protocol (MCP) 功能，允许管理员配置外部 MCP 服务器，AI 在对话时可调用这些服务器提供的工具来获取外部数据。
+
+## 需求
+
+- 管理员可在后台配置 MCP 服务器（支持 stdio、sse、http 三种传输方式）
+- AI 在对话时自动识别并调用 MCP 工具
+- MCP 工具与现有内置工具并行使用，复用确认机制
+- 单个 MCP 服务器连接失败不影响整体对话
+
+## 架构
+
+```
+管理员后台配置 MCP 服务器
+         ↓
+存储到 Agent2McpServer 表
+         ↓
+聊天时，后端读取已启用的 MCP 服务器
+         ↓
+用 @ai-sdk/mcp createMCPClient 连接各服务器
+         ↓
+获取 MCP 工具，与内置工具合并
+         ↓
+AI 自动选择合适的工具（内置或 MCP）
+         ↓
+MCP 工具执行走现有确认机制
+```
+
+## 数据库设计
+
+新增 `Agent2McpServer` 表：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| id | String (cuid) | 主键 |
+| name | String (@unique) | 服务器名称，同时作为工具前缀标识 |
+| description | String? | 服务器描述 |
+| transportType | McpTransportType (enum: stdio, sse, http) | 传输方式 |
+| config | Json | 连接配置（含 timeout） |
+| enabled | Boolean (默认 true) | 是否启用 |
+| createdAt | DateTime | 创建时间 |
+| updatedAt | DateTime | 更新时间 |
+
+### config JSON 结构
+
+**stdio**:
+```json
+{
+  "command": "node",
+  "args": ["server.js"],
+  "env": { "API_KEY": "xxx" },
+  "timeout": 5000
+}
+```
+
+**sse**:
+```json
+{
+  "url": "http://localhost:3000/sse",
+  "headers": { "Authorization": "Bearer xxx" },
+  "timeout": 5000
+}
+```
+
+**http**:
+```json
+{
+  "url": "http://localhost:3000/mcp",
+  "headers": { "Authorization": "Bearer xxx" },
+  "timeout": 5000
+}
+```
+
+`timeout` 字段为连接超时毫秒数，默认 5000。环境变量中的敏感值（env 和 headers 中的值）使用 AES-256-GCM 加密存储，与现有模型配置加密方式一致。
+
+## Prisma Schema 变更
+
+```prisma
+enum McpTransportType {
+  stdio
+  sse
+  http
+}
+
+model Agent2McpServer {
+  id            String            @id @default(cuid())
+  name          String            @unique
+  description   String?
+  transportType McpTransportType
+  config        Json
+  enabled       Boolean           @default(true)
+  createdAt     DateTime          @default(now())
+  updatedAt     DateTime          @updatedAt
+}
+```
+
+## API 路由
+
+```
+api/agent2/admin/mcp/
+├── route.ts              # GET (列表), POST (添加) — 仅管理员
+├── [id]/route.ts         # PATCH (更新), DELETE (删除) — 仅管理员
+└── [id]/test/route.ts    # POST (连接测试 + 列出工具) — 仅管理员
+```
+
+所有接口需检查 `session.user.role === "admin"`。
+
+### 接口详情
+
+**GET /api/agent2/admin/mcp**
+- 返回所有 MCP 服务器列表（config 中敏感字段解密后掩码显示）
+
+**POST /api/agent2/admin/mcp**
+- Body: `{ name, description?, transportType, config }`
+- 校验 name 唯一、config 结构符合 transportType
+- 敏感字段加密后存储
+
+**PATCH /api/agent2/admin/mcp/[id]**
+- Body: `{ name?, description?, transportType?, config?, enabled? }`
+- 更新时重新加密敏感字段
+
+**DELETE /api/agent2/admin/mcp/[id]**
+- 直接删除记录
+
+**POST /api/agent2/admin/mcp/[id]/test**
+- 创建临时 MCP 客户端连接
+- 调用 `listTools()` 获取工具列表
+- 返回 `{ success: true, tools: [...] }` 或 `{ success: false, error: "..." }`
+- 关闭连接
+
+## 服务层
+
+### 新文件: `src/lib/services/agent2-mcp.service.ts`
+
+遵循现有 ServiceResult 模式：
+
+```typescript
+// 主要函数
+listMcpServers(): Promise<ServiceResult<Agent2McpServerItem[]>>
+createMcpServer(data): Promise<ServiceResult<Agent2McpServerItem>>
+updateMcpServer(id, data): Promise<ServiceResult<Agent2McpServerItem>>
+deleteMcpServer(id): Promise<ServiceResult<void>>
+testMcpServer(id): Promise<ServiceResult<{ tools: McpToolInfo[] }>>
+```
+
+### 新文件: `src/lib/agent2/mcp-client.ts`
+
+MCP 客户端管理：
+
+```typescript
+// 创建 MCP 客户端连接
+createMcpClient(server: Agent2McpServer): Promise<MCPClient>
+
+// 获取所有已启用 MCP 服务器的工具
+getEnabledMcpTools(): Promise<{
+  tools: Record<string, Tool>
+  clients: MCPClient[]
+}>
+```
+
+## 类型定义
+
+### `src/types/agent2.ts` 新增
+
+```typescript
+interface Agent2McpServerItem {
+  id: string
+  name: string
+  description: string | null
+  transportType: 'stdio' | 'sse' | 'http'
+  config: McpServerConfig
+  enabled: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+type McpServerConfig =
+  | { type: 'stdio'; command: string; args?: string[]; env?: Record<string, string>; timeout?: number }
+  | { type: 'sse'; url: string; headers?: Record<string, string>; timeout?: number }
+  | { type: 'http'; url: string; headers?: Record<string, string>; timeout?: number }
+
+interface McpToolInfo {
+  name: string
+  description?: string
+  inputSchema?: object
+}
+```
+
+## 验证器
+
+### `src/validators/agent2.ts` 新增
+
+```typescript
+const createMcpServerSchema = z.discriminatedUnion('transportType', [
+  z.object({
+    name: z.string().min(1).max(50),
+    description: z.string().max(200).optional(),
+    transportType: z.literal('stdio'),
+    config: z.object({
+      command: z.string().min(1),
+      args: z.array(z.string()).optional(),
+      env: z.record(z.string()).optional(),
+      timeout: z.number().min(1000).max(60000).optional(),
+    }),
+  }),
+  z.object({
+    name: z.string().min(1).max(50),
+    description: z.string().max(200).optional(),
+    transportType: z.literal('sse'),
+    config: z.object({
+      url: z.string().url(),
+      headers: z.record(z.string()).optional(),
+      timeout: z.number().min(1000).max(60000).optional(),
+    }),
+  }),
+  z.object({
+    name: z.string().min(1).max(50),
+    description: z.string().max(200).optional(),
+    transportType: z.literal('http'),
+    config: z.object({
+      url: z.string().url(),
+      headers: z.record(z.string()).optional(),
+      timeout: z.number().min(1000).max(60000).optional(),
+    }),
+  }),
+])
+```
+
+## 聊天流程集成
+
+修改 `src/app/api/agent2/conversations/[id]/chat/route.ts`：
+
+```typescript
+// 现有流程
+const builtInTools = createTools(userId)
+
+// 新增：获取 MCP 工具
+const { tools: mcpTools, clients: mcpClients } = await getEnabledMcpTools()
+
+// 合并工具
+const allTools = { ...builtInTools, ...mcpTools }
+
+// streamText 使用合并后的工具
+streamText({
+  model,
+  system: systemPrompt,
+  messages: truncatedMessages,
+  tools: allTools,
+  // ...
+  onFinish: async () => {
+    // 关闭 MCP 连接
+    for (const client of mcpClients) await client.close()
+    // ... 现有消息持久化逻辑
+  },
+})
+```
+
+### MCP 工具命名
+
+使用 `mcp__{serverName}__{toolName}` 格式，确保与内置工具不冲突。工具 description 前追加 `[MCP: {serverName}]` 标记。
+
+### 系统提示增强
+
+在 `context-builder.ts` 的 `buildSystemPrompt()` 中增加 MCP 工具说明：
+
+```
+你还可以使用以下 MCP 外部工具：
+- [MCP: weather] 天气查询工具
+- [MCP: database] 外部数据库查询
+...
+```
+
+### 确认机制
+
+复用现有确认令牌机制。在 `Agent2UserSettings.autoConfirmTools` 中新增 `mcp` 类别：
+- 默认 MCP 工具需要确认
+- 用户可在设置中选择 MCP 工具自动确认
+
+### 错误处理
+
+- 单个 MCP 服务器连接超时或失败：跳过该服务器，记录警告日志
+- 不影响其他 MCP 服务器和内置工具
+- 超时使用各服务器配置的 timeout 值，默认 5000ms
+
+## 前端组件
+
+### 管理员 MCP 管理选项卡
+
+在 `settings-dialog.tsx` 中新增 "MCP 服务器" 选项卡：
+
+- 服务器列表（名称、传输类型、启用状态指示灯）
+- 添加按钮 → 表单弹窗
+  - 名称输入
+  - 描述输入（可选）
+  - 传输类型下拉（stdio / sse / http）
+  - 动态配置表单（根据传输类型显示不同字段）
+  - 超时时间输入（可选，默认 5000ms）
+- 每行操作：编辑、删除、启用/禁用切换、连接测试按钮
+- 连接测试结果展示：工具列表（名称 + 描述）
+
+### 新增组件: `src/components/agent2/mcp-server-manager.tsx`
+
+管理 MCP 服务器的独立组件，结构与 `model-manager.tsx` 类似。
+
+### 普通用户 MCP 信息展示
+
+在普通用户设置弹窗中增加 "MCP 工具" 选项卡（只读）：
+- 显示已启用的 MCP 服务器列表及其提供的工具
+- 让用户了解有哪些外部工具可用
+
+### 工具确认弹窗增强
+
+现有 `tool-confirm-dialog.tsx` 需增强：
+- MCP 工具显示来源标记 `[MCP: 服务器名]`
+- 展示 MCP 工具的参数 schema
+
+## 依赖
+
+已安装：
+- `@ai-sdk/mcp`（AI SDK 的 MCP 客户端支持）
+- `ai`（AI SDK 核心）
+
+可能需要额外安装：
+- `@modelcontextprotocol/sdk`（MCP 官方 SDK，用于 stdio 传输的 StdioClientTransport）
+
+## 文件变更清单
+
+### 新增文件
+- `src/types/agent2.ts` 中新增 MCP 相关类型（修改现有文件）
+- `src/validators/agent2.ts` 中新增 MCP 验证器（修改现有文件）
+- `src/lib/services/agent2-mcp.service.ts`（MCP 服务器 CRUD 服务）
+- `src/lib/agent2/mcp-client.ts`（MCP 客户端管理）
+- `src/app/api/agent2/admin/mcp/route.ts`（MCP 服务器列表/添加 API）
+- `src/app/api/agent2/admin/mcp/[id]/route.ts`（MCP 服务器更新/删除 API）
+- `src/app/api/agent2/admin/mcp/[id]/test/route.ts`（连接测试 API）
+- `src/components/agent2/mcp-server-manager.tsx`（MCP 管理组件）
+
+### 修改文件
+- `prisma/schema.prisma`（新增 McpTransportType 枚举和 Agent2McpServer 模型）
+- `src/app/api/agent2/conversations/[id]/chat/route.ts`（集成 MCP 工具）
+- `src/lib/agent2/context-builder.ts`（系统提示增加 MCP 工具说明）
+- `src/lib/agent2/tools.ts`（MCP 工具确认类别支持）
+- `src/components/agent2/settings-dialog.tsx`（新增 MCP 管理选项卡）
+- `src/components/agent2/tool-confirm-dialog.tsx`（MCP 工具来源标记）
+
+## 不在范围内
+
+- 用户自定义 MCP 服务器（仅管理员配置）
+- 工具级别的启用/禁用控制（仅服务器级别）
+- MCP 资源（Resources）和提示（Prompts）支持
+- MCP OAuth 认证流程
+- MCP 工具调用的审计日志

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "docx-template-system",
       "version": "0.3.9",
       "dependencies": {
+        "@ai-sdk/mcp": "^1.0.35",
         "@ai-sdk/openai": "^3.0.48",
         "@ai-sdk/openai-compatible": "^2.0.40",
         "@ai-sdk/react": "^3.0.144",
@@ -95,6 +96,40 @@
         "@ai-sdk/provider": "3.0.8",
         "@ai-sdk/provider-utils": "4.0.21",
         "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/mcp": {
+      "version": "1.0.35",
+      "resolved": "https://registry.npmmirror.com/@ai-sdk/mcp/-/mcp-1.0.35.tgz",
+      "integrity": "sha512-YeFHyq3pq/tkD8rp/U0P9sJsQfDTT4F/8WdpRLLo30cCLx2kfuIYafRyTLfERnYayYlLbH5aMBpjttFunvIDCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "pkce-challenge": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/mcp/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmmirror.com/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "release:major": "commit-and-tag-version --release-as major"
   },
   "dependencies": {
+    "@ai-sdk/mcp": "^1.0.35",
     "@ai-sdk/openai": "^3.0.48",
     "@ai-sdk/openai-compatible": "^2.0.40",
     "@ai-sdk/react": "^3.0.144",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -659,3 +659,22 @@ model Notification {
   @@map("notifications")
 }
 
+// ========== Agent2 MCP (Model Context Protocol) ==========
+
+enum McpTransportType {
+  stdio
+  sse
+  http
+}
+
+model Agent2McpServer {
+  id            String            @id @default(cuid())
+  name          String            @unique
+  description   String?
+  transportType McpTransportType
+  config        Json
+  enabled       Boolean           @default(true)
+  createdAt     DateTime          @default(now())
+  updatedAt     DateTime          @updatedAt
+}
+

--- a/src/app/api/agent2/admin/mcp/[id]/route.ts
+++ b/src/app/api/agent2/admin/mcp/[id]/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { ZodError } from "zod";
+import {
+  updateMcpServer,
+  deleteMcpServer,
+} from "@/lib/services/agent2-mcp.service";
+import { updateMcpServerSchema } from "@/validators/agent2";
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "未登录" } },
+      { status: 401 }
+    );
+  }
+
+  if (session.user.role !== "ADMIN") {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "需要管理员权限" } },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const parsed = updateMcpServerSchema.parse(body);
+    const result = await updateMcpServer(id, {
+      name: parsed.name,
+      description: parsed.description,
+      enabled: parsed.enabled,
+      config: parsed.config,
+    });
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+
+    return NextResponse.json({ success: true, data: result.data });
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "参数校验失败" } },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message:
+            error instanceof Error
+              ? error.message
+              : "更新 MCP 服务器失败",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "未登录" } },
+      { status: 401 }
+    );
+  }
+
+  if (session.user.role !== "ADMIN") {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "需要管理员权限" } },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const { id } = await params;
+    const result = await deleteMcpServer(id);
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+
+    return NextResponse.json({ success: true, data: result.data });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message:
+            error instanceof Error
+              ? error.message
+              : "删除 MCP 服务器失败",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/agent2/admin/mcp/[id]/test/route.ts
+++ b/src/app/api/agent2/admin/mcp/[id]/test/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { getDecryptedMcpServer } from "@/lib/services/agent2-mcp.service";
+import { testMcpConnection } from "@/lib/agent2/mcp-client";
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "未登录" } },
+      { status: 401 }
+    );
+  }
+
+  if (session.user.role !== "ADMIN") {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "需要管理员权限" } },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const { id } = await params;
+
+    // 获取解密后的服务器配置
+    const serverResult = await getDecryptedMcpServer(id);
+    if (!serverResult.success) {
+      return NextResponse.json({ error: serverResult.error }, { status: 400 });
+    }
+
+    const server = serverResult.data;
+
+    // 测试连接，使用配置中的 timeout 或默认 5000ms
+    const timeout =
+      typeof server.config.timeout === "number"
+        ? (server.config.timeout as number)
+        : 5000;
+
+    const testResult = await testMcpConnection(
+      {
+        name: server.name,
+        transportType: server.transportType,
+        config: server.config,
+      },
+      timeout
+    );
+
+    if (!testResult.success) {
+      return NextResponse.json(
+        { success: false, error: testResult.error },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: { tools: testResult.tools },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message:
+            error instanceof Error
+              ? error.message
+              : "测试 MCP 服务器连接失败",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/agent2/admin/mcp/route.ts
+++ b/src/app/api/agent2/admin/mcp/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { ZodError } from "zod";
+import {
+  listMcpServers,
+  createMcpServer,
+} from "@/lib/services/agent2-mcp.service";
+import { createMcpServerSchema } from "@/validators/agent2";
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "未登录" } },
+      { status: 401 }
+    );
+  }
+
+  if (session.user.role !== "ADMIN") {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "需要管理员权限" } },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const result = await listMcpServers();
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+
+    return NextResponse.json({ success: true, data: result.data });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message:
+            error instanceof Error
+              ? error.message
+              : "加载 MCP 服务器列表失败",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "未登录" } },
+      { status: 401 }
+    );
+  }
+
+  if (session.user.role !== "ADMIN") {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "需要管理员权限" } },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const parsed = createMcpServerSchema.parse(body);
+    const result = await createMcpServer({
+      name: parsed.name,
+      description: parsed.description,
+      transportType: parsed.transportType,
+      config: parsed.config,
+    });
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+
+    return NextResponse.json(
+      { success: true, data: result.data },
+      { status: 201 }
+    );
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "参数校验失败" } },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message:
+            error instanceof Error
+              ? error.message
+              : "创建 MCP 服务器失败",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/agent2/conversations/[id]/chat/route.ts
+++ b/src/app/api/agent2/conversations/[id]/chat/route.ts
@@ -80,7 +80,7 @@ export async function POST(
     const tools = createTools(conversationId, messageId, autoConfirm);
 
     // Get MCP tools from enabled servers
-    const mcpResult = await getEnabledMcpTools();
+    const mcpResult = await getEnabledMcpTools(conversationId, messageId, autoConfirm);
     mcpClients = mcpResult.clients;
     const allTools = { ...tools, ...mcpResult.tools };
 

--- a/src/app/api/agent2/conversations/[id]/chat/route.ts
+++ b/src/app/api/agent2/conversations/[id]/chat/route.ts
@@ -14,6 +14,8 @@ import {
   getLatestPersistableMessages,
   sanitizeStoredMessages,
 } from "@/lib/agent2/message-persistence";
+import { getEnabledMcpTools } from "@/lib/agent2/mcp-client";
+import type { MCPClient } from "@ai-sdk/mcp";
 import { db } from "@/lib/db";
 import { decrypt } from "@/lib/services/agent2-model.service";
 
@@ -25,6 +27,7 @@ export async function POST(
   request: NextRequest,
   { params }: RouteContext
 ) {
+  let mcpClients: MCPClient[] = [];
   const session = await auth();
   if (!session?.user) {
     return NextResponse.json(
@@ -76,6 +79,11 @@ export async function POST(
     const messageId = randomUUID();
     const tools = createTools(conversationId, messageId, autoConfirm);
 
+    // Get MCP tools from enabled servers
+    const mcpResult = await getEnabledMcpTools();
+    mcpClients = mcpResult.clients;
+    const allTools = { ...tools, ...mcpResult.tools };
+
     // Load conversation history from DB
     const historyResult = await getMessages(conversationId);
     const historyMessages: UIMessage[] = historyResult.success
@@ -97,7 +105,7 @@ export async function POST(
 
     // Convert UIMessages to ModelMessages and truncate to prevent context overflow
     const convertedMessages = await convertToModelMessages(allMessages, {
-      tools,
+      tools: allTools,
       ignoreIncompleteToolCalls: true,
     });
     const messages = truncateMessages(convertedMessages as { role: string; content: string }[]) as typeof convertedMessages;
@@ -107,7 +115,7 @@ export async function POST(
       model,
       system: systemPrompt,
       messages,
-      tools,
+      tools: allTools,
       stopWhen: stepCountIs(10),
     });
 
@@ -117,6 +125,11 @@ export async function POST(
       sendSources: true,
       onFinish: async ({ messages }) => {
         try {
+          // Close MCP client connections
+          for (const client of mcpClients) {
+            try { await client.close(); } catch { /* best effort */ }
+          }
+
           const persistableMessages = getLatestPersistableMessages(
             messages as UIMessage[]
           );
@@ -136,6 +149,11 @@ export async function POST(
       },
     });
   } catch (error) {
+    // Close MCP clients on error
+    for (const client of mcpClients) {
+      try { await client.close(); } catch { /* best effort */ }
+    }
+
     if (error instanceof ZodError) {
       return NextResponse.json(
         { error: { code: "VALIDATION_ERROR", message: "参数校验失败" } },

--- a/src/components/agent2/chat-area.tsx
+++ b/src/components/agent2/chat-area.tsx
@@ -94,6 +94,9 @@ export function ChatArea({ conversationId, onToggleSidebar, sidebarCollapsed, de
   const [model, setModel] = useState(defaultModel || "MiniMax-M2.5")
   const [inputError, setInputError] = useState<string | null>(null)
   const [loadedConversationId, setLoadedConversationId] = useState<string | null>(null)
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => { setMounted(true) }, [])
 
   // 使用 conversationId 作为 chatKey，切换模型时不重新创建会话
   const chatKey = conversationId
@@ -249,8 +252,12 @@ export function ChatArea({ conversationId, onToggleSidebar, sidebarCollapsed, de
       {/* Header */}
       <div className="flex items-center gap-2 px-4 py-2 border-b shrink-0">
         <Button variant="ghost" size="icon-xs" onClick={onToggleSidebar}>
-          {sidebarCollapsed ? (
-            <PanelLeft className="size-4" />
+          {mounted ? (
+            sidebarCollapsed ? (
+              <PanelLeft className="size-4" />
+            ) : (
+              <PanelLeftClose className="size-4" />
+            )
           ) : (
             <PanelLeftClose className="size-4" />
           )}

--- a/src/components/agent2/mcp-server-manager.tsx
+++ b/src/components/agent2/mcp-server-manager.tsx
@@ -1,0 +1,317 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog"
+import { Trash2, Plus, Pencil, Wifi, Power, PowerOff } from "lucide-react"
+import type { Agent2McpServerItem } from "@/types/agent2"
+
+function loadServers(): Promise<Agent2McpServerItem[]> {
+  return fetch("/api/agent2/admin/mcp")
+    .then(r => r.json())
+    .then(data => (data.success ? data.data : []))
+}
+
+interface FormState {
+  name: string
+  description: string
+  transportType: "stdio" | "sse" | "http"
+  command: string
+  args: string
+  env: string
+  url: string
+  headers: string
+  timeout: string
+}
+
+const emptyForm: FormState = {
+  name: "",
+  description: "",
+  transportType: "sse",
+  command: "",
+  args: "",
+  env: "",
+  url: "",
+  headers: "",
+  timeout: "5000",
+}
+
+function buildConfig(f: FormState): Record<string, unknown> {
+  const timeout = parseInt(f.timeout) || 5000
+  switch (f.transportType) {
+    case "stdio":
+      return {
+        command: f.command,
+        args: f.args ? f.args.split(" ").filter(Boolean) : undefined,
+        env: f.env ? JSON.parse(f.env) : undefined,
+        timeout,
+      }
+    case "sse":
+    case "http":
+      return {
+        url: f.url,
+        headers: f.headers ? JSON.parse(f.headers) : undefined,
+        timeout,
+      }
+  }
+}
+
+export function McpServerManager() {
+  const [servers, setServers] = useState<Agent2McpServerItem[]>([])
+  const [addOpen, setAddOpen] = useState(false)
+  const [form, setForm] = useState<FormState>({ ...emptyForm })
+  const [editOpen, setEditOpen] = useState(false)
+  const [editingServer, setEditingServer] = useState<Agent2McpServerItem | null>(null)
+  const [editForm, setEditForm] = useState<FormState>({ ...emptyForm })
+  const [testingId, setTestingId] = useState<string | null>(null)
+  const [testResult, setTestResult] = useState<{
+    id: string
+    success: boolean
+    message: string
+    tools?: Array<{ name: string; description?: string }>
+  } | null>(null)
+
+  const reload = () => loadServers().then(setServers)
+  useEffect(() => { reload() }, [])
+
+  const handleAdd = async () => {
+    try {
+      const config = buildConfig(form)
+      const res = await fetch("/api/agent2/admin/mcp", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: form.name,
+          description: form.description || undefined,
+          transportType: form.transportType,
+          config,
+        }),
+      })
+      const data = await res.json()
+      if (data.success) {
+        setAddOpen(false)
+        setForm({ ...emptyForm })
+        reload()
+      } else {
+        alert(data.error?.message || "添加失败")
+      }
+    } catch (error) {
+      alert(error instanceof Error ? error.message : "添加失败，请检查 JSON 格式")
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    if (!confirm("确定删除此 MCP 服务器？")) return
+    await fetch(`/api/agent2/admin/mcp/${id}`, { method: "DELETE" })
+    reload()
+  }
+
+  const handleToggle = async (server: Agent2McpServerItem) => {
+    await fetch(`/api/agent2/admin/mcp/${server.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled: !server.enabled }),
+    })
+    reload()
+  }
+
+  const handleEdit = (server: Agent2McpServerItem) => {
+    setEditingServer(server)
+    const config = server.config as Record<string, unknown>
+    setEditForm({
+      name: server.name,
+      description: server.description || "",
+      transportType: server.transportType,
+      command: (config.command as string) || "",
+      args: Array.isArray(config.args) ? (config.args as string[]).join(" ") : "",
+      env: config.env ? JSON.stringify(config.env) : "",
+      url: (config.url as string) || "",
+      headers: config.headers ? JSON.stringify(config.headers) : "",
+      timeout: String(config.timeout || 5000),
+    })
+    setEditOpen(true)
+  }
+
+  const handleEditSubmit = async () => {
+    if (!editingServer) return
+    try {
+      const config = buildConfig(editForm)
+      const res = await fetch(`/api/agent2/admin/mcp/${editingServer.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: editForm.name,
+          description: editForm.description || null,
+          config,
+        }),
+      })
+      const data = await res.json()
+      if (data.success) {
+        setEditOpen(false)
+        setEditingServer(null)
+        reload()
+      } else {
+        alert(data.error?.message || "更新失败")
+      }
+    } catch (error) {
+      alert(error instanceof Error ? error.message : "更新失败，请检查 JSON 格式")
+    }
+  }
+
+  const handleTest = async (server: Agent2McpServerItem) => {
+    setTestingId(server.id)
+    setTestResult(null)
+    try {
+      const res = await fetch(`/api/agent2/admin/mcp/${server.id}/test`, { method: "POST" })
+      const data = await res.json()
+      if (data.success) {
+        setTestResult({
+          id: server.id,
+          success: true,
+          message: `连接成功，发现 ${data.data.tools.length} 个工具`,
+          tools: data.data.tools,
+        })
+      } else {
+        setTestResult({
+          id: server.id,
+          success: false,
+          message: data.error?.message || "连接失败",
+        })
+      }
+    } catch (error) {
+      setTestResult({
+        id: server.id,
+        success: false,
+        message: error instanceof Error ? error.message : "测试失败",
+      })
+    } finally {
+      setTestingId(null)
+    }
+  }
+
+  const renderTransportFields = (
+    f: FormState,
+    setF: (fn: (prev: FormState) => FormState) => void,
+  ) => (
+    <>
+      <div>
+        <label className="text-sm font-medium">传输类型</label>
+        <select
+          value={f.transportType}
+          onChange={(e) => setF(prev => ({ ...prev, transportType: e.target.value as "stdio" | "sse" | "http" }))}
+          className="w-full h-8 rounded-md border bg-background px-2 text-sm mt-1"
+        >
+          <option value="stdio">Stdio（本地进程）</option>
+          <option value="sse">SSE（Server-Sent Events）</option>
+          <option value="http">HTTP（Streamable HTTP）</option>
+        </select>
+      </div>
+      {f.transportType === "stdio" && (
+        <>
+          <Input placeholder="命令 (如 npx, node, python)" value={f.command} onChange={e => setF(prev => ({ ...prev, command: e.target.value }))} />
+          <Input placeholder="参数 (空格分隔，可选)" value={f.args} onChange={e => setF(prev => ({ ...prev, args: e.target.value }))} />
+          <Input placeholder="环境变量 JSON (可选)" value={f.env} onChange={e => setF(prev => ({ ...prev, env: e.target.value }))} />
+        </>
+      )}
+      {(f.transportType === "sse" || f.transportType === "http") && (
+        <>
+          <Input placeholder="URL (如 http://localhost:3000/mcp)" value={f.url} onChange={e => setF(prev => ({ ...prev, url: e.target.value }))} />
+          <Input placeholder="请求头 JSON (可选)" value={f.headers} onChange={e => setF(prev => ({ ...prev, headers: e.target.value }))} />
+        </>
+      )}
+      <Input type="number" placeholder="连接超时 (ms，默认 5000)" value={f.timeout} onChange={e => setF(prev => ({ ...prev, timeout: e.target.value }))} />
+    </>
+  )
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium">MCP 服务器</p>
+        <Button variant="ghost" size="sm" onClick={() => setAddOpen(true)}>
+          <Plus className="size-3 mr-1" /> 添加
+        </Button>
+      </div>
+      <div className="space-y-1">
+        {servers.map(server => {
+          const config = server.config as Record<string, unknown>
+          return (
+            <div key={server.id} className="p-2 rounded-md bg-muted/50 text-sm">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2 min-w-0">
+                  <span className={`size-2 shrink-0 rounded-full ${server.enabled ? "bg-green-500" : "bg-muted-foreground/30"}`} />
+                  <div className="min-w-0">
+                    <p className="font-medium truncate">{server.name}</p>
+                    <p className="text-xs text-muted-foreground truncate">
+                      {server.transportType.toUpperCase()} · {config.url || config.command || ""}
+                      {server.description && ` · ${server.description}`}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-1 shrink-0">
+                  {testResult?.id === server.id && (
+                    <span className={`text-xs max-w-32 truncate ${testResult.success ? "text-green-500" : "text-destructive"}`}>
+                      {testResult.message}
+                    </span>
+                  )}
+                  <Button variant="ghost" size="icon-xs" onClick={() => handleTest(server)} disabled={testingId === server.id} title="测试连接">
+                    {testingId === server.id ? <span className="size-3 animate-spin">⟳</span> : <Wifi className="size-3" />}
+                  </Button>
+                  <Button variant="ghost" size="icon-xs" onClick={() => handleToggle(server)} title={server.enabled ? "禁用" : "启用"}>
+                    {server.enabled ? <PowerOff className="size-3" /> : <Power className="size-3" />}
+                  </Button>
+                  <Button variant="ghost" size="icon-xs" onClick={() => handleEdit(server)} title="编辑">
+                    <Pencil className="size-3" />
+                  </Button>
+                  <Button variant="ghost" size="icon-xs" onClick={() => handleDelete(server.id)} title="删除">
+                    <Trash2 className="size-3 text-destructive" />
+                  </Button>
+                </div>
+              </div>
+              {testResult?.id === server.id && testResult.success && testResult.tools && testResult.tools.length > 0 && (
+                <div className="mt-1 pl-4 text-xs text-muted-foreground">
+                  工具: {testResult.tools.map(t => t.name).join(", ")}
+                </div>
+              )}
+            </div>
+          )
+        })}
+        {servers.length === 0 && (
+          <p className="text-xs text-muted-foreground text-center py-2">暂未配置 MCP 服务器</p>
+        )}
+      </div>
+
+      {/* Add dialog */}
+      <Dialog open={addOpen} onOpenChange={setAddOpen}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>添加 MCP 服务器</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <Input placeholder="服务器名称" value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} />
+            <Input placeholder="描述 (可选)" value={form.description} onChange={e => setForm(f => ({ ...f, description: e.target.value }))} />
+            {renderTransportFields(form, setForm)}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setAddOpen(false)}>取消</Button>
+            <Button onClick={handleAdd} disabled={!form.name || (form.transportType === "stdio" ? !form.command : !form.url)}>添加</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit dialog */}
+      <Dialog open={editOpen} onOpenChange={setEditOpen}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>编辑 MCP 服务器</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <Input placeholder="服务器名称" value={editForm.name} onChange={e => setEditForm(f => ({ ...f, name: e.target.value }))} />
+            <Input placeholder="描述 (可选)" value={editForm.description} onChange={e => setEditForm(f => ({ ...f, description: e.target.value }))} />
+            {renderTransportFields(editForm, setEditForm)}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditOpen(false)}>取消</Button>
+            <Button onClick={handleEditSubmit} disabled={!editForm.name || (editForm.transportType === "stdio" ? !editForm.command : !editForm.url)}>保存</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/src/components/agent2/mcp-server-manager.tsx
+++ b/src/components/agent2/mcp-server-manager.tsx
@@ -209,18 +209,36 @@ export function McpServerManager() {
       </div>
       {f.transportType === "stdio" && (
         <>
-          <Input placeholder="命令 (如 npx, node, python)" value={f.command} onChange={e => setF(prev => ({ ...prev, command: e.target.value }))} />
-          <Input placeholder="参数 (空格分隔，可选)" value={f.args} onChange={e => setF(prev => ({ ...prev, args: e.target.value }))} />
-          <Input placeholder="环境变量 JSON (可选)" value={f.env} onChange={e => setF(prev => ({ ...prev, env: e.target.value }))} />
+          <div>
+            <label className="text-sm font-medium">命令</label>
+            <Input placeholder="如 npx, node, python" value={f.command} onChange={e => setF(prev => ({ ...prev, command: e.target.value }))} className="mt-1" />
+          </div>
+          <div>
+            <label className="text-sm font-medium">参数</label>
+            <Input placeholder="空格分隔，可选" value={f.args} onChange={e => setF(prev => ({ ...prev, args: e.target.value }))} className="mt-1" />
+          </div>
+          <div>
+            <label className="text-sm font-medium">环境变量 JSON</label>
+            <Input placeholder="可选" value={f.env} onChange={e => setF(prev => ({ ...prev, env: e.target.value }))} className="mt-1" />
+          </div>
         </>
       )}
       {(f.transportType === "sse" || f.transportType === "http") && (
         <>
-          <Input placeholder="URL (如 http://localhost:3000/mcp)" value={f.url} onChange={e => setF(prev => ({ ...prev, url: e.target.value }))} />
-          <Input placeholder="请求头 JSON (可选)" value={f.headers} onChange={e => setF(prev => ({ ...prev, headers: e.target.value }))} />
+          <div>
+            <label className="text-sm font-medium">URL</label>
+            <Input placeholder="如 http://localhost:3000/mcp" value={f.url} onChange={e => setF(prev => ({ ...prev, url: e.target.value }))} className="mt-1" />
+          </div>
+          <div>
+            <label className="text-sm font-medium">请求头 JSON</label>
+            <Input placeholder="可选" value={f.headers} onChange={e => setF(prev => ({ ...prev, headers: e.target.value }))} className="mt-1" />
+          </div>
         </>
       )}
-      <Input type="number" placeholder="连接超时 (ms，默认 5000)" value={f.timeout} onChange={e => setF(prev => ({ ...prev, timeout: e.target.value }))} />
+      <div>
+        <label className="text-sm font-medium">连接超时 (ms)</label>
+        <Input type="number" placeholder="默认 5000" value={f.timeout} onChange={e => setF(prev => ({ ...prev, timeout: e.target.value }))} className="mt-1" />
+      </div>
     </>
   )
 
@@ -249,11 +267,6 @@ export function McpServerManager() {
                   </div>
                 </div>
                 <div className="flex items-center gap-1 shrink-0">
-                  {testResult?.id === server.id && (
-                    <span className={`text-xs max-w-32 truncate ${testResult.success ? "text-green-500" : "text-destructive"}`}>
-                      {testResult.message}
-                    </span>
-                  )}
                   <Button variant="ghost" size="icon-xs" onClick={() => handleTest(server)} disabled={testingId === server.id} title="测试连接">
                     {testingId === server.id ? <span className="size-3 animate-spin">⟳</span> : <Wifi className="size-3" />}
                   </Button>
@@ -268,9 +281,14 @@ export function McpServerManager() {
                   </Button>
                 </div>
               </div>
-              {testResult?.id === server.id && testResult.success && testResult.tools && testResult.tools.length > 0 && (
-                <div className="mt-1 pl-4 text-xs text-muted-foreground">
-                  工具: {testResult.tools.map(t => t.name).join(", ")}
+              {testResult?.id === server.id && (
+                <div className={`mt-1 text-xs ${testResult.success ? "text-green-500" : "text-destructive"}`}>
+                  {testResult.message}
+                  {testResult.success && testResult.tools && testResult.tools.length > 0 && (
+                    <p className="text-muted-foreground mt-0.5">
+                      工具: {testResult.tools.map(t => t.name).join(", ")}
+                    </p>
+                  )}
                 </div>
               )}
             </div>
@@ -286,8 +304,14 @@ export function McpServerManager() {
         <DialogContent>
           <DialogHeader><DialogTitle>添加 MCP 服务器</DialogTitle></DialogHeader>
           <div className="space-y-3">
-            <Input placeholder="服务器名称" value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} />
-            <Input placeholder="描述 (可选)" value={form.description} onChange={e => setForm(f => ({ ...f, description: e.target.value }))} />
+            <div>
+              <label className="text-sm font-medium">服务器名称</label>
+              <Input placeholder="如 my-mcp-server" value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} className="mt-1" />
+            </div>
+            <div>
+              <label className="text-sm font-medium">描述</label>
+              <Input placeholder="可选" value={form.description} onChange={e => setForm(f => ({ ...f, description: e.target.value }))} className="mt-1" />
+            </div>
             {renderTransportFields(form, setForm)}
           </div>
           <DialogFooter>
@@ -302,8 +326,14 @@ export function McpServerManager() {
         <DialogContent>
           <DialogHeader><DialogTitle>编辑 MCP 服务器</DialogTitle></DialogHeader>
           <div className="space-y-3">
-            <Input placeholder="服务器名称" value={editForm.name} onChange={e => setEditForm(f => ({ ...f, name: e.target.value }))} />
-            <Input placeholder="描述 (可选)" value={editForm.description} onChange={e => setEditForm(f => ({ ...f, description: e.target.value }))} />
+            <div>
+              <label className="text-sm font-medium">服务器名称</label>
+              <Input placeholder="如 my-mcp-server" value={editForm.name} onChange={e => setEditForm(f => ({ ...f, name: e.target.value }))} className="mt-1" />
+            </div>
+            <div>
+              <label className="text-sm font-medium">描述</label>
+              <Input placeholder="可选" value={editForm.description} onChange={e => setEditForm(f => ({ ...f, description: e.target.value }))} className="mt-1" />
+            </div>
             {renderTransportFields(editForm, setEditForm)}
           </div>
           <DialogFooter>

--- a/src/components/agent2/mcp-server-manager.tsx
+++ b/src/components/agent2/mcp-server-manager.tsx
@@ -243,7 +243,7 @@ export function McpServerManager() {
                   <div className="min-w-0">
                     <p className="font-medium truncate">{server.name}</p>
                     <p className="text-xs text-muted-foreground truncate">
-                      {server.transportType.toUpperCase()} · {config.url || config.command || ""}
+                      {server.transportType.toUpperCase()} · {String(config.url || config.command || "")}
                       {server.description && ` · ${server.description}`}
                     </p>
                   </div>

--- a/src/components/agent2/message-parts.tsx
+++ b/src/components/agent2/message-parts.tsx
@@ -56,6 +56,10 @@ function getToolProgressLabel(toolName: string) {
     case "getTemplate":
       return "正在读取模板"
     default:
+      if (toolName.startsWith("mcp__")) {
+        const serverName = toolName.split("__")[1] || "";
+        return `正在调用 ${serverName} 工具`;
+      }
       return "正在处理工具调用"
   }
 }
@@ -273,7 +277,7 @@ export function MessageParts({ message, onToolConfirm }: MessagePartsProps) {
                             toolInput: confirmOutput.toolInput,
                             riskMessage: confirmOutput.riskMessage,
                             token: confirmOutput.token,
-                            toolCategory: confirmOutput.toolCategory || "execute",
+                            toolCategory: confirmOutput.toolCategory || (toolPart.toolName.startsWith("mcp__") ? "mcp" : "execute"),
                           })
                         }}
                       >

--- a/src/components/agent2/settings-dialog.tsx
+++ b/src/components/agent2/settings-dialog.tsx
@@ -5,6 +5,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Switch } from "@/components/ui/switch"
 import { ModelManager } from "./model-manager"
+import { McpServerManager } from "./mcp-server-manager"
 
 interface SettingsDialogProps {
   open: boolean
@@ -65,6 +66,7 @@ export function SettingsDialog({ open, onOpenChange, onSettingsChange }: Setting
             <TabsTrigger value="tools" className="flex-1">工具执行</TabsTrigger>
             <TabsTrigger value="models" className="flex-1">模型管理</TabsTrigger>
             <TabsTrigger value="display" className="flex-1">显示设置</TabsTrigger>
+            <TabsTrigger value="mcp" className="flex-1">MCP 服务器</TabsTrigger>
           </TabsList>
           <TabsContent value="tools" className="space-y-4 mt-4">
             {toolCategories.map(cat => (
@@ -98,6 +100,9 @@ export function SettingsDialog({ open, onOpenChange, onSettingsChange }: Setting
                 onCheckedChange={(checked: boolean) => updateSettings({ showReasoning: checked })}
               />
             </div>
+          </TabsContent>
+          <TabsContent value="mcp" className="mt-4">
+            <McpServerManager />
           </TabsContent>
         </Tabs>
       </DialogContent>

--- a/src/components/agent2/settings-dialog.tsx
+++ b/src/components/agent2/settings-dialog.tsx
@@ -51,6 +51,7 @@ export function SettingsDialog({ open, onOpenChange, onSettingsChange }: Setting
     { key: "write", label: "创建类工具", description: "创建记录、生成文档" },
     { key: "delete", label: "删除类工具", description: "删除记录" },
     { key: "execute", label: "执行类工具", description: "代码执行" },
+    { key: "mcp", label: "MCP 外部工具", description: "调用外部 MCP 服务器工具" },
   ]
 
   return (

--- a/src/components/agent2/tool-confirm-dialog.tsx
+++ b/src/components/agent2/tool-confirm-dialog.tsx
@@ -85,7 +85,13 @@ export function ToolConfirmDialog({
         <div className="space-y-3">
           <div>
             <p className="text-sm font-medium mb-1">工具</p>
-            <code className="text-sm bg-muted px-2 py-1 rounded">{toolName}</code>
+            <code className="text-sm bg-muted px-2 py-1 rounded">
+              {toolName.startsWith("mcp__") ? (
+                <>{toolName} <span className="text-xs text-muted-foreground">[外部工具]</span></>
+              ) : (
+                toolName
+              )}
+            </code>
           </div>
           <div>
             <p className="text-sm font-medium mb-1">参数</p>

--- a/src/components/ai-elements/prompt-input.tsx
+++ b/src/components/ai-elements/prompt-input.tsx
@@ -1155,7 +1155,7 @@ export const PromptInputButton = ({
 
   return (
     <Tooltip>
-      <TooltipTrigger>{button}</TooltipTrigger>
+      <TooltipTrigger render={<span />}>{button}</TooltipTrigger>
       <TooltipContent side={side}>
         {tooltipContent}
         {shortcut && (

--- a/src/lib/agent2/confirm-store.ts
+++ b/src/lib/agent2/confirm-store.ts
@@ -31,7 +31,12 @@ export function needsConfirm(toolName: string): boolean {
 }
 
 export function getRiskMessage(toolName: string): string {
-  return RISK_MESSAGES[toolName] || "此操作需要确认";
+  if (RISK_MESSAGES[toolName]) return RISK_MESSAGES[toolName];
+  if (toolName.startsWith("mcp__")) {
+    const serverName = toolName.split("__")[1] || "";
+    return `此操作将调用外部 MCP 服务器 "${serverName}" 的工具`;
+  }
+  return "此操作需要确认";
 }
 
 export async function createConfirmToken(

--- a/src/lib/agent2/context-builder.ts
+++ b/src/lib/agent2/context-builder.ts
@@ -18,6 +18,24 @@ export async function buildSystemPrompt(): Promise<string> {
 
   let tableContext = "";
 
+  let mcpContext = "";
+
+  try {
+    const { getEnabledMcpServers } = await import("@/lib/services/agent2-mcp.service");
+    const serversResult = await getEnabledMcpServers();
+    if (serversResult.success && serversResult.data.length > 0) {
+      mcpContext = "\n## 可用的 MCP 外部工具\n";
+      mcpContext += "你还可以使用以下 MCP 外部工具来获取外部数据。工具名称格式为 `mcp__服务器名__工具名`。\n\n";
+      for (const server of serversResult.data) {
+        const config = server.config as Record<string, unknown>;
+        mcpContext += `- **${server.name}** (${server.transportType}): ${config.url || config.command || ""}\n`;
+      }
+      mcpContext += "\n提示：使用 MCP 工具前，先了解该工具的参数要求。MCP 工具名称前缀为 `mcp__`。\n";
+    }
+  } catch {
+    // MCP 上下文获取失败不影响系统提示
+  }
+
   try {
     const tablesResult = await listTables();
     if (tablesResult.success && tablesResult.data.length > 0) {
@@ -59,6 +77,7 @@ export async function buildSystemPrompt(): Promise<string> {
 4. 主动提供帮助 — 根据用户意图推荐合适的工具
 5. 批量导入 — 用户上传文件后，解析内容并使用 batchCreateRecords 批量导入
 ${tableContext}
+${mcpContext}
 ## 回答语言
 默认使用中文回答，除非用户明确要求其他语言。`;
 

--- a/src/lib/agent2/mcp-client.ts
+++ b/src/lib/agent2/mcp-client.ts
@@ -1,7 +1,10 @@
 import { createMCPClient } from "@ai-sdk/mcp";
 import type { MCPClient, MCPClientConfig } from "@ai-sdk/mcp";
-import type { Tool } from "ai";
+import type { Tool, ToolExecutionOptions } from "ai";
+import { tool } from "ai";
+import { z } from "zod";
 import { getEnabledMcpServers } from "@/lib/services/agent2-mcp.service";
+import { createConfirmToken, getRiskMessage } from "@/lib/agent2/confirm-store";
 
 type McpTransport = MCPClientConfig["transport"];
 
@@ -56,33 +59,39 @@ async function createMcpConnection(
 
     const client = await createMCPClient({ transport });
 
-    const toolsPromise = client.tools();
-    const timeoutPromise = new Promise<never>((_, reject) =>
-      setTimeout(
-        () =>
-          reject(
-            new Error(
-              `MCP 服务器 "${server.name}" 连接超时 (${timeout}ms)`
-            )
-          ),
-        timeout
-      )
-    );
+    try {
+      const toolsPromise = client.tools();
+      const timeoutPromise = new Promise<never>((_, reject) =>
+        setTimeout(
+          () =>
+            reject(
+              new Error(
+                `MCP 服务器 "${server.name}" 连接超时 (${timeout}ms)`
+              )
+            ),
+          timeout
+        )
+      );
 
-    const rawTools = await Promise.race([toolsPromise, timeoutPromise]);
+      const rawTools = await Promise.race([toolsPromise, timeoutPromise]);
 
-    // Prefix tool names with mcp__{serverName}__ and add description tag
-    const prefixedTools: Record<string, Tool> = {};
-    for (const [toolName, toolDef] of Object.entries(rawTools)) {
-      const prefixedName = `mcp__${server.name}__${toolName}`;
-      const desc = (toolDef as { description?: string }).description;
-      prefixedTools[prefixedName] = {
-        ...toolDef,
-        description: `[MCP: ${server.name}] ${desc || toolName}`,
-      } as Tool;
+      // Prefix tool names with mcp__{serverName}__ and add description tag
+      const prefixedTools: Record<string, Tool> = {};
+      for (const [toolName, toolDef] of Object.entries(rawTools)) {
+        const prefixedName = `mcp__${server.name}__${toolName}`;
+        const desc = (toolDef as { description?: string }).description;
+        prefixedTools[prefixedName] = {
+          ...toolDef,
+          description: `[MCP: ${server.name}] ${desc || toolName}`,
+        } as Tool;
+      }
+
+      return { client, tools: prefixedTools };
+    } catch (error) {
+      // Close client on timeout or error to prevent resource leaks
+      try { await client.close(); } catch { /* best effort */ }
+      throw error;
     }
-
-    return { client, tools: prefixedTools };
   } catch (error) {
     console.warn(
       `[mcp-client] Failed to connect to "${server.name}":`,
@@ -93,9 +102,56 @@ async function createMcpConnection(
 }
 
 /**
- * 获取所有已启用 MCP 服务器的工具
+ * 将 MCP 工具包装确认机制
  */
-export async function getEnabledMcpTools(): Promise<McpToolsResult> {
+function wrapMcpToolWithConfirm(
+  prefixedName: string,
+  rawTool: Tool,
+  conversationId: string,
+  messageId: string,
+  autoConfirm: Record<string, boolean>
+): Tool {
+  if (!rawTool.execute) return rawTool;
+  const originalExecute = rawTool.execute;
+
+  return tool({
+    description: rawTool.description,
+    inputSchema: rawTool.inputSchema ?? z.object({}),
+    execute: async (args: unknown, context: ToolExecutionOptions) => {
+      const isAutoConfirmed = autoConfirm["mcp"] === true;
+      if (isAutoConfirmed) {
+        return originalExecute(args, context);
+      }
+
+      const tokenResult = await createConfirmToken(
+        conversationId,
+        messageId,
+        prefixedName,
+        args
+      );
+      if (!tokenResult.success) {
+        throw new Error(tokenResult.error.message);
+      }
+
+      return {
+        _needsConfirm: true,
+        token: tokenResult.data,
+        toolName: prefixedName,
+        toolInput: args,
+        riskMessage: getRiskMessage(prefixedName),
+      };
+    },
+  }) as Tool;
+}
+
+/**
+ * 获取所有已启用 MCP 服务器的工具（带确认包装）
+ */
+export async function getEnabledMcpTools(
+  conversationId: string,
+  messageId: string,
+  autoConfirm: Record<string, boolean>
+): Promise<McpToolsResult> {
   const result: McpToolsResult = {
     tools: {},
     clients: [],
@@ -118,7 +174,15 @@ export async function getEnabledMcpTools(): Promise<McpToolsResult> {
 
   for (const connection of connections) {
     if (connection) {
-      result.tools = { ...result.tools, ...connection.tools };
+      for (const [toolName, rawTool] of Object.entries(connection.tools)) {
+        result.tools[toolName] = wrapMcpToolWithConfirm(
+          toolName,
+          rawTool,
+          conversationId,
+          messageId,
+          autoConfirm
+        );
+      }
       result.clients.push(connection.client);
     }
   }

--- a/src/lib/agent2/mcp-client.ts
+++ b/src/lib/agent2/mcp-client.ts
@@ -1,0 +1,168 @@
+import { createMCPClient } from "@ai-sdk/mcp";
+import type { MCPClient, MCPClientConfig } from "@ai-sdk/mcp";
+import type { Tool } from "ai";
+import { getEnabledMcpServers } from "@/lib/services/agent2-mcp.service";
+
+type McpTransport = MCPClientConfig["transport"];
+
+interface McpToolsResult {
+  tools: Record<string, Tool>;
+  clients: MCPClient[];
+}
+
+/**
+ * 创建单个 MCP 客户端连接并获取工具
+ */
+async function createMcpConnection(
+  server: {
+    name: string;
+    transportType: "stdio" | "sse" | "http";
+    config: Record<string, unknown>;
+  },
+  timeout: number = 5000
+): Promise<{ client: MCPClient; tools: Record<string, Tool> } | null> {
+  try {
+    let transport: McpTransport;
+
+    switch (server.transportType) {
+      case "stdio": {
+        const { Experimental_StdioMCPTransport } = await import(
+          "@ai-sdk/mcp/mcp-stdio"
+        );
+        transport = new Experimental_StdioMCPTransport({
+          command: server.config.command as string,
+          args: server.config.args as string[] | undefined,
+          env: server.config.env as Record<string, string> | undefined,
+        });
+        break;
+      }
+      case "sse": {
+        transport = {
+          type: "sse" as const,
+          url: server.config.url as string,
+          headers: server.config.headers as Record<string, string> | undefined,
+        };
+        break;
+      }
+      case "http": {
+        transport = {
+          type: "http" as const,
+          url: server.config.url as string,
+          headers: server.config.headers as Record<string, string> | undefined,
+        };
+        break;
+      }
+    }
+
+    const client = await createMCPClient({ transport });
+
+    const toolsPromise = client.tools();
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(
+        () =>
+          reject(
+            new Error(
+              `MCP 服务器 "${server.name}" 连接超时 (${timeout}ms)`
+            )
+          ),
+        timeout
+      )
+    );
+
+    const rawTools = await Promise.race([toolsPromise, timeoutPromise]);
+
+    // Prefix tool names with mcp__{serverName}__ and add description tag
+    const prefixedTools: Record<string, Tool> = {};
+    for (const [toolName, toolDef] of Object.entries(rawTools)) {
+      const prefixedName = `mcp__${server.name}__${toolName}`;
+      const desc = (toolDef as { description?: string }).description;
+      prefixedTools[prefixedName] = {
+        ...toolDef,
+        description: `[MCP: ${server.name}] ${desc || toolName}`,
+      } as Tool;
+    }
+
+    return { client, tools: prefixedTools };
+  } catch (error) {
+    console.warn(
+      `[mcp-client] Failed to connect to "${server.name}":`,
+      error instanceof Error ? error.message : error
+    );
+    return null;
+  }
+}
+
+/**
+ * 获取所有已启用 MCP 服务器的工具
+ */
+export async function getEnabledMcpTools(): Promise<McpToolsResult> {
+  const result: McpToolsResult = {
+    tools: {},
+    clients: [],
+  };
+
+  const serversResult = await getEnabledMcpServers();
+  if (!serversResult.success || serversResult.data.length === 0) {
+    return result;
+  }
+
+  const connections = await Promise.all(
+    serversResult.data.map((server) => {
+      const timeout =
+        typeof server.config.timeout === "number"
+          ? (server.config.timeout as number)
+          : 5000;
+      return createMcpConnection(server, timeout);
+    })
+  );
+
+  for (const connection of connections) {
+    if (connection) {
+      result.tools = { ...result.tools, ...connection.tools };
+      result.clients.push(connection.client);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * 测试 MCP 服务器连接并返回工具列表（不带前缀）
+ */
+export async function testMcpConnection(
+  server: {
+    name: string;
+    transportType: "stdio" | "sse" | "http";
+    config: Record<string, unknown>;
+  },
+  timeout: number = 5000
+): Promise<{
+  success: boolean;
+  tools?: Array<{ name: string; description?: string }>;
+  error?: string;
+}> {
+  try {
+    const connection = await createMcpConnection(server, timeout);
+    if (!connection) {
+      return { success: false, error: "连接失败" };
+    }
+
+    const toolList = Object.entries(connection.tools).map(
+      ([name, toolDef]) => ({
+        name: name.replace(`mcp__${server.name}__`, ""),
+        description: (toolDef as { description?: string }).description?.replace(
+          `[MCP: ${server.name}] `,
+          ""
+        ),
+      })
+    );
+
+    await connection.client.close();
+    return { success: true, tools: toolList };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "连接测试失败",
+    };
+  }
+}

--- a/src/lib/services/agent2-mcp.service.ts
+++ b/src/lib/services/agent2-mcp.service.ts
@@ -2,6 +2,7 @@ import { db } from "@/lib/db";
 import { encrypt, decrypt } from "./agent2-model.service";
 import type { Agent2McpServerItem, McpServerConfig } from "@/types/agent2";
 import type { ServiceResult } from "@/types/data-table";
+import type { Prisma } from "@/generated/prisma/client";
 
 // ── Helpers ──
 
@@ -169,7 +170,7 @@ export async function createMcpServer(data: {
       name: data.name,
       description: data.description || null,
       transportType: data.transportType,
-      config: encryptedConfig,
+      config: encryptedConfig as unknown as Prisma.InputJsonValue,
       enabled: true,
     },
   });

--- a/src/lib/services/agent2-mcp.service.ts
+++ b/src/lib/services/agent2-mcp.service.ts
@@ -216,7 +216,29 @@ export async function updateMcpServer(
   if (data.enabled !== undefined) updateData.enabled = data.enabled;
   if (data.config !== undefined) {
     const transportType = existing.transportType as "stdio" | "sse" | "http";
-    updateData.config = encryptConfig(transportType, data.config);
+    const existingConfig = existing.config as Record<string, unknown>;
+    const newConfig = { ...data.config };
+
+    // Preserve encrypted values when the client sent masked placeholders
+    const MASK = "••••••••";
+    if (newConfig.headers && typeof newConfig.headers === "object") {
+      const existingHeaders = existingConfig.headers as Record<string, string> | undefined;
+      for (const [key, value] of Object.entries(newConfig.headers as Record<string, string>)) {
+        if (value === MASK && existingHeaders?.[key]) {
+          (newConfig.headers as Record<string, string>)[key] = existingHeaders[key];
+        }
+      }
+    }
+    if (transportType === "stdio" && newConfig.env && typeof newConfig.env === "object") {
+      const existingEnv = existingConfig.env as Record<string, string> | undefined;
+      for (const [key, value] of Object.entries(newConfig.env as Record<string, string>)) {
+        if (value === MASK && existingEnv?.[key]) {
+          (newConfig.env as Record<string, string>)[key] = existingEnv[key];
+        }
+      }
+    }
+
+    updateData.config = encryptConfig(transportType, newConfig);
   }
 
   const updated = await db.agent2McpServer.update({

--- a/src/lib/services/agent2-mcp.service.ts
+++ b/src/lib/services/agent2-mcp.service.ts
@@ -1,0 +1,324 @@
+import { db } from "@/lib/db";
+import { encrypt, decrypt } from "./agent2-model.service";
+import type { Agent2McpServerItem, McpServerConfig } from "@/types/agent2";
+import type { ServiceResult } from "@/types/data-table";
+
+// ── Helpers ──
+
+type McpServerRow = {
+  id: string;
+  name: string;
+  description: string | null;
+  transportType: "stdio" | "sse" | "http";
+  config: unknown;
+  enabled: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+/**
+ * 加密 config 中的敏感字段（headers 的值、env 的值）
+ */
+function encryptConfig(
+  transportType: "stdio" | "sse" | "http",
+  rawConfig: Record<string, unknown>
+): Record<string, unknown> {
+  const config = { ...rawConfig };
+
+  if (config.headers && typeof config.headers === "object") {
+    const encryptedHeaders: Record<string, string> = {};
+    for (const [key, value] of Object.entries(
+      config.headers as Record<string, string>
+    )) {
+      encryptedHeaders[key] = encrypt(value);
+    }
+    config.headers = encryptedHeaders;
+  }
+
+  if (transportType === "stdio" && config.env && typeof config.env === "object") {
+    const encryptedEnv: Record<string, string> = {};
+    for (const [key, value] of Object.entries(
+      config.env as Record<string, string>
+    )) {
+      encryptedEnv[key] = encrypt(value);
+    }
+    config.env = encryptedEnv;
+  }
+
+  return config;
+}
+
+/**
+ * 解密 config 中的敏感字段
+ */
+function decryptConfig(
+  transportType: "stdio" | "sse" | "http",
+  rawConfig: Record<string, unknown>
+): Record<string, unknown> {
+  const config = { ...rawConfig };
+
+  if (config.headers && typeof config.headers === "object") {
+    const decryptedHeaders: Record<string, string> = {};
+    for (const [key, value] of Object.entries(
+      config.headers as Record<string, string>
+    )) {
+      try {
+        decryptedHeaders[key] = decrypt(value);
+      } catch {
+        decryptedHeaders[key] = value;
+      }
+    }
+    config.headers = decryptedHeaders;
+  }
+
+  if (transportType === "stdio" && config.env && typeof config.env === "object") {
+    const decryptedEnv: Record<string, string> = {};
+    for (const [key, value] of Object.entries(
+      config.env as Record<string, string>
+    )) {
+      try {
+        decryptedEnv[key] = decrypt(value);
+      } catch {
+        decryptedEnv[key] = value;
+      }
+    }
+    config.env = decryptedEnv;
+  }
+
+  return config;
+}
+
+/**
+ * 将 config 中敏感字段掩码显示
+ */
+function maskConfig(
+  transportType: "stdio" | "sse" | "http",
+  rawConfig: Record<string, unknown>
+): Record<string, unknown> {
+  const config = { ...rawConfig };
+
+  if (config.headers && typeof config.headers === "object") {
+    const maskedHeaders: Record<string, string> = {};
+    for (const key of Object.keys(config.headers as Record<string, string>)) {
+      maskedHeaders[key] = "••••••••";
+    }
+    config.headers = maskedHeaders;
+  }
+
+  if (transportType === "stdio" && config.env && typeof config.env === "object") {
+    const maskedEnv: Record<string, string> = {};
+    for (const key of Object.keys(config.env as Record<string, string>)) {
+      maskedEnv[key] = "••••••••";
+    }
+    config.env = maskedEnv;
+  }
+
+  return config;
+}
+
+function mapMcpServerItem(row: McpServerRow): Agent2McpServerItem {
+  const rawConfig = row.config as Record<string, unknown>;
+  rawConfig.type = row.transportType;
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    transportType: row.transportType,
+    config: maskConfig(row.transportType, rawConfig) as unknown as McpServerConfig,
+    enabled: row.enabled,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+// ── CRUD ──
+
+export async function listMcpServers(): Promise<
+  ServiceResult<Agent2McpServerItem[]>
+> {
+  const servers = await db.agent2McpServer.findMany({
+    orderBy: { createdAt: "desc" },
+  });
+
+  return {
+    success: true,
+    data: servers.map((s) => mapMcpServerItem(s as unknown as McpServerRow)),
+  };
+}
+
+export async function createMcpServer(data: {
+  name: string;
+  description?: string;
+  transportType: "stdio" | "sse" | "http";
+  config: Record<string, unknown>;
+}): Promise<ServiceResult<Agent2McpServerItem>> {
+  const existing = await db.agent2McpServer.findUnique({
+    where: { name: data.name },
+  });
+  if (existing) {
+    return {
+      success: false,
+      error: { code: "DUPLICATE_NAME", message: `MCP 服务器名称 "${data.name}" 已存在` },
+    };
+  }
+
+  const encryptedConfig = encryptConfig(data.transportType, data.config);
+
+  const server = await db.agent2McpServer.create({
+    data: {
+      name: data.name,
+      description: data.description || null,
+      transportType: data.transportType,
+      config: encryptedConfig,
+      enabled: true,
+    },
+  });
+
+  return {
+    success: true,
+    data: mapMcpServerItem(server as unknown as McpServerRow),
+  };
+}
+
+export async function updateMcpServer(
+  id: string,
+  data: {
+    name?: string;
+    description?: string | null;
+    enabled?: boolean;
+    config?: Record<string, unknown>;
+  }
+): Promise<ServiceResult<Agent2McpServerItem>> {
+  const existing = await db.agent2McpServer.findUnique({ where: { id } });
+  if (!existing) {
+    return {
+      success: false,
+      error: { code: "NOT_FOUND", message: "MCP 服务器不存在" },
+    };
+  }
+
+  if (data.name && data.name !== existing.name) {
+    const duplicate = await db.agent2McpServer.findUnique({
+      where: { name: data.name },
+    });
+    if (duplicate) {
+      return {
+        success: false,
+        error: { code: "DUPLICATE_NAME", message: `MCP 服务器名称 "${data.name}" 已存在` },
+      };
+    }
+  }
+
+  const updateData: Record<string, unknown> = {};
+  if (data.name !== undefined) updateData.name = data.name;
+  if (data.description !== undefined) updateData.description = data.description;
+  if (data.enabled !== undefined) updateData.enabled = data.enabled;
+  if (data.config !== undefined) {
+    const transportType = existing.transportType as "stdio" | "sse" | "http";
+    updateData.config = encryptConfig(transportType, data.config);
+  }
+
+  const updated = await db.agent2McpServer.update({
+    where: { id },
+    data: updateData,
+  });
+
+  return {
+    success: true,
+    data: mapMcpServerItem(updated as unknown as McpServerRow),
+  };
+}
+
+export async function deleteMcpServer(
+  id: string
+): Promise<ServiceResult<{ id: string }>> {
+  const existing = await db.agent2McpServer.findUnique({ where: { id } });
+  if (!existing) {
+    return {
+      success: false,
+      error: { code: "NOT_FOUND", message: "MCP 服务器不存在" },
+    };
+  }
+
+  await db.agent2McpServer.delete({ where: { id } });
+
+  return {
+    success: true,
+    data: { id },
+  };
+}
+
+/**
+ * 获取已解密的配置（用于创建 MCP 客户端连接）
+ */
+export async function getDecryptedMcpServer(
+  id: string
+): Promise<
+  ServiceResult<{
+    id: string;
+    name: string;
+    transportType: "stdio" | "sse" | "http";
+    config: Record<string, unknown>;
+  }>
+> {
+  const server = await db.agent2McpServer.findUnique({ where: { id } });
+  if (!server) {
+    return {
+      success: false,
+      error: { code: "NOT_FOUND", message: "MCP 服务器不存在" },
+    };
+  }
+
+  const rawConfig = server.config as Record<string, unknown>;
+  rawConfig.type = server.transportType;
+  const decryptedConfig = decryptConfig(
+    server.transportType as "stdio" | "sse" | "http",
+    rawConfig
+  );
+
+  return {
+    success: true,
+    data: {
+      id: server.id,
+      name: server.name,
+      transportType: server.transportType as "stdio" | "sse" | "http",
+      config: decryptedConfig,
+    },
+  };
+}
+
+/**
+ * 获取所有已启用的 MCP 服务器（解密配置）
+ */
+export async function getEnabledMcpServers(): Promise<
+  ServiceResult<
+    Array<{
+      id: string;
+      name: string;
+      transportType: "stdio" | "sse" | "http";
+      config: Record<string, unknown>;
+    }>
+  >
+> {
+  const servers = await db.agent2McpServer.findMany({
+    where: { enabled: true },
+    orderBy: { createdAt: "desc" },
+  });
+
+  const result = servers.map((server) => {
+    const rawConfig = server.config as Record<string, unknown>;
+    rawConfig.type = server.transportType;
+    const decryptedConfig = decryptConfig(
+      server.transportType as "stdio" | "sse" | "http",
+      rawConfig
+    );
+    return {
+      id: server.id,
+      name: server.name,
+      transportType: server.transportType as "stdio" | "sse" | "http",
+      config: decryptedConfig,
+    };
+  });
+
+  return { success: true, data: result };
+}

--- a/src/lib/services/agent2-model.service.ts
+++ b/src/lib/services/agent2-model.service.ts
@@ -16,7 +16,7 @@ if (!ENCRYPTION_KEY || !/^[0-9a-f]{64}$/i.test(ENCRYPTION_KEY)) {
   );
 }
 
-function encrypt(text: string): string {
+export function encrypt(text: string): string {
   if (!ENCRYPTION_KEY || ENCRYPTION_KEY.length !== 64) {
     throw new Error("MODEL_CONFIG_ENCRYPTION_KEY 未配置或无效（需要 64 位十六进制字符）");
   }

--- a/src/types/agent2.ts
+++ b/src/types/agent2.ts
@@ -83,3 +83,26 @@ export interface Agent2UploadResult {
   fileName: string;
   fileType: string;
 }
+
+// ============ MCP Server ============
+export interface Agent2McpServerItem {
+  id: string;
+  name: string;
+  description: string | null;
+  transportType: "stdio" | "sse" | "http";
+  config: McpServerConfig;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type McpServerConfig =
+  | { type: "stdio"; command: string; args?: string[]; env?: Record<string, string>; timeout?: number }
+  | { type: "sse"; url: string; headers?: Record<string, string>; timeout?: number }
+  | { type: "http"; url: string; headers?: Record<string, string>; timeout?: number };
+
+export interface McpToolInfo {
+  name: string;
+  description?: string;
+  inputSchema?: object;
+}

--- a/src/validators/agent2.ts
+++ b/src/validators/agent2.ts
@@ -65,7 +65,7 @@ export const createMcpServerSchema = z.discriminatedUnion("transportType", [
     config: z.object({
       command: z.string().min(1),
       args: z.array(z.string()).optional(),
-      env: z.record(z.string()).optional(),
+      env: z.record(z.string(), z.string()).optional(),
       timeout: z.number().min(1000).max(60000).optional(),
     }),
   }),
@@ -75,7 +75,7 @@ export const createMcpServerSchema = z.discriminatedUnion("transportType", [
     transportType: z.literal("sse"),
     config: z.object({
       url: z.string().url(),
-      headers: z.record(z.string()).optional(),
+      headers: z.record(z.string(), z.string()).optional(),
       timeout: z.number().min(1000).max(60000).optional(),
     }),
   }),
@@ -85,7 +85,7 @@ export const createMcpServerSchema = z.discriminatedUnion("transportType", [
     transportType: z.literal("http"),
     config: z.object({
       url: z.string().url(),
-      headers: z.record(z.string()).optional(),
+      headers: z.record(z.string(), z.string()).optional(),
       timeout: z.number().min(1000).max(60000).optional(),
     }),
   }),
@@ -99,9 +99,9 @@ export const updateMcpServerSchema = z.object({
     .object({
       command: z.string().min(1).optional(),
       args: z.array(z.string()).optional(),
-      env: z.record(z.string()).optional(),
+      env: z.record(z.string(), z.string()).optional(),
       url: z.string().url().optional(),
-      headers: z.record(z.string()).optional(),
+      headers: z.record(z.string(), z.string()).optional(),
       timeout: z.number().min(1000).max(60000).optional(),
     })
     .optional(),

--- a/src/validators/agent2.ts
+++ b/src/validators/agent2.ts
@@ -55,3 +55,57 @@ export type ToolConfirmInput = z.infer<typeof toolConfirmSchema>;
 export type CreateModelInput = z.infer<typeof createModelSchema>;
 export type UpdateModelInput = z.infer<typeof updateModelSchema>;
 export type UpdateSettingsInput = z.infer<typeof updateSettingsSchema>;
+
+// ============ MCP Server ============
+export const createMcpServerSchema = z.discriminatedUnion("transportType", [
+  z.object({
+    name: z.string().min(1).max(50),
+    description: z.string().max(200).optional(),
+    transportType: z.literal("stdio"),
+    config: z.object({
+      command: z.string().min(1),
+      args: z.array(z.string()).optional(),
+      env: z.record(z.string()).optional(),
+      timeout: z.number().min(1000).max(60000).optional(),
+    }),
+  }),
+  z.object({
+    name: z.string().min(1).max(50),
+    description: z.string().max(200).optional(),
+    transportType: z.literal("sse"),
+    config: z.object({
+      url: z.string().url(),
+      headers: z.record(z.string()).optional(),
+      timeout: z.number().min(1000).max(60000).optional(),
+    }),
+  }),
+  z.object({
+    name: z.string().min(1).max(50),
+    description: z.string().max(200).optional(),
+    transportType: z.literal("http"),
+    config: z.object({
+      url: z.string().url(),
+      headers: z.record(z.string()).optional(),
+      timeout: z.number().min(1000).max(60000).optional(),
+    }),
+  }),
+]);
+
+export const updateMcpServerSchema = z.object({
+  name: z.string().min(1).max(50).optional(),
+  description: z.string().max(200).optional().nullable(),
+  enabled: z.boolean().optional(),
+  config: z
+    .object({
+      command: z.string().min(1).optional(),
+      args: z.array(z.string()).optional(),
+      env: z.record(z.string()).optional(),
+      url: z.string().url().optional(),
+      headers: z.record(z.string()).optional(),
+      timeout: z.number().min(1000).max(60000).optional(),
+    })
+    .optional(),
+});
+
+export type CreateMcpServerInput = z.infer<typeof createMcpServerSchema>;
+export type UpdateMcpServerInput = z.infer<typeof updateMcpServerSchema>;


### PR DESCRIPTION
## Summary
- 为 AI Agent2 新增 MCP (Model Context Protocol) 服务器管理功能，支持 stdio/SSE/HTTP 三种传输方式
- 管理员可在设置中配置全局 MCP 服务器，支持增删改查、启用禁用、连接测试
- AI 聊天自动加载已启用的 MCP 工具，模型可调用外部 MCP 工具获取数据
- 敏感配置（headers、env）使用 AES-256-GCM 加密存储
- 复用现有工具确认机制，MCP 工具标记为 `[外部工具]`

## 改动文件
- `prisma/schema.prisma` — 新增 `Agent2McpServer` 模型
- `src/types/agent2.ts` — 新增 MCP 类型定义
- `src/validators/agent2.ts` — 新增 MCP 校验 Schema
- `src/lib/services/agent2-mcp.service.ts` — MCP CRUD 服务层
- `src/lib/agent2/mcp-client.ts` — MCP 客户端管理
- `src/lib/agent2/context-builder.ts` — 系统提示增加 MCP 说明
- `src/lib/agent2/confirm-store.ts` — 确认机制增加 MCP 类别
- `src/app/api/agent2/admin/mcp/` — MCP 管理 API 路由
- `src/app/api/agent2/conversations/[id]/chat/route.ts` — 聊天集成 MCP 工具
- `src/components/agent2/mcp-server-manager.tsx` — MCP 管理器组件
- `src/components/agent2/settings-dialog.tsx` — 设置弹窗新增 MCP 选项卡
- `src/components/agent2/tool-confirm-dialog.tsx` — 工具确认标记外部工具
- `src/components/agent2/message-parts.tsx` — 消息渲染 MCP 工具来源

## Test plan
- [x] 管理员设置页面 MCP 选项卡正常显示
- [x] 添加/编辑/删除 MCP 服务器正常工作
- [x] 测试连接返回工具列表
- [x] 启用/禁用切换正常
- [x] AI 聊天中模型正确识别并调用 MCP 工具
- [x] TypeScript 类型检查通过
- [x] ESLint 检查通过
- [x] 生产构建通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)