### PR TITLE
[Fix] 手机端 AI 助手侧边栏适配

### DIFF
--- a/src/components/agent2/agent2-layout.tsx
+++ b/src/components/agent2/agent2-layout.tsx
@@ -1,26 +1,28 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useState, useCallback } from "react"
 import { ConversationSidebar } from "./conversation-sidebar"
 import { ChatArea } from "./chat-area"
 import { SettingsDialog } from "./settings-dialog"
 import { Button } from "@/components/ui/button"
+import { Sheet, SheetContent } from "@/components/ui/sheet"
 import { MessageSquarePlus, PanelLeft, PanelLeftClose } from "lucide-react"
 
 const SELECTED_CONVERSATION_STORAGE_KEY = "agent2:selectedConversationId"
 
 export function Agent2Layout() {
-  const [selectedConversationId, setSelectedConversationId] = useState<string | null>(() => {
-    if (typeof window === "undefined") {
-      return null
-    }
-
-    return window.localStorage.getItem(SELECTED_CONVERSATION_STORAGE_KEY)
-  })
+  const [selectedConversationId, setSelectedConversationId] = useState<string | null>(null)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [refreshKey, setRefreshKey] = useState(0)
   const [defaultModel, setDefaultModel] = useState<string>("")
+
+  // Read from localStorage after mount to avoid hydration mismatch
+  useEffect(() => {
+    const stored = window.localStorage.getItem(SELECTED_CONVERSATION_STORAGE_KEY)
+    if (stored) setSelectedConversationId(stored)
+  }, [])
 
   useEffect(() => {
     if (selectedConversationId) {
@@ -35,47 +37,74 @@ export function Agent2Layout() {
     setDefaultModel(settings.defaultModel)
   }
 
+  const toggleSidebar = useCallback(() => {
+    setSidebarCollapsed(c => !c)
+  }, [])
+
+  const handleMobileSelect = useCallback((id: string) => {
+    setSelectedConversationId(id)
+    setMobileMenuOpen(false)
+  }, [])
+
+  const handleNewConversation = useCallback(async () => {
+    const res = await fetch("/api/agent2/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    })
+    const data = await res.json()
+    if (data.success) {
+      setSelectedConversationId(data.data.id)
+      setRefreshKey(k => k + 1)
+      setMobileMenuOpen(false)
+    }
+  }, [])
+
+  const sidebarContent = (
+    <ConversationSidebar
+      selectedId={selectedConversationId}
+      onSelect={handleMobileSelect}
+      onToggleCollapse={toggleSidebar}
+      settingsOpen={settingsOpen}
+      onSettingsOpenChange={setSettingsOpen}
+      refreshKey={refreshKey}
+    />
+  )
+
   return (
     <div className="flex h-[calc(100vh-4rem)] overflow-hidden">
-      {/* Sidebar */}
-      <div
-        className={`shrink-0 border-r transition-all duration-200 ${sidebarCollapsed ? "w-0 overflow-hidden" : "w-[280px]"}`}
-      >
-        <ConversationSidebar
-          selectedId={selectedConversationId}
-          onSelect={setSelectedConversationId}
-          onToggleCollapse={() => setSidebarCollapsed(!sidebarCollapsed)}
-          settingsOpen={settingsOpen}
-          onSettingsOpenChange={setSettingsOpen}
-          refreshKey={refreshKey}
-        />
+      {/* Desktop sidebar */}
+      <div className="hidden md:block">
+        <div
+          className={`shrink-0 border-r transition-all duration-200 h-full ${sidebarCollapsed ? "w-0 overflow-hidden" : "w-[280px]"}`}
+        >
+          {sidebarContent}
+        </div>
       </div>
+
+      {/* Mobile sidebar (Sheet drawer) */}
+      <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
+        <SheetContent side="left" className="w-[280px] p-0 gap-0" showCloseButton={false}>
+          {sidebarContent}
+        </SheetContent>
+      </Sheet>
 
       {/* Chat area */}
       <div className="flex-1 min-w-0">
         {selectedConversationId ? (
           <ChatArea
             conversationId={selectedConversationId}
-            onToggleSidebar={() => setSidebarCollapsed(!sidebarCollapsed)}
+            onToggleSidebar={toggleSidebar}
             sidebarCollapsed={sidebarCollapsed}
+            onMobileMenuOpen={() => setMobileMenuOpen(true)}
             defaultModel={defaultModel}
           />
         ) : (
           <EmptyState
-            onToggleSidebar={() => setSidebarCollapsed(!sidebarCollapsed)}
+            onToggleSidebar={toggleSidebar}
             sidebarCollapsed={sidebarCollapsed}
-            onNewConversation={async () => {
-              const res = await fetch("/api/agent2/conversations", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: "{}",
-              })
-              const data = await res.json()
-              if (data.success) {
-                setSelectedConversationId(data.data.id)
-                setRefreshKey(k => k + 1)
-              }
-            }}
+            onMobileMenuOpen={() => setMobileMenuOpen(true)}
+            onNewConversation={handleNewConversation}
           />
         )}
       </div>
@@ -89,22 +118,27 @@ export function Agent2Layout() {
 function EmptyState({
   onToggleSidebar,
   sidebarCollapsed,
+  onMobileMenuOpen,
   onNewConversation,
 }: {
   onToggleSidebar: () => void
   sidebarCollapsed: boolean
+  onMobileMenuOpen: () => void
   onNewConversation: () => void
 }) {
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
       <div className="flex items-center gap-2 p-3 border-b shrink-0">
-        <Button variant="ghost" size="icon-xs" onClick={onToggleSidebar}>
+        <Button variant="ghost" size="icon-xs" className="hidden md:inline-flex" onClick={onToggleSidebar}>
           {sidebarCollapsed ? (
             <PanelLeftClose className="size-4" />
           ) : (
             <PanelLeft className="size-4" />
           )}
+        </Button>
+        <Button variant="ghost" size="icon-xs" className="md:hidden" onClick={onMobileMenuOpen}>
+          <PanelLeft className="size-4" />
         </Button>
       </div>
 

--- a/src/components/agent2/chat-area.tsx
+++ b/src/components/agent2/chat-area.tsx
@@ -40,6 +40,7 @@ interface ChatAreaProps {
   conversationId: string
   onToggleSidebar: () => void
   sidebarCollapsed: boolean
+  onMobileMenuOpen?: () => void
   defaultModel?: string
 }
 
@@ -89,7 +90,7 @@ function PromptInputAttachmentButton({ disabled = false }: { disabled?: boolean 
   )
 }
 
-export function ChatArea({ conversationId, onToggleSidebar, sidebarCollapsed, defaultModel }: ChatAreaProps) {
+export function ChatArea({ conversationId, onToggleSidebar, sidebarCollapsed, onMobileMenuOpen, defaultModel }: ChatAreaProps) {
   const [modelName, setModelName] = useState("MiniMax-M2.5")
   const [model, setModel] = useState(defaultModel || "MiniMax-M2.5")
   const [inputError, setInputError] = useState<string | null>(null)
@@ -251,7 +252,7 @@ export function ChatArea({ conversationId, onToggleSidebar, sidebarCollapsed, de
     <div className="flex flex-col h-full">
       {/* Header */}
       <div className="flex items-center gap-2 px-4 py-2 border-b shrink-0">
-        <Button variant="ghost" size="icon-xs" onClick={onToggleSidebar}>
+        <Button variant="ghost" size="icon-xs" className="hidden md:inline-flex" onClick={onToggleSidebar}>
           {mounted ? (
             sidebarCollapsed ? (
               <PanelLeft className="size-4" />
@@ -262,6 +263,11 @@ export function ChatArea({ conversationId, onToggleSidebar, sidebarCollapsed, de
             <PanelLeftClose className="size-4" />
           )}
         </Button>
+        {onMobileMenuOpen && (
+          <Button variant="ghost" size="icon-xs" className="md:hidden" onClick={onMobileMenuOpen}>
+            <PanelLeft className="size-4" />
+          </Button>
+        )}
         <span className="text-sm font-medium truncate">AI 助手</span>
         <span className="text-xs text-muted-foreground">{modelName}</span>
       </div>


### PR DESCRIPTION
## Summary
- 手机端（< md 断点）隐藏固定侧边栏，聊天区域占满全屏
- 点击菜单按钮以 Sheet 抽屉从左侧滑出展示会话列表
- 选择会话后自动收起抽屉
- 桌面端保持原有折叠/展开行为不变

## Test plan
- [x] 桌面端侧边栏正常显示和折叠
- [x] 手机端侧边栏隐藏，点击按钮打开 Sheet
- [x] 选择会话后 Sheet 自动关闭
- [x] TypeScript 类型检查通过

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)