### PR TITLE
[Feature] 论文导入工具及确认流程优化

### DIFF
--- a/docs/superpowers/plans/2026-04-11-paper-import-agent2.md
+++ b/docs/superpowers/plans/2026-04-11-paper-import-agent2.md
@@ -1,0 +1,713 @@
+# 论文导入 AI Agent2 工具 实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 AI Agent2 注册论文导入专用工具，支持文本粘贴解析和 DOI 查询两种方式导入论文到论文表和作者表。
+
+**Architecture:** 新增 3 个 Agent2 工具（parsePaperText、fetchPaperByDOI、importPaper），通过现有的 `createTools()` 工厂函数注册，复用 Agent2 的聊天、确认、流式响应机制。DOI 查询调用 Crossref 公共 API。导入执行通过 `data-record.service` 和 `data-relation.service` 操作数据库。
+
+**Tech Stack:** AI SDK `tool()`, Zod schemas, Crossref REST API, Prisma (data-record, data-relation services)
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `src/lib/agent2/doi-service.ts` | Crossref API 封装，DOI → 结构化论文元数据 |
+| Create | `src/lib/agent2/paper-import-executor.ts` | 导入执行：作者匹配/创建、论文创建、关联建立 |
+| Modify | `src/lib/agent2/tools.ts` | 注册 3 个新工具到 `createTools()` |
+| Modify | `src/lib/agent2/tool-executor.ts` | 添加 `importPaper` 的实际执行逻辑 |
+| Modify | `src/lib/agent2/confirm-store.ts` | 注册 `importPaper` 到 CONFIRM_REQUIRED_TOOLS 和 RISK_MESSAGES |
+| Modify | `src/lib/agent2/context-builder.ts` | 系统提示中增加论文导入能力说明 |
+
+---
+
+### Task 1: 创建 DOI 服务 (`src/lib/agent2/doi-service.ts`)
+
+**Files:**
+- Create: `src/lib/agent2/doi-service.ts`
+
+- [ ] **Step 1: 实现 DOI 查询服务**
+
+```typescript
+// src/lib/agent2/doi-service.ts
+
+export interface DOIPaperResult {
+  title: string;
+  authors: Array<{ name: string; orcid?: string }>;
+  year?: number;
+  publishDate?: string;
+  venueName?: string;
+  doi: string;
+  paperType?: "journal" | "conference";
+  volume?: string;
+  issue?: string;
+  pages?: string;
+  issn?: string;
+  url?: string;
+}
+
+/**
+ * 通过 DOI 从 Crossref API 获取论文元数据
+ * API: https://api.crossref.org/works/{doi}
+ */
+export async function fetchPaperByDOI(
+  doi: string
+): Promise<{ success: true; data: DOIPaperResult } | { success: false; error: string }> {
+  // 清理 DOI：移除 URL 前缀
+  const cleanDOI = doi
+    .replace(/^https?:\/\/doi\.org\//i, "")
+    .replace(/^DOI:\s*/i, "")
+    .trim();
+
+  try {
+    const response = await fetch(
+      `https://api.crossref.org/works/${encodeURIComponent(cleanDOI)}`,
+      {
+        headers: { "User-Agent": "IDRL-DocxTemplateSystem/1.0 (mailto:admin@example.com)" },
+        signal: AbortSignal.timeout(15_000),
+      }
+    );
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        return { success: false, error: `未找到 DOI "${cleanDOI}" 对应的论文，请检查 DOI 是否正确` };
+      }
+      return { success: false, error: `Crossref API 返回错误 (${response.status})` };
+    }
+
+    const json = (await response.json()) as { message: CrossrefWork };
+    const item = json.message;
+
+    // 提取作者
+    const authors = (item.author ?? []).map((a) => ({
+      name: [a.given, a.family].filter(Boolean).join(" "),
+      orcid: a.ORCID?.replace("http://orcid.org/", ""),
+    }));
+
+    // 提取年份和日期
+    const year = item.published?.["date-parts"]?.[0]?.[0]
+      ?? item.created?.["date-parts"]?.[0]?.[0];
+    const publishDate = item.published?.["date-parts"]?.[0]
+      ? formatDateParts(item.published["date-parts"][0])
+      : undefined;
+
+    // 提取期刊/会议名
+    const venueName = item["container-title"]?.[0] ?? item["event"]?.name ?? undefined;
+
+    // 判断论文类型
+    const paperType = inferPaperType(item.type);
+
+    return {
+      success: true,
+      data: {
+        title: item.title?.[0] ?? "",
+        authors,
+        year,
+        publishDate,
+        venueName,
+        doi: cleanDOI,
+        paperType,
+        volume: item.volume ?? undefined,
+        issue: item.issue ?? undefined,
+        pages: item.page ?? undefined,
+        issn: item.ISSN?.[0] ?? undefined,
+        url: item.URL ?? `https://doi.org/${cleanDOI}`,
+      },
+    };
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "TimeoutError") {
+      return { success: false, error: "Crossref API 请求超时，请稍后重试或手动输入论文信息" };
+    }
+    return { success: false, error: `DOI 查询失败: ${err instanceof Error ? err.message : "未知错误"}` };
+  }
+}
+
+// ── Crossref API 类型 ──
+
+interface CrossrefWork {
+  title?: string[];
+  author?: Array<{ given?: string; family?: string; ORCID?: string }>;
+  published?: { "date-parts": number[][] };
+  created?: { "date-parts": number[][] };
+  "container-title"?: string[];
+  event?: { name?: string };
+  type?: string;
+  volume?: string;
+  issue?: string;
+  page?: string;
+  ISSN?: string[];
+  URL?: string;
+}
+
+function formatDateParts(parts: number[]): string {
+  const [y, m, d] = parts;
+  if (d && m) return `${y}-${String(m).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+  if (m) return `${y}-${String(m).padStart(2, "0")}`;
+  return String(y);
+}
+
+function inferPaperType(type?: string): "journal" | "conference" | undefined {
+  if (!type) return undefined;
+  const lower = type.toLowerCase();
+  if (lower.includes("proceedings") || lower.includes("conference")) return "conference";
+  if (lower.includes("journal") || lower.includes("article")) return "journal";
+  return undefined;
+}
+```
+
+- [ ] **Step 2: 验证类型检查通过**
+
+Run: `npx tsc --noEmit 2>&1 | grep doi-service`
+Expected: no output (no errors)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/agent2/doi-service.ts
+git commit -m "feat(agent2): 添加 DOI 查询服务（Crossref API）"
+```
+
+---
+
+### Task 2: 创建论文导入执行器 (`src/lib/agent2/paper-import-executor.ts`)
+
+**Files:**
+- Create: `src/lib/agent2/paper-import-executor.ts`
+
+- [ ] **Step 1: 实现论文导入执行器**
+
+```typescript
+// src/lib/agent2/paper-import-executor.ts
+import { db } from "@/lib/db";
+import type { Prisma } from "@/generated/prisma/client";
+import { syncRelationSubtableValues } from "@/lib/services/data-relation.service";
+import type { RelationSubtableValueItem } from "@/types/data-table";
+
+// ── Types ──
+
+export interface PaperInput {
+  title_en: string;
+  title_cn?: string;
+  paper_type?: "journal" | "conference";
+  group_name?: string;
+  publish_year?: number;
+  publish_date?: string;
+  conf_start_date?: string;
+  conf_end_date?: string;
+  venue_name?: string;
+  venue_name_cn?: string;
+  conf_location?: string;
+  doi?: string;
+  index_type?: string;
+  pub_status?: string;
+  archive_status?: string;
+  corr_authors?: string;
+  inst_rank?: number;
+  fund_no?: string;
+  paper_url?: string;
+  volume?: string;
+  issue?: string;
+  pages?: string;
+  impact_factor?: number;
+  issn_isbn?: string;
+  ccf_category?: string;
+  cas_partition?: string;
+  jcr_partition?: string;
+  sci_partition?: string;
+}
+
+export interface AuthorInput {
+  name: string;               // 原始姓名
+  author_order: number;       // 作者顺序
+  is_first_author: "Y" | "N";
+  is_corresponding_author: "Y" | "N";
+}
+
+export interface ImportResult {
+  paperId: string;
+  authors: Array<{
+    name: string;
+    status: "matched" | "created";
+    authorId: string;
+  }>;
+}
+
+// ── Helpers ──
+
+/** 标准化姓名：小写、去空格标点 */
+function normalizeName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[\s\-,.]+/g, "")
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "");
+}
+
+/** 按名称查找"作者"表和"论文"表 */
+async function findPaperAndAuthorTables(): Promise<{
+  paperTableId: string;
+  authorTableId: string;
+  authorsFieldId: string;
+} | null> {
+  // 查找论文表（名称包含"论文"）
+  const paperTable = await db.dataTable.findFirst({
+    where: { name: { contains: "论文" } },
+    include: { fields: true },
+  });
+  if (!paperTable) return null;
+
+  // 在论文表中找到 authors 关系字段
+  const authorsField = paperTable.fields.find(
+    (f) => f.key === "authors" && f.type === "RELATION_SUBTABLE"
+  );
+  if (!authorsField || !authorsField.relationTo) return null;
+
+  return {
+    paperTableId: paperTable.id,
+    authorTableId: authorsField.relationTo,
+    authorsFieldId: authorsField.id,
+  };
+}
+
+/** 在作者表中按标准化姓名匹配作者 */
+async function matchOrCreateAuthor(
+  authorTableId: string,
+  name: string,
+  userId: string
+): Promise<{ id: string; status: "matched" | "created" }> {
+  const norm = normalizeName(name);
+
+  // 尝试匹配：按 name_norm 或 name_cn/name_en
+  const existing = await db.dataRecord.findFirst({
+    where: {
+      tableId: authorTableId,
+      OR: [
+        { data: { path: ["name_norm"], string_contains: norm } },
+        { data: { path: ["name_cn"], string_contains: norm } },
+        { data: { path: ["name_en"], string_contains: norm } },
+      ],
+    },
+  });
+
+  if (existing) {
+    return { id: existing.id, status: "matched" };
+  }
+
+  // 未匹配则新建
+  const record = await db.dataRecord.create({
+    data: {
+      tableId: authorTableId,
+      data: {
+        name_cn: name,
+        name_en: name,
+        name_norm: norm,
+      } as unknown as Prisma.InputJsonValue,
+      createdById: userId,
+    },
+  });
+
+  return { id: record.id, status: "created" };
+}
+
+// ── Main executor ──
+
+export async function importPaper(
+  paperData: PaperInput,
+  authors: AuthorInput[],
+  userId: string
+): Promise<{ success: true; data: ImportResult } | { success: false; error: string }> {
+  try {
+    const tables = await findPaperAndAuthorTables();
+    if (!tables) {
+      return { success: false, error: "未找到论文表或作者表，请确保已运行 seed-papers 初始化" };
+    }
+
+    const { paperTableId, authorTableId, authorsFieldId } = tables;
+
+    // 1. 匹配/创建所有作者
+    const authorResults: ImportResult["authors"] = [];
+    const authorIdMap = new Map<number, string>(); // author_order → recordId
+
+    for (const author of authors) {
+      const result = await matchOrCreateAuthor(authorTableId, author.name, userId);
+      authorResults.push({
+        name: author.name,
+        status: result.status,
+        authorId: result.id,
+      });
+      authorIdMap.set(author.author_order, result.id);
+    }
+
+    // 2. 创建论文记录
+    const paperRecord = await db.dataRecord.create({
+      data: {
+        tableId: paperTableId,
+        data: {
+          paper_id: `paper-${Date.now()}`,
+          title_en: paperData.title_en,
+          title_cn: paperData.title_cn ?? "",
+          paper_type: paperData.paper_type ?? "",
+          group_name: paperData.group_name ?? "",
+          publish_year: paperData.publish_year ?? null,
+          publish_date: paperData.publish_date ?? "",
+          conf_start_date: paperData.conf_start_date ?? "",
+          conf_end_date: paperData.conf_end_date ?? "",
+          venue_name: paperData.venue_name ?? "",
+          venue_name_cn: paperData.venue_name_cn ?? "",
+          conf_location: paperData.conf_location ?? "",
+          doi: paperData.doi ?? "",
+          index_type: paperData.index_type ?? "",
+          pub_status: paperData.pub_status ?? "",
+          archive_status: paperData.archive_status ?? "",
+          corr_authors: paperData.corr_authors ?? "",
+          inst_rank: paperData.inst_rank ?? null,
+          fund_no: paperData.fund_no ?? "",
+          paper_url: paperData.paper_url ?? "",
+          volume: paperData.volume ?? "",
+          issue: paperData.issue ?? "",
+          pages: paperData.pages ?? "",
+          impact_factor: paperData.impact_factor ?? null,
+          issn_isbn: paperData.issn_isbn ?? "",
+          ccf_category: paperData.ccf_category ?? "",
+          cas_partition: paperData.cas_partition ?? "",
+          jcr_partition: paperData.jcr_partition ?? "",
+          sci_partition: paperData.sci_partition ?? "",
+        } as unknown as Prisma.InputJsonValue,
+        createdById: userId,
+      },
+    });
+
+    // 3. 建立论文-作者关联（RELATION_SUBTABLE）
+    if (authors.length > 0) {
+      const relationItems: RelationSubtableValueItem[] = authors.map((author, idx) => ({
+        targetRecordId: authorResults[idx].authorId,
+        displayValue: author.name,
+        attributes: {
+          author_order: author.author_order,
+          is_first_author: author.is_first_author,
+          is_corresponding_author: author.is_corresponding_author,
+        },
+        sortOrder: author.author_order,
+      }));
+
+      // 使用事务执行关联同步
+      await db.$transaction(async (tx) => {
+        await syncRelationSubtableValues({
+          tx,
+          sourceRecordId: paperRecord.id,
+          tableId: paperTableId,
+          relationPayload: { authors: relationItems },
+        });
+      });
+    }
+
+    return {
+      success: true,
+      data: {
+        paperId: paperRecord.id,
+        authors: authorResults,
+      },
+    };
+  } catch (err) {
+    return {
+      success: false,
+      error: `导入论文失败: ${err instanceof Error ? err.message : "未知错误"}`,
+    };
+  }
+}
+```
+
+- [ ] **Step 2: 验证类型检查**
+
+Run: `npx tsc --noEmit 2>&1 | grep paper-import-executor`
+Expected: no output (no errors)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/agent2/paper-import-executor.ts
+git commit -m "feat(agent2): 添加论文导入执行器（作者匹配+关联建立）"
+```
+
+---
+
+### Task 3: 注册工具到 `createTools()` (`src/lib/agent2/tools.ts`)
+
+**Files:**
+- Modify: `src/lib/agent2/tools.ts`
+
+- [ ] **Step 1: 在 tools.ts 顶部添加 import**
+
+在文件顶部 `import * as helpers from "./tool-helpers";` 后添加：
+
+```typescript
+import { fetchPaperByDOI } from "./doi-service";
+import type { PaperInput, AuthorInput } from "./paper-import-executor";
+```
+
+- [ ] **Step 2: 在 `createTools()` 返回对象中添加 3 个新工具**
+
+在 `generateChart` 工具后面、`return` 对象闭合括号前添加：
+
+```typescript
+    // ── Paper import tools ──
+    parsePaperText: tool({
+      description:
+        "将用户输入的论文文本解析为结构化的论文元数据。当用户粘贴论文信息（标题、作者、年份等）时使用此工具。返回解析后的字段供用户确认。",
+      inputSchema: z.object({
+        rawText: z.string().describe("用户粘贴的论文信息原始文本"),
+      }),
+      execute: async (args) => {
+        // AI 本身已在上下文中理解文本，此工具返回结构化模板供 AI 填充
+        return {
+          message: "请根据以下原始文本提取结构化论文信息，确保字段准确。提取后展示给用户确认。",
+          rawText: args.rawText,
+          fields: [
+            "title_en", "title_cn", "paper_type", "group_name",
+            "publish_year", "publish_date", "venue_name", "venue_name_cn",
+            "doi", "index_type", "volume", "issue", "pages",
+            "ccf_category", "cas_partition", "corr_authors",
+          ],
+          authorFields: ["name", "author_order", "is_first_author", "is_corresponding_author"],
+        };
+      },
+    }),
+
+    fetchPaperByDOI: tool({
+      description:
+        "通过 DOI 从 Crossref 学术数据库获取论文元数据。当用户提供 DOI 编号时使用此工具自动获取论文信息。",
+      inputSchema: z.object({
+        doi: z.string().describe("论文 DOI 编号，如 10.1038/nature14539"),
+      }),
+      execute: async (args) => {
+        const result = await fetchPaperByDOI(args.doi);
+        if (!result.success) {
+          return { error: result.error };
+        }
+        return {
+          paper: result.data,
+          message: "请将以上信息展示给用户确认，并根据需要补充 group_name、index_type 等本地字段。",
+        };
+      },
+    }),
+
+    importPaper: wrapConfirm(
+      "importPaper",
+      "write",
+      z.object({
+        paperData: z.object({
+          title_en: z.string().describe("英文标题"),
+          title_cn: z.string().optional().describe("中文标题"),
+          paper_type: z.enum(["journal", "conference"]).optional().describe("论文类型"),
+          group_name: z.string().optional().describe("组别"),
+          publish_year: z.number().optional().describe("发表年份"),
+          publish_date: z.string().optional().describe("发表日期"),
+          conf_start_date: z.string().optional().describe("会议开始日期"),
+          conf_end_date: z.string().optional().describe("会议结束日期"),
+          venue_name: z.string().optional().describe("期刊/会议名"),
+          venue_name_cn: z.string().optional().describe("期刊/会议中文名"),
+          conf_location: z.string().optional().describe("会议地点"),
+          doi: z.string().optional().describe("DOI"),
+          index_type: z.string().optional().describe("收录类型"),
+          pub_status: z.string().optional().describe("刊出状态"),
+          archive_status: z.string().optional().describe("归档状态"),
+          corr_authors: z.string().optional().describe("通讯作者"),
+          inst_rank: z.number().optional().describe("机构排名"),
+          fund_no: z.string().optional().describe("基金编号"),
+          paper_url: z.string().optional().describe("论文链接"),
+          volume: z.string().optional().describe("卷"),
+          issue: z.string().optional().describe("期"),
+          pages: z.string().optional().describe("页码"),
+          impact_factor: z.number().optional().describe("影响因子"),
+          issn_isbn: z.string().optional().describe("ISSN/ISBN"),
+          ccf_category: z.string().optional().describe("CCF分类"),
+          cas_partition: z.string().optional().describe("中科院分区"),
+          jcr_partition: z.string().optional().describe("JCR分区"),
+          sci_partition: z.string().optional().describe("SCI分区"),
+        }).describe("论文元数据"),
+        authors: z.array(
+          z.object({
+            name: z.string().describe("作者姓名"),
+            author_order: z.number().describe("作者顺序"),
+            is_first_author: z.enum(["Y", "N"]).describe("是否第一作者"),
+            is_corresponding_author: z.enum(["Y", "N"]).describe("是否通讯作者"),
+          })
+        ).describe("作者列表"),
+      }),
+      "导入论文到论文表（需要确认）",
+      async (args) => {
+        return { message: "论文导入待确认", args };
+      }
+    ),
+```
+
+- [ ] **Step 3: 验证类型检查**
+
+Run: `npx tsc --noEmit 2>&1 | grep "tools\.ts"`
+Expected: no output (no errors)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/agent2/tools.ts
+git commit -m "feat(agent2): 注册论文导入工具（parsePaperText, fetchPaperByDOI, importPaper）"
+```
+
+---
+
+### Task 4: 添加 `importPaper` 到 tool-executor 和 confirm-store
+
+**Files:**
+- Modify: `src/lib/agent2/tool-executor.ts`
+- Modify: `src/lib/agent2/confirm-store.ts`
+
+- [ ] **Step 1: 在 confirm-store.ts 的 CONFIRM_REQUIRED_TOOLS 中添加 `"importPaper"`**
+
+在 `CONFIRM_REQUIRED_TOOLS` 集合中添加 `"importPaper"`：
+
+```typescript
+const CONFIRM_REQUIRED_TOOLS = new Set([
+  "createRecord",
+  "updateRecord",
+  "deleteRecord",
+  "generateDocument",
+  "executeCode",
+  "batchCreateRecords",
+  "batchUpdateRecords",
+  "batchDeleteRecords",
+  "importPaper",
+]);
+```
+
+在 `RISK_MESSAGES` 中添加：
+
+```typescript
+  importPaper: "此操作将导入论文并创建/匹配作者记录",
+```
+
+- [ ] **Step 2: 在 tool-executor.ts 中添加 importPaper 的 case**
+
+在文件顶部添加 import：
+
+```typescript
+import { importPaper } from "./paper-import-executor";
+```
+
+在 `batchDeleteRecords` case 之后、`default` 之前添加：
+
+```typescript
+    case "importPaper": {
+      const paperData = toolInput.paperData as Parameters<typeof importPaper>[0];
+      const authors = toolInput.authors as Parameters<typeof importPaper>[1];
+      const result = await importPaper(paperData, authors, userId);
+      if (!result.success) {
+        return { success: false, error: result.error };
+      }
+      invalidateSyspromptCache();
+      return { success: true, data: result.data };
+    }
+```
+
+- [ ] **Step 3: 验证类型检查**
+
+Run: `npx tsc --noEmit 2>&1 | grep -E "(tool-executor|confirm-store)"`
+Expected: no output (no errors)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/agent2/tool-executor.ts src/lib/agent2/confirm-store.ts
+git commit -m "feat(agent2): 添加 importPaper 到确认机制和执行器"
+```
+
+---
+
+### Task 5: 更新系统提示 (`src/lib/agent2/context-builder.ts`)
+
+**Files:**
+- Modify: `src/lib/agent2/context-builder.ts`
+
+- [ ] **Step 1: 在系统提示中添加论文导入能力说明**
+
+在 `## 能力范围` 列表中添加：
+
+```
+	- 通过 DOI 查询并导入论文（fetchPaperByDOI）
+	- 解析用户输入的论文文本并导入（parsePaperText）
+	- 导入论文到论文表，自动匹配/创建作者（importPaper）
+```
+
+在 `## 工作原则` 中添加第 6 条：
+
+```
+	6. 论文导入流程 — 用户提到"导入论文"时：先用 parsePaperText 解析文本或 fetchPaperByDOI 获取 DOI 信息，展示结果让用户确认，再调用 importPaper 导入。逐条确认。
+```
+
+- [ ] **Step 2: 验证构建**
+
+Run: `npx tsc --noEmit 2>&1 | grep context-builder`
+Expected: no output (no errors)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/agent2/context-builder.ts
+git commit -m "feat(agent2): 系统提示增加论文导入能力说明"
+```
+
+---
+
+### Task 6: 集成测试（手动）
+
+- [ ] **Step 1: 启动开发服务器**
+
+Run: `npm run dev`
+
+- [ ] **Step 2: 在 Agent2 聊天中测试 DOI 导入**
+
+输入: "帮我导入 DOI 10.1038/nature14539"
+
+验证：
+- AI 调用 `fetchPaperByDOI` 返回论文元数据
+- AI 展示解析结果（标题 "Deep learning"、3 位作者等）
+- AI 展示作者匹配预览
+- 用户点击确认后调用 `importPaper`
+- 返回导入成功结果（论文 ID + 作者匹配状态）
+
+- [ ] **Step 3: 在 Agent2 聊天中测试文本导入**
+
+输入: "帮我导入这篇论文：Attention Is All You Need, 作者 Ashish Vaswani, Noam Shazeer, 2017, NeurIPS"
+
+验证：
+- AI 解析文本后展示结构化结果
+- 用户确认后导入成功
+
+- [ ] **Step 4: Commit (如有修复)**
+
+```bash
+git add -A
+git commit -m "fix(agent2): 论文导入集成测试修复"
+```
+
+---
+
+## Self-Review
+
+1. **Spec coverage:**
+   - parsePaperText 工具 → Task 3 ✓
+   - fetchPaperByDOI 工具 → Task 1 + Task 3 ✓
+   - importPaper 工具 → Task 2 + Task 3 ✓
+   - 作者匹配逻辑 → Task 2 ✓
+   - 确认机制 → Task 4 ✓
+   - 系统提示更新 → Task 5 ✓
+   - 集成测试 → Task 6 ✓
+
+2. **Placeholder scan:** 无 TBD/TODO/模糊描述。所有代码块包含完整实现。
+
+3. **Type consistency:**
+   - `PaperInput` 和 `AuthorInput` 类型在 Task 2 定义，Task 3 引用一致
+   - `importPaper()` 函数签名在 Task 2 定义，Task 4 tool-executor 调用参数匹配
+   - `wrapConfirm` 的使用模式与现有工具一致
+   - `syncRelationSubtableValues` 参数与 `data-relation.service.ts` 一致

--- a/docs/superpowers/plans/2026-04-12-confirm-detail-preview.md
+++ b/docs/superpowers/plans/2026-04-12-confirm-detail-preview.md
@@ -1,0 +1,802 @@
+# 确认工具详情预取 实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让确认框展示操作对象的详情（如论文标题、作者），同时通过 system prompt 指导 AI 正确处理确认流程，避免反复重试。
+
+**Architecture:** 后端 `wrapConfirm` 在创建确认 token 后预取操作对象详情，通过 `detailPreview` 字段传给前端；前端确认框根据 `detailPreview` 渲染结构化详情卡片，无详情时回退到 JSON 展示；system prompt 增加确认流程和删除操作指导。
+
+**Tech Stack:** TypeScript, React, AI SDK (tool), Zod, Vitest, Testing Library
+
+---
+
+## File Structure
+
+| 操作 | 文件 | 职责 |
+|------|------|------|
+| Modify | `src/lib/agent2/tools.ts` | 添加 `DetailPreview` 接口、`fetchDetailPreview` 函数、更新 `wrapConfirm` 返回值 |
+| Modify | `src/lib/agent2/context-builder.ts` | system prompt 增加确认流程指导 |
+| Modify | `src/components/agent2/message-parts.tsx` | 扩展 `ConfirmToolOutput`/`ConfirmState`、确认工具加 `defaultOpen` |
+| Modify | `src/components/agent2/tool-confirm-dialog.tsx` | 接收并渲染 `detailPreview` 详情卡片 |
+| Create | `src/lib/agent2/detail-preview.test.ts` | `fetchDetailPreview` 的单元测试 |
+
+---
+
+### Task 1: 添加 `fetchDetailPreview` 函数及测试
+
+**Files:**
+- Create: `src/lib/agent2/detail-preview.ts`
+- Create: `src/lib/agent2/detail-preview.test.ts`
+- Reference: `src/lib/agent2/tool-helpers.ts` (getRecord, getTemplateDetail)
+
+- [ ] **Step 1: 创建测试文件 `src/lib/agent2/detail-preview.test.ts`**
+
+```typescript
+import { describe, expect, it, vi } from "vitest"
+import { fetchDetailPreview, formatFieldValue, extractRecordTitle } from "./detail-preview"
+
+// Mock tool-helpers
+vi.mock("./tool-helpers", () => ({
+  getRecord: vi.fn(),
+  getTemplateDetail: vi.fn(),
+}))
+
+import { getRecord, getTemplateDetail } from "./tool-helpers"
+
+const mockGetRecord = vi.mocked(getRecord)
+const mockGetTemplateDetail = vi.mocked(getTemplateDetail)
+
+describe("formatFieldValue", () => {
+  it("字符串直接返回", () => {
+    expect(formatFieldValue("hello")).toBe("hello")
+  })
+
+  it("数字转字符串", () => {
+    expect(formatFieldValue(42)).toBe("42")
+  })
+
+  it("null/undefined 返回 -", () => {
+    expect(formatFieldValue(null)).toBe("-")
+    expect(formatFieldValue(undefined)).toBe("-")
+  })
+
+  it("数组用逗号连接", () => {
+    expect(formatFieldValue(["a", "b", "c"])).toBe("a, b, c")
+  })
+
+  it("对象 JSON 序列化", () => {
+    expect(formatFieldValue({ key: "val" })).toBe('{"key":"val"}')
+  })
+})
+
+describe("extractRecordTitle", () => {
+  it("优先使用 title_en", () => {
+    expect(extractRecordTitle({ title_en: "Hello", title_cn: "你好", id: "1", tableId: "t1" }))
+      .toBe("Hello")
+  })
+
+  it("其次使用 title_cn", () => {
+    expect(extractRecordTitle({ title_cn: "你好", id: "1", tableId: "t1" }))
+      .toBe("你好")
+  })
+
+  it("使用第一个非空字符串字段", () => {
+    expect(extractRecordTitle({ name: "Alice", age: 30, id: "1", tableId: "t1" }))
+      .toBe("Alice")
+  })
+
+  it("无可用字段时返回 记录 ID", () => {
+    expect(extractRecordTitle({ id: "rec-123", tableId: "t1", age: 30 }))
+      .toBe("记录 rec-123")
+  })
+})
+
+describe("fetchDetailPreview", () => {
+  it("deleteRecord 返回记录详情", async () => {
+    mockGetRecord.mockResolvedValueOnce({
+      success: true,
+      data: { id: "r1", tableId: "t1", title_en: "Attention Is All You Need", year: 2017 },
+    })
+
+    const result = await fetchDetailPreview("deleteRecord", { recordId: "r1" })
+
+    expect(result).toEqual({
+      title: "Attention Is All You Need",
+      type: "record",
+      fields: expect.arrayContaining([
+        { label: "title_en", value: "Attention Is All You Need" },
+        { label: "year", value: "2017" },
+      ]),
+    })
+  })
+
+  it("deleteRecord 记录不存在时返回 null", async () => {
+    mockGetRecord.mockResolvedValueOnce({
+      success: false,
+      error: { code: "NOT_FOUND", message: "记录不存在" },
+    })
+
+    const result = await fetchDetailPreview("deleteRecord", { recordId: "bad-id" })
+    expect(result).toBeNull()
+  })
+
+  it("importPaper 返回论文详情", async () => {
+    const result = await fetchDetailPreview("importPaper", {
+      paperData: { title_en: "Test Paper", title_cn: "测试论文", publish_year: 2024, venue_name: "ICML", doi: "10.1234/test" },
+      authors: [
+        { name: "Alice", author_order: 1, is_first_author: "Y", is_corresponding_author: "N" },
+        { name: "Bob", author_order: 2, is_first_author: "N", is_corresponding_author: "Y" },
+      ],
+    })
+
+    expect(result).toEqual({
+      title: "论文: Test Paper",
+      type: "paper",
+      fields: [
+        { label: "英文标题", value: "Test Paper" },
+        { label: "中文标题", value: "测试论文" },
+        { label: "年份", value: "2024" },
+        { label: "期刊/会议", value: "ICML" },
+        { label: "DOI", value: "10.1234/test" },
+      ],
+      summary: "共 2 位作者: Alice, Bob",
+    })
+  })
+
+  it("generateDocument 返回模板详情", async () => {
+    mockGetTemplateDetail.mockResolvedValueOnce({
+      success: true,
+      data: {
+        id: "tpl1",
+        name: "论文报告",
+        description: null,
+        status: "PUBLISHED",
+        placeholders: [
+          { id: "p1", key: "title", label: "标题", inputType: "text", required: true, defaultValue: null },
+        ],
+      },
+    })
+
+    const result = await fetchDetailPreview("generateDocument", {
+      templateId: "tpl1",
+      formData: { title: "My Paper" },
+    })
+
+    expect(result).toEqual({
+      title: "模板: 论文报告",
+      type: "template",
+      fields: [{ label: "title", value: "My Paper" }],
+    })
+  })
+
+  it("batchDeleteRecords 返回批量预览（限制 10 条）", async () => {
+    const ids = Array.from({ length: 12 }, (_, i) => `r${i}`)
+    for (let i = 0; i < 10; i++) {
+      mockGetRecord.mockResolvedValueOnce({
+        success: true,
+        data: { id: `r${i}`, tableId: "t1", title_en: `Paper ${i}` },
+      })
+    }
+
+    const result = await fetchDetailPreview("batchDeleteRecords", { recordIds: ids })
+
+    expect(result?.recordCount).toBe(12)
+    expect(result?.items).toHaveLength(10)
+    expect(result?.title).toBe("批量操作 12 条记录")
+  })
+
+  it("未知工具返回 null", async () => {
+    const result = await fetchDetailPreview("unknownTool", {})
+    expect(result).toBeNull()
+  })
+
+  it("异常时返回 null", async () => {
+    mockGetRecord.mockRejectedValueOnce(new Error("DB error"))
+    const result = await fetchDetailPreview("deleteRecord", { recordId: "r1" })
+    expect(result).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `npx vitest run src/lib/agent2/detail-preview.test.ts`
+Expected: FAIL — 模块不存在
+
+- [ ] **Step 3: 创建 `src/lib/agent2/detail-preview.ts`**
+
+```typescript
+// src/lib/agent2/detail-preview.ts
+import * as helpers from "./tool-helpers"
+
+export interface DetailPreview {
+  title: string
+  type: "record" | "paper" | "template" | "code" | "generic"
+  fields?: Array<{ label: string; value: string }>
+  summary?: string
+  recordCount?: number
+  items?: Array<{ id: string; label: string }>
+}
+
+/** 格式化字段值为可读字符串 */
+export function formatFieldValue(value: unknown): string {
+  if (value == null) return "-"
+  if (typeof value === "string") return value
+  if (typeof value === "number" || typeof value === "boolean") return String(value)
+  if (Array.isArray(value)) return value.map((v) => (typeof v === "string" ? v : JSON.stringify(v))).join(", ")
+  return JSON.stringify(value)
+}
+
+/** 从记录数据中提取可读标题 */
+export function extractRecordTitle(data: Record<string, unknown>): string {
+  // 优先使用常见标题字段
+  for (const key of ["title_en", "title_cn", "name", "title"]) {
+    const val = data[key]
+    if (typeof val === "string" && val.trim()) return val.trim()
+  }
+  // 使用第一个非空字符串字段
+  for (const [key, val] of Object.entries(data)) {
+    if (key === "id" || key === "tableId") continue
+    if (typeof val === "string" && val.trim()) return val.trim()
+  }
+  return `记录 ${data.id ?? "未知"}`
+}
+
+/**
+ * 根据工具名和参数预取操作对象详情。
+ * 失败时返回 null，不影响确认流程。
+ */
+export async function fetchDetailPreview(
+  toolName: string,
+  args: unknown
+): Promise<DetailPreview | null> {
+  try {
+    const input = args as Record<string, unknown>
+
+    switch (toolName) {
+      case "deleteRecord":
+      case "updateRecord": {
+        const result = await helpers.getRecord(input.recordId as string)
+        if (!result.success) return null
+        const data = result.data as Record<string, unknown>
+        return {
+          title: extractRecordTitle(data),
+          type: "record",
+          fields: Object.entries(data)
+            .filter(([k]) => k !== "id" && k !== "tableId")
+            .filter(([_, v]) => v != null && v !== "")
+            .map(([key, value]) => ({
+              label: key,
+              value: formatFieldValue(value),
+            })),
+        }
+      }
+
+      case "importPaper": {
+        const paperData = input.paperData as Record<string, unknown>
+        const authors = input.authors as Array<Record<string, unknown>>
+        return {
+          title: `论文: ${(paperData.title_en as string) || (paperData.title_cn as string) || "未知"}`,
+          type: "paper",
+          fields: [
+            { label: "英文标题", value: (paperData.title_en as string) || "-" },
+            { label: "中文标题", value: (paperData.title_cn as string) || "-" },
+            { label: "年份", value: paperData.publish_year ? String(paperData.publish_year) : "-" },
+            { label: "期刊/会议", value: (paperData.venue_name as string) || "-" },
+            { label: "DOI", value: (paperData.doi as string) || "-" },
+          ].filter((f) => f.value !== "-"),
+          summary: `共 ${authors.length} 位作者: ${authors.map((a) => a.name).join(", ")}`,
+        }
+      }
+
+      case "generateDocument": {
+        const result = await helpers.getTemplateDetail(input.templateId as string)
+        if (!result.success) return null
+        const formData = input.formData as Record<string, unknown>
+        return {
+          title: `模板: ${result.data.name}`,
+          type: "template",
+          fields: result.data.placeholders.map((p) => ({
+            label: p.key,
+            value: formatFieldValue(formData?.[p.key]) || "(空)",
+          })),
+        }
+      }
+
+      case "batchDeleteRecords":
+      case "batchUpdateRecords": {
+        const ids = (
+          toolName === "batchDeleteRecords"
+            ? input.recordIds
+            : (input.updates as Array<{ recordId: string }>)?.map((u) => u.recordId)
+        ) as string[]
+        if (!ids || ids.length === 0) return null
+
+        const previews = await Promise.all(
+          ids.slice(0, 10).map(async (id) => {
+            const result = await helpers.getRecord(id)
+            return {
+              id,
+              label: result.success ? extractRecordTitle(result.data as Record<string, unknown>) : id,
+            }
+          })
+        )
+        return {
+          title: `批量操作 ${ids.length} 条记录`,
+          type: "record",
+          recordCount: ids.length,
+          items: previews,
+        }
+      }
+
+      default:
+        return null
+    }
+  } catch {
+    return null
+  }
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `npx vitest run src/lib/agent2/detail-preview.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/lib/agent2/detail-preview.ts src/lib/agent2/detail-preview.test.ts
+git commit -m "feat(agent2): 添加确认工具详情预取函数 fetchDetailPreview"
+```
+
+---
+
+### Task 2: 更新 `wrapConfirm` 调用 `fetchDetailPreview`
+
+**Files:**
+- Modify: `src/lib/agent2/tools.ts:119-149` (wrapConfirm 函数)
+
+- [ ] **Step 1: 在 `tools.ts` 中导入并调用 `fetchDetailPreview`**
+
+在文件顶部添加导入：
+
+```typescript
+import { fetchDetailPreview } from "./detail-preview"
+```
+
+修改 `wrapConfirm` 函数（第 119-149 行），在 `return` 语句中添加 `detailPreview`：
+
+```typescript
+function wrapConfirm<T>(
+  toolName: string,
+  schema: z.ZodType<T>,
+  description: string,
+  executeFn: (args: T) => Promise<unknown>
+) {
+  return tool({
+    description,
+    inputSchema: schema,
+    execute: async (args: T) => {
+      const tokenResult = await createConfirmToken(
+        conversationId,
+        messageId,
+        toolName,
+        args
+      );
+      if (!tokenResult.success) {
+        throw new Error(tokenResult.error.message);
+      }
+
+      return {
+        _needsConfirm: true,
+        token: tokenResult.data,
+        toolName,
+        toolInput: args,
+        riskMessage: getRiskMessage(toolName),
+        detailPreview: await fetchDetailPreview(toolName, args),
+      };
+    },
+  });
+}
+```
+
+- [ ] **Step 2: 类型检查**
+
+Run: `npx tsc --noEmit`
+Expected: 无新增错误
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add src/lib/agent2/tools.ts
+git commit -m "feat(agent2): wrapConfirm 返回 detailPreview 字段"
+```
+
+---
+
+### Task 3: 更新 System Prompt
+
+**Files:**
+- Modify: `src/lib/agent2/context-builder.ts:76-86` (工作原则部分)
+
+- [ ] **Step 1: 在 system prompt 工作原则中添加第 7、8 条**
+
+在 `context-builder.ts` 的 system prompt 模板中，第 82 行 `6. 论文导入流程...` 之后添加：
+
+```
+7. 确认流程 — 调用需要确认的工具（createRecord, updateRecord, deleteRecord, batchDeleteRecords, importPaper 等）时：
+   - 工具会返回 { _needsConfirm: true }，表示操作已暂停等待用户确认
+   - 收到此响应后，你必须停止生成，不要再次调用相同或类似的工具
+   - 简短告知用户操作正在等待确认，用户可以在确认框中查看详情
+   - 等待用户在界面中确认或拒绝后再继续
+8. 删除操作流程 — 当用户要求删除记录时：
+   - 如果用户提供了明确的记录 ID，直接调用 deleteRecord
+   - 如果用户提供了模糊描述（如"删除论文 Attention Is All You Need"），先用 searchRecords 查询确认记录
+   - deleteRecord 调用后系统会自动在确认框中展示记录详情
+   - 不要反复重试调用，等待用户确认即可
+```
+
+- [ ] **Step 2: 验证 system prompt 缓存失效逻辑正常**
+
+`invalidateSyspromptCache` 已在 `tool-executor.ts` 中被调用，无需修改。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add src/lib/agent2/context-builder.ts
+git commit -m "feat(agent2): system prompt 添加确认流程和删除操作指导"
+```
+
+---
+
+### Task 4: 前端接口扩展 + 确认工具自动展开
+
+**Files:**
+- Modify: `src/components/agent2/message-parts.tsx:16-31, 248-286, 320-358`
+
+- [ ] **Step 1: 扩展 `ConfirmToolOutput` 和 `ConfirmState` 接口**
+
+替换 `message-parts.tsx` 第 16-31 行的接口定义：
+
+```typescript
+interface DetailPreview {
+  title: string
+  type: "record" | "paper" | "template" | "code" | "generic"
+  fields?: Array<{ label: string; value: string }>
+  summary?: string
+  recordCount?: number
+  items?: Array<{ id: string; label: string }>
+}
+
+interface ConfirmState {
+  open: boolean
+  toolName: string
+  toolCallId: string
+  toolInput: Record<string, unknown>
+  riskMessage: string
+  token: string
+  detailPreview?: DetailPreview | null
+}
+
+interface ConfirmToolOutput {
+  _needsConfirm: true
+  riskMessage: string
+  toolInput: Record<string, unknown>
+  token: string
+  detailPreview?: DetailPreview | null
+}
+```
+
+- [ ] **Step 2: 在 dynamic-tool 的确认分支中传递 `detailPreview` 并加 `defaultOpen`**
+
+修改第 256-286 行，`<Tool key={index}>` 改为 `<Tool key={index} defaultOpen>`，并在 `setConfirmState` 中传递 `detailPreview`：
+
+```tsx
+<Tool key={index} defaultOpen>
+  <ToolHeader
+    type="dynamic-tool"
+    state="approval-requested"
+    toolName={toolPart.toolName}
+  />
+  <ToolContent>
+    <div className="space-y-3 p-3">
+      <p className="text-sm text-muted-foreground">{confirmOutput.riskMessage}</p>
+      <ToolInput input={confirmOutput.toolInput} />
+      <button
+        className="px-3 py-1.5 text-sm bg-primary text-primary-foreground rounded-md"
+        onClick={() => {
+          setConfirmState({
+            open: true,
+            toolName: toolPart.toolName,
+            toolCallId: toolPart.toolCallId,
+            toolInput: confirmOutput.toolInput,
+            riskMessage: confirmOutput.riskMessage,
+            token: confirmOutput.token,
+            detailPreview: confirmOutput.detailPreview,
+          })
+        }}
+      >
+        查看详情并确认
+      </button>
+    </div>
+  </ToolContent>
+</Tool>
+```
+
+- [ ] **Step 3: 在 tool-${name} 的确认分支中做同样修改**
+
+修改第 329-358 行（static tool part 的确认分支），同样加 `defaultOpen` 和 `detailPreview`：
+
+```tsx
+<Tool key={index} defaultOpen>
+  <ToolHeader
+    type="dynamic-tool"
+    state="approval-requested"
+    toolName={toolName}
+  />
+  <ToolContent>
+    <div className="space-y-3 p-3">
+      <p className="text-sm text-muted-foreground">{confirmOutput.riskMessage}</p>
+      <ToolInput input={confirmOutput.toolInput} />
+      <button
+        className="px-3 py-1.5 text-sm bg-primary text-primary-foreground rounded-md"
+        onClick={() => {
+          setConfirmState({
+            open: true,
+            toolName,
+            toolCallId: toolPart.toolCallId,
+            toolInput: confirmOutput.toolInput,
+            riskMessage: confirmOutput.riskMessage,
+            token: confirmOutput.token,
+            detailPreview: confirmOutput.detailPreview,
+          })
+        }}
+      >
+        查看详情并确认
+      </button>
+    </div>
+  </ToolContent>
+</Tool>
+```
+
+- [ ] **Step 4: 更新 `ToolConfirmDialog` 调用，传递 `detailPreview`**
+
+修改第 423-441 行的 `<ToolConfirmDialog>` 组件调用，添加 `detailPreview` 属性：
+
+```tsx
+<ToolConfirmDialog
+  open={confirmState.open}
+  onOpenChange={(open) => setConfirmState(prev => ({ ...prev, open }))}
+  toolName={confirmState.toolName}
+  toolInput={confirmState.toolInput}
+  riskMessage={confirmState.riskMessage}
+  token={confirmState.token}
+  detailPreview={confirmState.detailPreview}
+  onConfirm={(result) => {
+    setConfirmState(prev => ({ ...prev, open: false }))
+    if (onToolConfirm && confirmState.toolCallId) {
+      onToolConfirm({
+        toolCallId: confirmState.toolCallId,
+        toolName: confirmState.toolName,
+        result,
+      })
+    }
+  }}
+  onReject={() => setConfirmState(prev => ({ ...prev, open: false }))}
+/>
+```
+
+- [ ] **Step 5: 类型检查**
+
+Run: `npx tsc --noEmit`
+Expected: 可能有类型错误（ToolConfirmDialog 还没接收 detailPreview prop），将在 Task 5 修复
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add src/components/agent2/message-parts.tsx
+git commit -m "feat(agent2): 前端接口扩展 + 确认工具自动展开"
+```
+
+---
+
+### Task 5: 确认框渲染详情卡片
+
+**Files:**
+- Modify: `src/components/agent2/tool-confirm-dialog.tsx`
+
+- [ ] **Step 1: 更新 props 接口并渲染详情卡片**
+
+替换整个 `tool-confirm-dialog.tsx`：
+
+```tsx
+"use client"
+
+import { useState } from "react"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { AlertTriangle } from "lucide-react"
+
+interface DetailPreview {
+  title: string
+  type: "record" | "paper" | "template" | "code" | "generic"
+  fields?: Array<{ label: string; value: string }>
+  summary?: string
+  recordCount?: number
+  items?: Array<{ id: string; label: string }>
+}
+
+interface ToolConfirmDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  toolName: string
+  toolInput: Record<string, unknown>
+  riskMessage: string
+  token: string
+  detailPreview?: DetailPreview | null
+  onConfirm: (result: unknown) => void
+  onReject: () => void
+}
+
+function DetailPreviewCard({ preview }: { preview: DetailPreview }) {
+  return (
+    <div className="rounded-md border bg-muted/50 p-3 space-y-2">
+      <p className="text-sm font-medium">{preview.title}</p>
+      {preview.fields && preview.fields.length > 0 && (
+        <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-sm">
+          {preview.fields.map((field, i) => (
+            <span key={i} className="contents">
+              <span className="text-muted-foreground whitespace-nowrap">{field.label}:</span>
+              <span className="break-all">{field.value}</span>
+            </span>
+          ))}
+        </div>
+      )}
+      {preview.summary && (
+        <p className="text-xs text-muted-foreground">{preview.summary}</p>
+      )}
+      {preview.items && preview.items.length > 0 && (
+        <ul className="text-xs text-muted-foreground space-y-0.5">
+          {preview.items.map((item) => (
+            <li key={item.id} className="truncate">
+              {item.label}
+            </li>
+          ))}
+          {(preview.recordCount ?? 0) > preview.items.length && (
+            <li className="italic">
+              ...共 {preview.recordCount} 条
+            </li>
+          )}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+export function ToolConfirmDialog({
+  open, onOpenChange, toolName, toolInput, riskMessage, token,
+  detailPreview, onConfirm, onReject,
+}: ToolConfirmDialogProps) {
+  const [loading, setLoading] = useState(false)
+
+  const handleConfirm = async () => {
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/agent2/confirm/${token}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ approved: true }),
+      })
+      const data = await res.json()
+      if (data.success) onConfirm(data.data)
+      else onReject()
+    } catch {
+      onReject()
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleReject = async () => {
+    await fetch(`/api/agent2/confirm/${token}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ approved: false }),
+    })
+    onReject()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="size-5 text-yellow-500" />
+            确认执行操作
+          </DialogTitle>
+          <DialogDescription>{riskMessage}</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div>
+            <p className="text-sm font-medium mb-1">工具</p>
+            <code className="text-sm bg-muted px-2 py-1 rounded">
+              {toolName.startsWith("mcp__") ? (
+                <>{toolName} <span className="text-xs text-muted-foreground">[外部工具]</span></>
+              ) : (
+                toolName
+              )}
+            </code>
+          </div>
+          {detailPreview ? (
+            <div>
+              <p className="text-sm font-medium mb-1">操作对象</p>
+              <DetailPreviewCard preview={detailPreview} />
+            </div>
+          ) : (
+            <div>
+              <p className="text-sm font-medium mb-1">参数</p>
+              <pre className="text-xs bg-muted p-3 rounded-md overflow-auto max-h-40">
+                {JSON.stringify(toolInput, null, 2)}
+              </pre>
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={handleReject} disabled={loading}>拒绝</Button>
+          <Button onClick={handleConfirm} disabled={loading}>
+            {loading ? "执行中..." : "确认执行"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+```
+
+- [ ] **Step 2: 类型检查**
+
+Run: `npx tsc --noEmit`
+Expected: 无新增错误
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add src/components/agent2/tool-confirm-dialog.tsx
+git commit -m "feat(agent2): 确认框展示操作对象详情卡片"
+```
+
+---
+
+### Task 6: 集成测试与验证
+
+**Files:** 无新文件
+
+- [ ] **Step 1: 运行全量测试确保无回归**
+
+Run: `npx vitest run src/lib/agent2/ src/components/agent2/`
+Expected: ALL PASS
+
+- [ ] **Step 2: 运行类型检查**
+
+Run: `npx tsc --noEmit`
+Expected: 无错误
+
+- [ ] **Step 3: 启动开发服务器手动验证**
+
+Run: `npm run dev`
+
+验证步骤：
+1. 打开 agent2 对话页面
+2. 输入"删除论文 Attention Is All You Need"
+3. 确认 AI 不再反复重试调用 deleteRecord
+4. 确认工具调用自动展开（不需要手动点开）
+5. 点击"查看详情并确认"，确认对话框中显示论文详情（标题、作者等）
+6. 点击"确认执行"或"拒绝"，确认操作正常完成
+
+- [ ] **Step 4: 最终提交（如有修复）**
+
+```bash
+git add -u
+git commit -m "fix(agent2): 集成测试修复"
+```

--- a/docs/superpowers/specs/2026-04-11-paper-import-agent2-design.md
+++ b/docs/superpowers/specs/2026-04-11-paper-import-agent2-design.md
@@ -1,0 +1,96 @@
+# 论文导入功能 — AI Agent2 集成设计
+
+## 背景
+
+Issue #20: 通过 AI Agent2 以自然语言对话形式将论文信息导入"论文表"和"作者表"，确认后写入数据。
+
+已有基础设施：
+- AI Agent2 聊天系统（流式响应、工具调用、确认机制）
+- 论文表 + 作者表（RELATION_SUBTABLE 关联），结构定义在 `scripts/seed-papers.ts`
+- 作者匹配基于 `name_norm` 标准化姓名
+
+## 方案
+
+为 Agent2 注册 3 个专用工具，复用现有聊天 + 确认 + 流式响应机制。
+
+### 工具定义
+
+#### 1. `parsePaperText`（只读，无需确认）
+
+- **参数：** `{ text: string }`
+- **功能：** AI 已在对话上下文中理解文本，此工具将解析结果规范化为论文字段结构，便于后续展示确认
+- **返回：** 结构化论文元数据（title_en, title_cn, authors[], publish_year, venue_name, doi, paper_type 等）
+
+#### 2. `fetchPaperByDOI`（只读，无需确认）
+
+- **参数：** `{ doi: string }`
+- **功能：** 调用 Crossref API 获取论文元数据
+- **API：** `https://api.crossref.org/works/{doi}`（免费、无需 API key）
+- **备选：** Semantic Scholar API `https://api.semanticscholar.org/graph/v1/paper/DOI:{doi}`
+- **返回：** 结构化论文元数据 + 作者列表
+
+#### 3. `importPaper`（需要 write 级别确认）
+
+- **参数：** `{ paperData: PaperData, authors: AuthorInput[] }`
+- **功能：**
+  1. 按 `name_norm` 匹配已有作者，未找到则新建
+  2. 创建论文记录
+  3. 建立 RELATION_SUBTABLE 关联（含 author_order, is_first_author, is_corresponding_author）
+  4. 刷新关联快照
+- **返回：** 论文 ID + 各作者匹配/新建状态
+
+### 数据流
+
+#### 场景 1：文本粘贴导入
+
+```
+用户粘贴文本 → AI 调用 parsePaperText → 展示结构化结果
+→ 用户逐条确认 → AI 调用 importPaper → 返回导入结果
+```
+
+#### 场景 2：DOI 查询导入
+
+```
+用户输入 DOI → AI 调用 fetchPaperByDOI → 展示元数据 + 作者匹配预览
+→ 用户确认 → AI 调用 importPaper → 返回导入结果
+```
+
+#### 场景 3：多论文批量
+
+```
+用户粘贴多篇 → AI 逐篇 parse → 逐条展示确认 → 逐条 import → 汇总结果
+```
+
+### 作者匹配策略
+
+1. 按 `name_norm` 模糊匹配已有作者
+2. 匹配到 → 展示匹配结果
+3. 未匹配 → 标记为"新建"，在确认阶段提示用户
+4. 多个同名人冲突 → 展示候选列表让用户选择
+
+### 文件结构
+
+| 文件 | 用途 |
+|------|------|
+| `src/lib/agent2/paper-import-tools.ts` | 工具定义（parsePaperText, fetchPaperByDOI, importPaper） |
+| `src/lib/agent2/paper-parser.ts` | 论文文本结构化解析 |
+| `src/lib/agent2/doi-service.ts` | Crossref API 封装 |
+| `src/lib/agent2/paper-import-executor.ts` | 导入执行（作者匹配、记录创建、关联建立） |
+| `src/lib/agent2/tools.ts` | 修改：注册新工具 |
+
+### 错误处理
+
+- DOI 查不到 → 提示检查 DOI 或改用手动输入
+- 必填字段缺失 → AI 追问用户补充
+- 作者匹配冲突 → 展示候选列表
+- API 调用失败 → 降级提示手动输入
+
+### 实现优先级
+
+**Phase 1（本次实现）：**
+- 文本粘贴解析 + 导入
+- DOI 查询导入
+
+**Phase 2（后续迭代）：**
+- 文件上传（PDF/Word）提取
+- 批量 Excel 导入

--- a/docs/superpowers/specs/2026-04-12-confirm-detail-preview-design.md
+++ b/docs/superpowers/specs/2026-04-12-confirm-detail-preview-design.md
@@ -199,6 +199,16 @@ interface ConfirmState {
 
 当 `detailPreview` 为 null 时，回退到当前的原始 JSON 展示。
 
+#### 2.4 确认工具自动展开
+
+需要确认的工具调用组件使用 `defaultOpen` 属性，使其自动展开而不是折叠状态：
+
+```tsx
+<Tool key={index} defaultOpen>
+```
+
+适用于 `message-parts.tsx` 中所有渲染 `_needsConfirm` 工具的 `<Tool>` 组件（dynamic-tool 和 tool-${name} 两种分支）。
+
 ### 3. System Prompt 更新
 
 **修改文件：** `src/lib/agent2/context-builder.ts`

--- a/docs/superpowers/specs/2026-04-12-confirm-detail-preview-design.md
+++ b/docs/superpowers/specs/2026-04-12-confirm-detail-preview-design.md
@@ -1,0 +1,240 @@
+# 确认工具详情预取与 AI 流程指导
+
+## 问题
+
+1. **AI 不知道如何处理 `_needsConfirm`**：AI 调用 deleteRecord 等工具后，收到 `{ _needsConfirm: true }` 响应，但 system prompt 没有指导它停止并等待用户确认，导致它反复重试调用相同工具。
+2. **确认框缺少有意义的详情**：用户在确认对话框中只看到 `{ recordId: "xxx" }` 这样的原始参数，看不到论文标题、作者等人类可读的信息。
+
+## 设计方案
+
+### 1. 后端：`wrapConfirm` 预取操作对象详情
+
+**修改文件：** `src/lib/agent2/tools.ts`
+
+在 `wrapConfirm` 的 `execute` 函数中，创建确认 token 之后，根据 `toolName` 调用对应的查询函数获取操作对象详情，将结果附加到返回的 `_needsConfirm` 响应中作为 `detailPreview` 字段。
+
+#### 各工具的预取逻辑
+
+| 工具 | 预取方式 | 预取内容 |
+|------|----------|----------|
+| `deleteRecord` | `helpers.getRecord(args.recordId)` | 记录的所有字段值 |
+| `updateRecord` | `helpers.getRecord(args.recordId)` | 记录的当前字段值（对比用） |
+| `createRecord` | 无预取 | 展示 `args.data`（即用户要创建的数据） |
+| `batchDeleteRecords` | 逐个 `helpers.getRecord`（限制最多 10 条预览） | 各记录摘要 |
+| `batchUpdateRecords` | 同上 | 各记录当前值 |
+| `batchCreateRecords` | 无预取 | 展示前 5 条记录数据 |
+| `importPaper` | 无预取（数据已在 args 中） | 格式化展示 `args.paperData` 和 `args.authors` |
+| `generateDocument` | `helpers.getTemplateDetail(args.templateId)` | 模板名称和占位符列表 |
+| `executeCode` | 无预取 | 展示代码内容 |
+| MCP 工具 | 无预取 | 展示工具参数 |
+
+`detailPreview` 的数据结构：
+
+```typescript
+interface DetailPreview {
+  title: string           // 概要标题，如 "论文记录: Attention Is All You Need"
+  type: "record" | "paper" | "template" | "code" | "generic"
+  fields?: Array<{        // key-value 展示用
+    label: string
+    value: string
+  }>
+  summary?: string        // 额外描述
+  recordCount?: number    // 批量操作时的记录数
+  items?: Array<{         // 批量操作的简要列表
+    id: string
+    label: string
+  }>
+}
+```
+
+#### 实现方式
+
+在 `wrapConfirm` 中新增异步函数 `fetchDetailPreview(toolName, args)`，返回 `DetailPreview | null`。如果预取失败（如记录不存在），返回 null，确认框仍然正常工作，只是不展示详情。
+
+```typescript
+async function fetchDetailPreview(
+  toolName: string,
+  args: unknown
+): Promise<DetailPreview | null> {
+  try {
+    const input = args as Record<string, unknown>;
+    switch (toolName) {
+      case "deleteRecord":
+      case "updateRecord": {
+        const result = await helpers.getRecord(input.recordId as string);
+        if (!result.success) return null;
+        const data = result.data as Record<string, unknown>;
+        // 从 data.values 中提取字段用于展示
+        return {
+          title: extractRecordTitle(data),
+          type: "record",
+          fields: Object.entries(data.values as Record<string, unknown> || {})
+            .filter(([_, v]) => v != null && v !== "")
+            .map(([key, value]) => ({
+              label: key,
+              value: formatFieldValue(value),
+            })),
+        };
+      }
+      case "importPaper": {
+        const paperData = input.paperData as Record<string, unknown>;
+        const authors = input.authors as Array<Record<string, unknown>>;
+        return {
+          title: `论文: ${paperData.title_en || paperData.title_cn || "未知"}`,
+          type: "paper",
+          fields: [
+            { label: "英文标题", value: paperData.title_en as string },
+            { label: "中文标题", value: (paperData.title_cn as string) || "-" },
+            { label: "年份", value: String(paperData.publish_year || "-") },
+            { label: "期刊/会议", value: (paperData.venue_name as string) || "-" },
+            { label: "DOI", value: (paperData.doi as string) || "-" },
+          ],
+          summary: `共 ${authors.length} 位作者: ${authors.map(a => a.name).join(", ")}`,
+        };
+      }
+      case "generateDocument": {
+        const result = await helpers.getTemplateDetail(input.templateId as string);
+        if (!result.success) return null;
+        return {
+          title: `模板: ${result.data.name}`,
+          type: "template",
+          fields: (result.data.placeholders || []).map((p: { name: string }) => ({
+            label: p.name,
+            value: (input.formData as Record<string, unknown>)?.[p.name] as string || "(空)",
+          })),
+        };
+      }
+      case "batchDeleteRecords":
+      case "batchUpdateRecords": {
+        const ids = (input.recordIds || input.updates?.map((u: { recordId: string }) => u.recordId)) as string[];
+        const previews = await Promise.all(
+          ids.slice(0, 10).map(async (id: string) => {
+            const result = await helpers.getRecord(id);
+            return {
+              id,
+              label: result.success ? extractRecordTitle(result.data) : id,
+            };
+          })
+        );
+        return {
+          title: `批量操作 ${ids.length} 条记录`,
+          type: "record",
+          recordCount: ids.length,
+          items: previews,
+        };
+      }
+      default:
+        return null;
+    }
+  } catch {
+    return null;
+  }
+}
+```
+
+然后在 `wrapConfirm` 的返回值中包含 `detailPreview`：
+
+```typescript
+return {
+  _needsConfirm: true,
+  token: tokenResult.data,
+  toolName,
+  toolInput: args,
+  riskMessage: getRiskMessage(toolName),
+  detailPreview: await fetchDetailPreview(toolName, args),
+};
+```
+
+### 2. 前端：确认框展示详情
+
+**修改文件：**
+- `src/components/agent2/tool-confirm-dialog.tsx`
+- `src/components/agent2/message-parts.tsx`
+
+#### 2.1 ConfirmToolOutput 接口扩展
+
+在 `message-parts.tsx` 中扩展接口：
+
+```typescript
+interface DetailPreview {
+  title: string
+  type: "record" | "paper" | "template" | "code" | "generic"
+  fields?: Array<{ label: string; value: string }>
+  summary?: string
+  recordCount?: number
+  items?: Array<{ id: string; label: string }>
+}
+
+interface ConfirmToolOutput {
+  _needsConfirm: true
+  riskMessage: string
+  toolInput: Record<string, unknown>
+  token: string
+  detailPreview?: DetailPreview | null
+}
+```
+
+#### 2.2 ConfirmState 扩展
+
+```typescript
+interface ConfirmState {
+  open: boolean
+  toolName: string
+  toolCallId: string
+  toolInput: Record<string, unknown>
+  riskMessage: string
+  token: string
+  detailPreview?: DetailPreview | null
+}
+```
+
+#### 2.3 确认框 UI
+
+当 `detailPreview` 存在时，在对话框中展示详情卡片：
+
+- 标题行显示 `detailPreview.title`
+- 字段以 key-value 表格展示（`detailPreview.fields`）
+- 摘要文本显示在字段下方（`detailPreview.summary`）
+- 批量操作时显示数量和简要列表
+
+当 `detailPreview` 为 null 时，回退到当前的原始 JSON 展示。
+
+### 3. System Prompt 更新
+
+**修改文件：** `src/lib/agent2/context-builder.ts`
+
+在 system prompt 的"工作原则"部分添加确认流程指导：
+
+```
+7. 确认流程 — 调用需要确认的工具（createRecord, updateRecord, deleteRecord, batchDeleteRecords, importPaper 等）时：
+   - 工具会返回 { _needsConfirm: true }，表示操作已暂停等待用户确认
+   - 收到此响应后，你必须停止生成，不要再次调用相同或类似的工具
+   - 简短告知用户操作正在等待确认，用户可以在确认框中查看详情
+   - 等待用户在界面中确认或拒绝后再继续
+```
+
+同时更新删除操作的具体指导：
+
+```
+8. 删除操作流程 — 当用户要求删除记录时：
+   - 如果用户提供了明确的记录 ID，直接调用 deleteRecord
+   - 如果用户提供了模糊描述（如"删除论文 Attention Is All You Need"），先用 searchRecords 查询确认记录
+   - deleteRecord 调用后系统会自动在确认框中展示记录详情
+   - 不要反复重试调用，等待用户确认即可
+```
+
+## 不在范围内
+
+- 不修改确认 API 端点（`/api/agent2/confirm/[token]`）
+- 不修改 `stopWhen` 逻辑（当前已正确检测 `_needsConfirm` 并停止）
+- 不修改 MCP 工具的确认包装（MCP 工具参数本身已是详情）
+- 不增加数据库字段（`detailPreview` 随工具返回值传递，不持久化）
+
+## 关键文件
+
+| 文件 | 改动 |
+|------|------|
+| `src/lib/agent2/tools.ts` | `wrapConfirm` 中添加 `fetchDetailPreview`，返回值增加 `detailPreview` |
+| `src/lib/agent2/context-builder.ts` | system prompt 增加确认流程和删除操作指导 |
+| `src/components/agent2/message-parts.tsx` | 扩展 `ConfirmToolOutput` 和 `ConfirmState` 接口 |
+| `src/components/agent2/tool-confirm-dialog.tsx` | 接收 `detailPreview` 并渲染详情卡片 |

--- a/src/app/api/agent2/confirm/[token]/route.ts
+++ b/src/app/api/agent2/confirm/[token]/route.ts
@@ -7,6 +7,7 @@ import {
   rejectToken,
 } from "@/lib/agent2/confirm-store";
 import { executeToolAction } from "@/lib/agent2/tool-executor";
+import { db } from "@/lib/db";
 
 interface RouteContext {
   params: Promise<{ token: string }>;
@@ -56,6 +57,57 @@ export async function POST(
           },
           { status: 500 }
         );
+      }
+
+      // Update the DB-stored assistant message to replace _needsConfirm with
+      // a clear success message so the next AI continuation understands the tool was executed
+      try {
+        // Find the message by conversationId + toolName + _needsConfirm pattern
+        // (messageId from confirm token may not match the DB-generated message ID)
+        const messages = await db.agent2Message.findMany({
+          where: {
+            conversationId: claimResult.data.conversationId,
+            role: "assistant",
+          },
+          orderBy: { createdAt: "desc" },
+          take: 5,
+        });
+
+        for (const message of messages) {
+          const parts = message.parts as Array<Record<string, unknown>>;
+          let found = false;
+          const updatedParts = parts.map((part) => {
+            if (
+              !found &&
+              (part.type === "dynamic-tool" || (typeof part.type === "string" && part.type.startsWith("tool-"))) &&
+              part.toolName === claimResult.data.toolName &&
+              part.output != null &&
+              typeof part.output === "object" &&
+              "_needsConfirm" in (part.output as Record<string, unknown>)
+            ) {
+              found = true;
+              return {
+                ...part,
+                output: {
+                  success: true,
+                  message: `${claimResult.data.toolName} 已由用户确认并执行成功`,
+                  data: execResult.data,
+                },
+              };
+            }
+            return part;
+          });
+
+          if (found) {
+            await db.agent2Message.update({
+              where: { id: message.id },
+              data: { parts: updatedParts as Prisma.InputJsonValue },
+            });
+            break;
+          }
+        }
+      } catch {
+        // Non-critical: if DB update fails, the client still has the result
       }
 
       return NextResponse.json({ success: true, data: execResult.data });

--- a/src/app/api/agent2/confirm/[token]/route.ts
+++ b/src/app/api/agent2/confirm/[token]/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/agent2/confirm-store";
 import { executeToolAction } from "@/lib/agent2/tool-executor";
 import { db } from "@/lib/db";
+import type { Prisma } from "@/generated/prisma/client";
 
 interface RouteContext {
   params: Promise<{ token: string }>;
@@ -28,7 +29,7 @@ export async function POST(
   try {
     const { token } = await params;
     const body = await request.json();
-    const { approved } = toolConfirmSchema.parse(body);
+    const { approved, toolCallId } = toolConfirmSchema.parse(body);
 
     if (approved) {
       const claimResult = await validateAndClaimToken(token, session.user.id);
@@ -61,53 +62,54 @@ export async function POST(
 
       // Update the DB-stored assistant message to replace _needsConfirm with
       // a clear success message so the next AI continuation understands the tool was executed
-      try {
-        // Find the message by conversationId + toolName + _needsConfirm pattern
-        // (messageId from confirm token may not match the DB-generated message ID)
-        const messages = await db.agent2Message.findMany({
-          where: {
-            conversationId: claimResult.data.conversationId,
-            role: "assistant",
-          },
-          orderBy: { createdAt: "desc" },
-          take: 5,
-        });
-
-        for (const message of messages) {
-          const parts = message.parts as Array<Record<string, unknown>>;
-          let found = false;
-          const updatedParts = parts.map((part) => {
-            if (
-              !found &&
-              (part.type === "dynamic-tool" || (typeof part.type === "string" && part.type.startsWith("tool-"))) &&
-              part.toolName === claimResult.data.toolName &&
-              part.output != null &&
-              typeof part.output === "object" &&
-              "_needsConfirm" in (part.output as Record<string, unknown>)
-            ) {
-              found = true;
-              return {
-                ...part,
-                output: {
-                  success: true,
-                  message: `${claimResult.data.toolName} 已由用户确认并执行成功`,
-                  data: execResult.data,
-                },
-              };
-            }
-            return part;
+      if (toolCallId) {
+        try {
+          // Search by conversationId + precise toolCallId for exact match
+          const messages = await db.agent2Message.findMany({
+            where: {
+              conversationId: claimResult.data.conversationId,
+              role: "assistant",
+            },
+            orderBy: { createdAt: "desc" },
+            take: 10,
           });
 
-          if (found) {
-            await db.agent2Message.update({
-              where: { id: message.id },
-              data: { parts: updatedParts as Prisma.InputJsonValue },
+          for (const message of messages) {
+            const parts = message.parts as Array<Record<string, unknown>>;
+            let found = false;
+            const updatedParts = parts.map((part) => {
+              if (
+                !found &&
+                (part.type === "dynamic-tool" || (typeof part.type === "string" && part.type.startsWith("tool-"))) &&
+                part.toolCallId === toolCallId &&
+                part.output != null &&
+                typeof part.output === "object" &&
+                "_needsConfirm" in (part.output as Record<string, unknown>)
+              ) {
+                found = true;
+                return {
+                  ...part,
+                  output: {
+                    success: true,
+                    message: `${claimResult.data.toolName} 已由用户确认并执行成功`,
+                    data: execResult.data,
+                  },
+                };
+              }
+              return part;
             });
-            break;
+
+            if (found) {
+              await db.agent2Message.update({
+                where: { id: message.id },
+                data: { parts: updatedParts as Prisma.InputJsonValue },
+              });
+              break;
+            }
           }
+        } catch {
+          // Non-critical: if DB update fails, the client still has the result
         }
-      } catch {
-        // Non-critical: if DB update fails, the client still has the result
       }
 
       return NextResponse.json({ success: true, data: execResult.data });

--- a/src/app/api/agent2/conversations/[id]/chat/route.ts
+++ b/src/app/api/agent2/conversations/[id]/chat/route.ts
@@ -5,7 +5,6 @@ import { randomUUID } from "crypto";
 import { ZodError } from "zod";
 import { chatRequestSchema } from "@/validators/agent2";
 import { getConversation } from "@/lib/services/agent2-conversation.service";
-import { getSettings } from "@/lib/services/agent2-settings.service";
 import { saveMessages, getMessages } from "@/lib/services/agent2-message.service";
 import { resolveModel, isReasoningModel } from "@/lib/agent2/model-resolver";
 import { buildSystemPrompt, truncateMessages } from "@/lib/agent2/context-builder";
@@ -50,12 +49,6 @@ export async function POST(
       );
     }
 
-    // Get user settings for auto-confirm
-    const settingsResult = await getSettings(session.user.id);
-    const autoConfirm = settingsResult.success
-      ? (settingsResult.data.autoConfirmTools as Record<string, boolean>)
-      : {};
-
     // 检测是否是 reasoning 模型
     const config = await db.agent2ModelConfig.findFirst({
       where: {
@@ -77,10 +70,10 @@ export async function POST(
     const model = await resolveModel(validated.model, session.user.id);
     const systemPrompt = await buildSystemPrompt();
     const messageId = randomUUID();
-    const tools = createTools(conversationId, messageId, autoConfirm, session.user.id);
+    const tools = createTools(conversationId, messageId, session.user.id);
 
     // Get MCP tools from enabled servers
-    const mcpResult = await getEnabledMcpTools(conversationId, messageId, autoConfirm);
+    const mcpResult = await getEnabledMcpTools(conversationId, messageId);
     mcpClients = mcpResult.clients;
     const allTools = { ...tools, ...mcpResult.tools };
 

--- a/src/app/api/agent2/conversations/[id]/chat/route.ts
+++ b/src/app/api/agent2/conversations/[id]/chat/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
-import { streamText, convertToModelMessages, stepCountIs, type UIMessage } from "ai";
+import { streamText, convertToModelMessages, type UIMessage } from "ai";
 import { randomUUID } from "crypto";
 import { ZodError } from "zod";
 import { chatRequestSchema } from "@/validators/agent2";
@@ -104,12 +104,21 @@ export async function POST(
     const messages = truncateMessages(convertedMessages as { role: string; content: string }[]) as typeof convertedMessages;
 
     // Stream with AI SDK
+    // Custom stopWhen: stop on _needsConfirm (tool needs user confirmation) or max 10 steps
     const result = streamText({
       model,
       system: systemPrompt,
       messages,
       tools: allTools,
-      stopWhen: stepCountIs(10),
+      stopWhen: ({ steps }) => {
+        if (steps.length >= 10) return true;
+        const lastStep = steps[steps.length - 1];
+        if (!lastStep) return false;
+        // Stop if any tool returned _needsConfirm to wait for user approval
+        return lastStep.dynamicToolResults.some(
+          (r) => typeof r.output === "object" && r.output !== null && "_needsConfirm" in (r.output as Record<string, unknown>)
+        );
+      },
     });
 
     return result.toUIMessageStreamResponse({

--- a/src/app/api/agent2/conversations/[id]/chat/route.ts
+++ b/src/app/api/agent2/conversations/[id]/chat/route.ts
@@ -5,7 +5,7 @@ import { randomUUID } from "crypto";
 import { ZodError } from "zod";
 import { chatRequestSchema } from "@/validators/agent2";
 import { getConversation } from "@/lib/services/agent2-conversation.service";
-import { saveMessages, getMessages } from "@/lib/services/agent2-message.service";
+import { saveMessages } from "@/lib/services/agent2-message.service";
 import { resolveModel, isReasoningModel } from "@/lib/agent2/model-resolver";
 import { buildSystemPrompt, truncateMessages } from "@/lib/agent2/context-builder";
 import { createTools } from "@/lib/agent2/tools";
@@ -77,24 +77,14 @@ export async function POST(
     mcpClients = mcpResult.clients;
     const allTools = { ...tools, ...mcpResult.tools };
 
-    // Load conversation history from DB
-    const historyResult = await getMessages(conversationId);
-    const historyMessages: UIMessage[] = historyResult.success
-      ? historyResult.data.map((m) => ({
-          id: m.id,
-          role: m.role as "user" | "assistant",
-          parts: m.parts as UIMessage["parts"],
-          createdAt: new Date(m.createdAt),
-        }))
-      : [];
-
-    // Extract the latest user message from the frontend payload
+    // Use client messages directly — the client sends the full message list
+    // which includes all history (loaded from DB on page init) plus the latest
+    // updates such as addToolOutput results from tool confirmations.
+    // This avoids a race condition where the DB hasn't been updated yet
+    // (onFinish may still be saving the original messages when a confirm
+    // route tries to update them).
     const uiMessages = validated.messages as unknown as UIMessage[];
-    const lastUserMessage = uiMessages[uiMessages.length - 1];
-    const allMessages = sanitizeStoredMessages([
-      ...historyMessages,
-      lastUserMessage as unknown as UIMessage,
-    ]);
+    const allMessages = sanitizeStoredMessages(uiMessages);
 
     // Convert UIMessages to ModelMessages and truncate to prevent context overflow
     const convertedMessages = await convertToModelMessages(allMessages, {

--- a/src/app/api/agent2/conversations/[id]/chat/route.ts
+++ b/src/app/api/agent2/conversations/[id]/chat/route.ts
@@ -77,7 +77,7 @@ export async function POST(
     const model = await resolveModel(validated.model, session.user.id);
     const systemPrompt = await buildSystemPrompt();
     const messageId = randomUUID();
-    const tools = createTools(conversationId, messageId, autoConfirm);
+    const tools = createTools(conversationId, messageId, autoConfirm, session.user.id);
 
     // Get MCP tools from enabled servers
     const mcpResult = await getEnabledMcpTools(conversationId, messageId, autoConfirm);

--- a/src/components/agent2/agent2-layout.tsx
+++ b/src/components/agent2/agent2-layout.tsx
@@ -41,8 +41,8 @@ export function Agent2Layout() {
     setSidebarCollapsed(c => !c)
   }, [])
 
-  const handleMobileSelect = useCallback((id: string) => {
-    setSelectedConversationId(id)
+  const handleMobileSelect = useCallback((id: string | null) => {
+    if (id) setSelectedConversationId(id)
     setMobileMenuOpen(false)
   }, [])
 

--- a/src/components/agent2/chat-area.tsx
+++ b/src/components/agent2/chat-area.tsx
@@ -2,7 +2,7 @@
 
 import { useChat } from "@ai-sdk/react"
 import { useCallback, useEffect, useState } from "react"
-import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls, type FileUIPart, type UIMessage } from "ai"
+import { DefaultChatTransport, type FileUIPart, type UIMessage } from "ai"
 
 // AI Elements
 import { Conversation, ConversationContent, ConversationEmptyState, ConversationScrollButton } from "@/components/ai-elements/conversation"
@@ -117,7 +117,6 @@ export function ChatArea({ conversationId, onToggleSidebar, sidebarCollapsed, on
       api: `/api/agent2/conversations/${conversationId}/chat`,
       body: { model },
     }),
-    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
   })
 
   // Sync defaultModel prop changes to local state
@@ -313,6 +312,8 @@ export function ChatArea({ conversationId, onToggleSidebar, sidebarCollapsed, on
                         toolCallId,
                         output: result,
                       })
+                      // Trigger AI continuation after user confirms tool execution
+                      void sendMessage({ text: "确认执行" })
                     }}
                   />
                 </MessageContent>

--- a/src/components/agent2/chat-area.tsx
+++ b/src/components/agent2/chat-area.tsx
@@ -2,7 +2,7 @@
 
 import { useChat } from "@ai-sdk/react"
 import { useCallback, useEffect, useState } from "react"
-import { DefaultChatTransport, type FileUIPart, type UIMessage } from "ai"
+import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls, type FileUIPart, type UIMessage } from "ai"
 
 // AI Elements
 import { Conversation, ConversationContent, ConversationEmptyState, ConversationScrollButton } from "@/components/ai-elements/conversation"
@@ -117,6 +117,7 @@ export function ChatArea({ conversationId, onToggleSidebar, sidebarCollapsed, on
       api: `/api/agent2/conversations/${conversationId}/chat`,
       body: { model },
     }),
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
   })
 
   // Sync defaultModel prop changes to local state

--- a/src/components/agent2/message-parts.tsx
+++ b/src/components/agent2/message-parts.tsx
@@ -265,7 +265,7 @@ export function MessageParts({ message, onToolConfirm }: MessagePartsProps) {
             if (toolOutput && typeof toolOutput === "object" && toolOutput !== null && "_needsConfirm" in toolOutput) {
               const confirmOutput = toolOutput as ConfirmToolOutput
               return (
-                <Tool key={index} defaultOpen>
+                <Tool key={index} open>
                   <ToolHeader
                     type="dynamic-tool"
                     state="approval-requested"
@@ -338,7 +338,7 @@ export function MessageParts({ message, onToolConfirm }: MessagePartsProps) {
               if (toolState === "output-available" && toolPart.output && typeof toolPart.output === "object" && toolPart.output !== null && "_needsConfirm" in toolPart.output) {
                 const confirmOutput = toolPart.output as ConfirmToolOutput
                 return (
-                  <Tool key={index} defaultOpen>
+                  <Tool key={index} open>
                     <ToolHeader
                       type="dynamic-tool"
                       state="approval-requested"

--- a/src/components/agent2/message-parts.tsx
+++ b/src/components/agent2/message-parts.tsx
@@ -20,7 +20,6 @@ interface ConfirmState {
   toolInput: Record<string, unknown>
   riskMessage: string
   token: string
-  toolCategory: string
 }
 
 interface ConfirmToolOutput {
@@ -28,7 +27,6 @@ interface ConfirmToolOutput {
   riskMessage: string
   toolInput: Record<string, unknown>
   token: string
-  toolCategory?: string
 }
 
 interface MessagePartsProps {
@@ -150,7 +148,6 @@ export function MessageParts({ message, onToolConfirm }: MessagePartsProps) {
     toolInput: {},
     riskMessage: "",
     token: "",
-    toolCategory: "",
   })
 
   if (!message.parts || message.parts.length === 0) {
@@ -277,7 +274,6 @@ export function MessageParts({ message, onToolConfirm }: MessagePartsProps) {
                             toolInput: confirmOutput.toolInput,
                             riskMessage: confirmOutput.riskMessage,
                             token: confirmOutput.token,
-                            toolCategory: confirmOutput.toolCategory || (toolPart.toolName.startsWith("mcp__") ? "mcp" : "execute"),
                           })
                         }}
                       >
@@ -396,7 +392,6 @@ export function MessageParts({ message, onToolConfirm }: MessagePartsProps) {
         toolInput={confirmState.toolInput}
         riskMessage={confirmState.riskMessage}
         token={confirmState.token}
-        toolCategory={confirmState.toolCategory}
         onConfirm={(result) => {
           setConfirmState(prev => ({ ...prev, open: false }))
           if (onToolConfirm && confirmState.toolCallId) {

--- a/src/components/agent2/message-parts.tsx
+++ b/src/components/agent2/message-parts.tsx
@@ -440,6 +440,7 @@ export function MessageParts({ message, onToolConfirm }: MessagePartsProps) {
         toolInput={confirmState.toolInput}
         riskMessage={confirmState.riskMessage}
         token={confirmState.token}
+        toolCallId={confirmState.toolCallId}
         detailPreview={confirmState.detailPreview}
         onConfirm={(result) => {
           setConfirmState(prev => ({ ...prev, open: false }))

--- a/src/components/agent2/message-parts.tsx
+++ b/src/components/agent2/message-parts.tsx
@@ -13,6 +13,15 @@ import { parseThinkTaggedText } from "@/lib/agent2/think-parser"
 import { extractChartOptionFromText } from "@/lib/agent2/chart-text-parser"
 import { AssistantStreamState } from "../ai-chat/assistant-stream-state"
 
+interface DetailPreview {
+  title: string
+  type: "record" | "paper" | "template" | "code" | "generic"
+  fields?: Array<{ label: string; value: string }>
+  summary?: string
+  recordCount?: number
+  items?: Array<{ id: string; label: string }>
+}
+
 interface ConfirmState {
   open: boolean
   toolName: string
@@ -20,6 +29,7 @@ interface ConfirmState {
   toolInput: Record<string, unknown>
   riskMessage: string
   token: string
+  detailPreview?: DetailPreview | null
 }
 
 interface ConfirmToolOutput {
@@ -27,6 +37,7 @@ interface ConfirmToolOutput {
   riskMessage: string
   toolInput: Record<string, unknown>
   token: string
+  detailPreview?: DetailPreview | null
 }
 
 interface MessagePartsProps {
@@ -254,7 +265,7 @@ export function MessageParts({ message, onToolConfirm }: MessagePartsProps) {
             if (toolOutput && typeof toolOutput === "object" && toolOutput !== null && "_needsConfirm" in toolOutput) {
               const confirmOutput = toolOutput as ConfirmToolOutput
               return (
-                <Tool key={index}>
+                <Tool key={index} defaultOpen>
                   <ToolHeader
                     type="dynamic-tool"
                     state="approval-requested"
@@ -274,6 +285,7 @@ export function MessageParts({ message, onToolConfirm }: MessagePartsProps) {
                             toolInput: confirmOutput.toolInput,
                             riskMessage: confirmOutput.riskMessage,
                             token: confirmOutput.token,
+                            detailPreview: confirmOutput.detailPreview,
                           })
                         }}
                       >
@@ -321,6 +333,42 @@ export function MessageParts({ message, onToolConfirm }: MessagePartsProps) {
               const toolPart = part as ToolUIPart
               const toolName = part.type.replace("tool-", "")
               const toolState = toolPart.state
+
+              // Check for needs-confirm from tool output
+              if (toolState === "output-available" && toolPart.output && typeof toolPart.output === "object" && toolPart.output !== null && "_needsConfirm" in toolPart.output) {
+                const confirmOutput = toolPart.output as ConfirmToolOutput
+                return (
+                  <Tool key={index} defaultOpen>
+                    <ToolHeader
+                      type="dynamic-tool"
+                      state="approval-requested"
+                      toolName={toolName}
+                    />
+                    <ToolContent>
+                      <div className="space-y-3 p-3">
+                        <p className="text-sm text-muted-foreground">{confirmOutput.riskMessage}</p>
+                        <ToolInput input={confirmOutput.toolInput} />
+                        <button
+                          className="px-3 py-1.5 text-sm bg-primary text-primary-foreground rounded-md"
+                          onClick={() => {
+                            setConfirmState({
+                              open: true,
+                              toolName,
+                              toolCallId: toolPart.toolCallId,
+                              toolInput: confirmOutput.toolInput,
+                              riskMessage: confirmOutput.riskMessage,
+                              token: confirmOutput.token,
+                              detailPreview: confirmOutput.detailPreview,
+                            })
+                          }}
+                        >
+                          查看详情并确认
+                        </button>
+                      </div>
+                    </ToolContent>
+                  </Tool>
+                )
+              }
 
               if (toolName === "generateChart" && toolState === "output-available") {
                 return (
@@ -392,6 +440,7 @@ export function MessageParts({ message, onToolConfirm }: MessagePartsProps) {
         toolInput={confirmState.toolInput}
         riskMessage={confirmState.riskMessage}
         token={confirmState.token}
+        detailPreview={confirmState.detailPreview}
         onConfirm={(result) => {
           setConfirmState(prev => ({ ...prev, open: false }))
           if (onToolConfirm && confirmState.toolCallId) {

--- a/src/components/agent2/settings-dialog.tsx
+++ b/src/components/agent2/settings-dialog.tsx
@@ -14,14 +14,12 @@ interface SettingsDialogProps {
 }
 
 interface Settings {
-  autoConfirmTools: Record<string, boolean>
   defaultModel: string
   showReasoning: boolean
 }
 
 export function SettingsDialog({ open, onOpenChange, onSettingsChange }: SettingsDialogProps) {
   const [settings, setSettings] = useState<Settings>({
-    autoConfirmTools: {},
     defaultModel: "gpt-4o",
     showReasoning: true,
   })
@@ -47,45 +45,18 @@ export function SettingsDialog({ open, onOpenChange, onSettingsChange }: Setting
     onSettingsChange?.(newSettings)
   }
 
-  const toolCategories = [
-    { key: "read", label: "查询类工具", description: "搜索、查询、聚合统计" },
-    { key: "write", label: "创建类工具", description: "创建记录、生成文档" },
-    { key: "delete", label: "删除类工具", description: "删除记录" },
-    { key: "execute", label: "执行类工具", description: "代码执行" },
-    { key: "mcp", label: "MCP 外部工具", description: "调用外部 MCP 服务器工具" },
-  ]
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg">
         <DialogHeader>
           <DialogTitle>设置</DialogTitle>
         </DialogHeader>
-        <Tabs defaultValue="tools">
+        <Tabs defaultValue="models">
           <TabsList className="w-full">
-            <TabsTrigger value="tools" className="flex-1">工具执行</TabsTrigger>
             <TabsTrigger value="models" className="flex-1">模型管理</TabsTrigger>
             <TabsTrigger value="display" className="flex-1">显示设置</TabsTrigger>
             <TabsTrigger value="mcp" className="flex-1">MCP 服务器</TabsTrigger>
           </TabsList>
-          <TabsContent value="tools" className="space-y-4 mt-4">
-            {toolCategories.map(cat => (
-              <div key={cat.key} className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm font-medium">{cat.label}</p>
-                  <p className="text-xs text-muted-foreground">{cat.description}</p>
-                </div>
-                <Switch
-                  checked={settings.autoConfirmTools[cat.key] || false}
-                  onCheckedChange={(checked: boolean) => {
-                    updateSettings({
-                      autoConfirmTools: { ...settings.autoConfirmTools, [cat.key]: checked },
-                    })
-                  }}
-                />
-              </div>
-            ))}
-          </TabsContent>
           <TabsContent value="models" className="mt-4">
             <ModelManager settings={settings} onUpdateSettings={(updates) => updateSettings(updates as Partial<Settings>)} />
           </TabsContent>

--- a/src/components/agent2/tool-confirm-dialog.tsx
+++ b/src/components/agent2/tool-confirm-dialog.tsx
@@ -21,6 +21,7 @@ interface ToolConfirmDialogProps {
   toolInput: Record<string, unknown>
   riskMessage: string
   token: string
+  toolCallId: string
   detailPreview?: DetailPreview | null
   onConfirm: (result: unknown) => void
   onReject: () => void
@@ -62,7 +63,7 @@ function DetailPreviewCard({ preview }: { preview: DetailPreview }) {
 }
 
 export function ToolConfirmDialog({
-  open, onOpenChange, toolName, toolInput, riskMessage, token,
+  open, onOpenChange, toolName, toolInput, riskMessage, token, toolCallId,
   detailPreview, onConfirm, onReject,
 }: ToolConfirmDialogProps) {
   const [loading, setLoading] = useState(false)
@@ -73,7 +74,7 @@ export function ToolConfirmDialog({
       const res = await fetch(`/api/agent2/confirm/${token}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ approved: true }),
+        body: JSON.stringify({ approved: true, toolCallId }),
       })
       const data = await res.json()
       if (data.success) onConfirm(data.data)

--- a/src/components/agent2/tool-confirm-dialog.tsx
+++ b/src/components/agent2/tool-confirm-dialog.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react"
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
-import { Checkbox } from "@/components/ui/checkbox"
 import { AlertTriangle } from "lucide-react"
 
 interface ToolConfirmDialogProps {
@@ -15,14 +14,12 @@ interface ToolConfirmDialogProps {
   token: string
   onConfirm: (result: unknown) => void
   onReject: () => void
-  toolCategory: string
 }
 
 export function ToolConfirmDialog({
   open, onOpenChange, toolName, toolInput, riskMessage, token,
-  onConfirm, onReject, toolCategory,
+  onConfirm, onReject,
 }: ToolConfirmDialogProps) {
-  const [autoConfirm, setAutoConfirm] = useState(false)
   const [loading, setLoading] = useState(false)
 
   const handleConfirm = async () => {
@@ -40,26 +37,6 @@ export function ToolConfirmDialog({
       onReject()
     } finally {
       setLoading(false)
-    }
-
-    if (autoConfirm) {
-      // Merge with existing auto-confirm settings instead of overwriting
-      try {
-        const settingsRes = await fetch("/api/agent2/settings")
-        const settingsData = await settingsRes.json()
-        const existing = settingsData.success
-          ? (settingsData.data.autoConfirmTools as Record<string, boolean>)
-          : {}
-        await fetch("/api/agent2/settings", {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            autoConfirmTools: { ...existing, [toolCategory]: true },
-          }),
-        })
-      } catch {
-        // Best-effort — don't block the confirm flow
-      }
     }
   }
 
@@ -99,16 +76,6 @@ export function ToolConfirmDialog({
               {JSON.stringify(toolInput, null, 2)}
             </pre>
           </div>
-        </div>
-        <div className="flex items-center gap-2 mt-3">
-          <Checkbox
-            id="auto-confirm"
-            checked={autoConfirm}
-            onCheckedChange={(checked: boolean) => setAutoConfirm(checked)}
-          />
-          <label htmlFor="auto-confirm" className="text-sm text-muted-foreground cursor-pointer">
-            以后自动确认此类操作
-          </label>
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={handleReject} disabled={loading}>拒绝</Button>

--- a/src/components/agent2/tool-confirm-dialog.tsx
+++ b/src/components/agent2/tool-confirm-dialog.tsx
@@ -5,6 +5,15 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Button } from "@/components/ui/button"
 import { AlertTriangle } from "lucide-react"
 
+interface DetailPreview {
+  title: string
+  type: "record" | "paper" | "template" | "code" | "generic"
+  fields?: Array<{ label: string; value: string }>
+  summary?: string
+  recordCount?: number
+  items?: Array<{ id: string; label: string }>
+}
+
 interface ToolConfirmDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -12,13 +21,49 @@ interface ToolConfirmDialogProps {
   toolInput: Record<string, unknown>
   riskMessage: string
   token: string
+  detailPreview?: DetailPreview | null
   onConfirm: (result: unknown) => void
   onReject: () => void
 }
 
+function DetailPreviewCard({ preview }: { preview: DetailPreview }) {
+  return (
+    <div className="rounded-md border bg-muted/50 p-3 space-y-2">
+      <p className="text-sm font-medium">{preview.title}</p>
+      {preview.fields && preview.fields.length > 0 && (
+        <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-sm">
+          {preview.fields.map((field, i) => (
+            <span key={i} className="contents">
+              <span className="text-muted-foreground whitespace-nowrap">{field.label}:</span>
+              <span className="break-all">{field.value}</span>
+            </span>
+          ))}
+        </div>
+      )}
+      {preview.summary && (
+        <p className="text-xs text-muted-foreground">{preview.summary}</p>
+      )}
+      {preview.items && preview.items.length > 0 && (
+        <ul className="text-xs text-muted-foreground space-y-0.5">
+          {preview.items.map((item) => (
+            <li key={item.id} className="truncate">
+              {item.label}
+            </li>
+          ))}
+          {(preview.recordCount ?? 0) > preview.items.length && (
+            <li className="italic">
+              ...共 {preview.recordCount} 条
+            </li>
+          )}
+        </ul>
+      )}
+    </div>
+  )
+}
+
 export function ToolConfirmDialog({
   open, onOpenChange, toolName, toolInput, riskMessage, token,
-  onConfirm, onReject,
+  detailPreview, onConfirm, onReject,
 }: ToolConfirmDialogProps) {
   const [loading, setLoading] = useState(false)
 
@@ -70,12 +115,19 @@ export function ToolConfirmDialog({
               )}
             </code>
           </div>
-          <div>
-            <p className="text-sm font-medium mb-1">参数</p>
-            <pre className="text-xs bg-muted p-3 rounded-md overflow-auto max-h-40">
-              {JSON.stringify(toolInput, null, 2)}
-            </pre>
-          </div>
+          {detailPreview ? (
+            <div>
+              <p className="text-sm font-medium mb-1">操作对象</p>
+              <DetailPreviewCard preview={detailPreview} />
+            </div>
+          ) : (
+            <div>
+              <p className="text-sm font-medium mb-1">参数</p>
+              <pre className="text-xs bg-muted p-3 rounded-md overflow-auto max-h-40">
+                {JSON.stringify(toolInput, null, 2)}
+              </pre>
+            </div>
+          )}
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={handleReject} disabled={loading}>拒绝</Button>

--- a/src/components/agent2/tool-confirm-dialog.tsx
+++ b/src/components/agent2/tool-confirm-dialog.tsx
@@ -104,7 +104,7 @@ export function ToolConfirmDialog({
           </DialogTitle>
           <DialogDescription>{riskMessage}</DialogDescription>
         </DialogHeader>
-        <div className="space-y-3">
+        <div className="space-y-3 max-h-[60vh] overflow-y-auto pr-1">
           <div>
             <p className="text-sm font-medium mb-1">工具</p>
             <code className="text-sm bg-muted px-2 py-1 rounded">

--- a/src/lib/agent2/confirm-store.ts
+++ b/src/lib/agent2/confirm-store.ts
@@ -13,6 +13,7 @@ const CONFIRM_REQUIRED_TOOLS = new Set([
   "batchCreateRecords",
   "batchUpdateRecords",
   "batchDeleteRecords",
+  "importPaper",
 ]);
 
 const RISK_MESSAGES: Record<string, string> = {
@@ -24,6 +25,7 @@ const RISK_MESSAGES: Record<string, string> = {
   batchCreateRecords: "即将批量创建多条记录",
   batchUpdateRecords: "即将批量更新多条记录",
   batchDeleteRecords: "⚠️ 即将永久删除多条记录，此操作不可撤销",
+  importPaper: "此操作将导入论文并创建/匹配作者记录",
 };
 
 export function needsConfirm(toolName: string): boolean {

--- a/src/lib/agent2/context-builder.ts
+++ b/src/lib/agent2/context-builder.ts
@@ -85,6 +85,7 @@ export async function buildSystemPrompt(): Promise<string> {
    - 收到此响应后，你必须停止生成，不要再次调用相同或类似的工具
    - 简短告知用户操作正在等待确认，用户可以在确认框中查看详情
    - 等待用户在界面中确认或拒绝后再继续
+   - 当用户发送"确认执行"时，如果历史消息中该工具的输出包含 { success: true, message: "..." }，说明操作已被用户确认并成功执行，直接总结结果即可，绝对不要再次调用该工具
 8. 删除操作流程 — 当用户要求删除记录时：
    - 如果用户提供了明确的记录 ID，直接调用 deleteRecord
    - 如果用户提供了模糊描述（如"删除论文 Attention Is All You Need"），先用 searchRecords 查询确认记录

--- a/src/lib/agent2/context-builder.ts
+++ b/src/lib/agent2/context-builder.ts
@@ -80,6 +80,16 @@ export async function buildSystemPrompt(): Promise<string> {
 4. 主动提供帮助 — 根据用户意图推荐合适的工具
 5. 批量导入 — 用户上传文件后，解析内容并使用 batchCreateRecords 批量导入
 6. 论文导入流程 — 用户提到"导入论文"时：先用 parsePaperText 解析文本或 fetchPaperByDOI 获取 DOI 信息，展示结果让用户确认，再调用 importPaper 导入。逐条确认。
+7. 确认流程 — 调用需要确认的工具（createRecord, updateRecord, deleteRecord, batchDeleteRecords, importPaper 等）时：
+   - 工具会返回 { _needsConfirm: true }，表示操作已暂停等待用户确认
+   - 收到此响应后，你必须停止生成，不要再次调用相同或类似的工具
+   - 简短告知用户操作正在等待确认，用户可以在确认框中查看详情
+   - 等待用户在界面中确认或拒绝后再继续
+8. 删除操作流程 — 当用户要求删除记录时：
+   - 如果用户提供了明确的记录 ID，直接调用 deleteRecord
+   - 如果用户提供了模糊描述（如"删除论文 Attention Is All You Need"），先用 searchRecords 查询确认记录
+   - deleteRecord 调用后系统会自动在确认框中展示记录详情
+   - 不要反复重试调用，等待用户确认即可
 ${tableContext}
 ${mcpContext}
 ## 回答语言

--- a/src/lib/agent2/context-builder.ts
+++ b/src/lib/agent2/context-builder.ts
@@ -69,6 +69,9 @@ export async function buildSystemPrompt(): Promise<string> {
 - 查看和生成文档（基于模板）
 - 生成数据可视化图表
 - 获取当前时间
+- 通过 DOI 查询并导入论文（fetchPaperByDOI）
+- 解析用户输入的论文文本并导入（parsePaperText）
+- 导入论文到论文表，自动匹配/创建作者（importPaper）
 
 ## 工作原则
 1. 先查询再操作 — 在修改数据前，先确认目标记录或数据
@@ -76,6 +79,7 @@ export async function buildSystemPrompt(): Promise<string> {
 3. 解释操作结果 — 每次操作后清晰说明结果
 4. 主动提供帮助 — 根据用户意图推荐合适的工具
 5. 批量导入 — 用户上传文件后，解析内容并使用 batchCreateRecords 批量导入
+6. 论文导入流程 — 用户提到"导入论文"时：先用 parsePaperText 解析文本或 fetchPaperByDOI 获取 DOI 信息，展示结果让用户确认，再调用 importPaper 导入。逐条确认。
 ${tableContext}
 ${mcpContext}
 ## 回答语言

--- a/src/lib/agent2/detail-preview.test.ts
+++ b/src/lib/agent2/detail-preview.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from "vitest"
+import { fetchDetailPreview, formatFieldValue, extractRecordTitle } from "./detail-preview"
+
+// Mock tool-helpers
+vi.mock("./tool-helpers", () => ({
+  getRecord: vi.fn(),
+  getTemplateDetail: vi.fn(),
+}))
+
+import { getRecord, getTemplateDetail } from "./tool-helpers"
+
+const mockGetRecord = vi.mocked(getRecord)
+const mockGetTemplateDetail = vi.mocked(getTemplateDetail)
+
+describe("formatFieldValue", () => {
+  it("字符串直接返回", () => {
+    expect(formatFieldValue("hello")).toBe("hello")
+  })
+
+  it("数字转字符串", () => {
+    expect(formatFieldValue(42)).toBe("42")
+  })
+
+  it("null/undefined 返回 -", () => {
+    expect(formatFieldValue(null)).toBe("-")
+    expect(formatFieldValue(undefined)).toBe("-")
+  })
+
+  it("数组用逗号连接", () => {
+    expect(formatFieldValue(["a", "b", "c"])).toBe("a, b, c")
+  })
+
+  it("对象 JSON 序列化", () => {
+    expect(formatFieldValue({ key: "val" })).toBe('{"key":"val"}')
+  })
+})
+
+describe("extractRecordTitle", () => {
+  it("优先使用 title_en", () => {
+    expect(extractRecordTitle({ title_en: "Hello", title_cn: "你好", id: "1", tableId: "t1" }))
+      .toBe("Hello")
+  })
+
+  it("其次使用 title_cn", () => {
+    expect(extractRecordTitle({ title_cn: "你好", id: "1", tableId: "t1" }))
+      .toBe("你好")
+  })
+
+  it("使用第一个非空字符串字段", () => {
+    expect(extractRecordTitle({ name: "Alice", age: 30, id: "1", tableId: "t1" }))
+      .toBe("Alice")
+  })
+
+  it("无可用字段时返回 记录 ID", () => {
+    expect(extractRecordTitle({ id: "rec-123", tableId: "t1", age: 30 }))
+      .toBe("记录 rec-123")
+  })
+})
+
+describe("fetchDetailPreview", () => {
+  it("deleteRecord 返回记录详情", async () => {
+    mockGetRecord.mockResolvedValueOnce({
+      success: true,
+      data: { id: "r1", tableId: "t1", title_en: "Attention Is All You Need", year: 2017 },
+    })
+
+    const result = await fetchDetailPreview("deleteRecord", { recordId: "r1" })
+
+    expect(result).toEqual({
+      title: "Attention Is All You Need",
+      type: "record",
+      fields: expect.arrayContaining([
+        { label: "title_en", value: "Attention Is All You Need" },
+        { label: "year", value: "2017" },
+      ]),
+    })
+  })
+
+  it("deleteRecord 记录不存在时返回 null", async () => {
+    mockGetRecord.mockResolvedValueOnce({
+      success: false,
+      error: { code: "NOT_FOUND", message: "记录不存在" },
+    })
+
+    const result = await fetchDetailPreview("deleteRecord", { recordId: "bad-id" })
+    expect(result).toBeNull()
+  })
+
+  it("importPaper 返回论文详情", async () => {
+    const result = await fetchDetailPreview("importPaper", {
+      paperData: { title_en: "Test Paper", title_cn: "测试论文", publish_year: 2024, venue_name: "ICML", doi: "10.1234/test" },
+      authors: [
+        { name: "Alice", author_order: 1, is_first_author: "Y", is_corresponding_author: "N" },
+        { name: "Bob", author_order: 2, is_first_author: "N", is_corresponding_author: "Y" },
+      ],
+    })
+
+    expect(result).toEqual({
+      title: "论文: Test Paper",
+      type: "paper",
+      fields: [
+        { label: "英文标题", value: "Test Paper" },
+        { label: "中文标题", value: "测试论文" },
+        { label: "年份", value: "2024" },
+        { label: "期刊/会议", value: "ICML" },
+        { label: "DOI", value: "10.1234/test" },
+      ],
+      summary: "共 2 位作者: Alice, Bob",
+    })
+  })
+
+  it("generateDocument 返回模板详情", async () => {
+    mockGetTemplateDetail.mockResolvedValueOnce({
+      success: true,
+      data: {
+        id: "tpl1",
+        name: "论文报告",
+        description: null,
+        status: "PUBLISHED",
+        placeholders: [
+          { id: "p1", key: "title", label: "标题", inputType: "text", required: true, defaultValue: null },
+        ],
+      },
+    })
+
+    const result = await fetchDetailPreview("generateDocument", {
+      templateId: "tpl1",
+      formData: { title: "My Paper" },
+    })
+
+    expect(result).toEqual({
+      title: "模板: 论文报告",
+      type: "template",
+      fields: [{ label: "title", value: "My Paper" }],
+    })
+  })
+
+  it("batchDeleteRecords 返回批量预览（限制 10 条）", async () => {
+    const ids = Array.from({ length: 12 }, (_, i) => `r${i}`)
+    for (let i = 0; i < 10; i++) {
+      mockGetRecord.mockResolvedValueOnce({
+        success: true,
+        data: { id: `r${i}`, tableId: "t1", title_en: `Paper ${i}` },
+      })
+    }
+
+    const result = await fetchDetailPreview("batchDeleteRecords", { recordIds: ids })
+
+    expect(result?.recordCount).toBe(12)
+    expect(result?.items).toHaveLength(10)
+    expect(result?.title).toBe("批量操作 12 条记录")
+  })
+
+  it("未知工具返回 null", async () => {
+    const result = await fetchDetailPreview("unknownTool", {})
+    expect(result).toBeNull()
+  })
+
+  it("异常时返回 null", async () => {
+    mockGetRecord.mockRejectedValueOnce(new Error("DB error"))
+    const result = await fetchDetailPreview("deleteRecord", { recordId: "r1" })
+    expect(result).toBeNull()
+  })
+})

--- a/src/lib/agent2/detail-preview.ts
+++ b/src/lib/agent2/detail-preview.ts
@@ -1,0 +1,130 @@
+// src/lib/agent2/detail-preview.ts
+import * as helpers from "./tool-helpers"
+
+export interface DetailPreview {
+  title: string
+  type: "record" | "paper" | "template" | "code" | "generic"
+  fields?: Array<{ label: string; value: string }>
+  summary?: string
+  recordCount?: number
+  items?: Array<{ id: string; label: string }>
+}
+
+/** 格式化字段值为可读字符串 */
+export function formatFieldValue(value: unknown): string {
+  if (value == null) return "-"
+  if (typeof value === "string") return value
+  if (typeof value === "number" || typeof value === "boolean") return String(value)
+  if (Array.isArray(value)) return value.map((v) => (typeof v === "string" ? v : JSON.stringify(v))).join(", ")
+  return JSON.stringify(value)
+}
+
+/** 从记录数据中提取可读标题 */
+export function extractRecordTitle(data: Record<string, unknown>): string {
+  // 优先使用常见标题字段
+  for (const key of ["title_en", "title_cn", "name", "title"]) {
+    const val = data[key]
+    if (typeof val === "string" && val.trim()) return val.trim()
+  }
+  // 使用第一个非空字符串字段
+  for (const [key, val] of Object.entries(data)) {
+    if (key === "id" || key === "tableId") continue
+    if (typeof val === "string" && val.trim()) return val.trim()
+  }
+  return `记录 ${data.id ?? "未知"}`
+}
+
+/**
+ * 根据工具名和参数预取操作对象详情。
+ * 失败时返回 null，不影响确认流程。
+ */
+export async function fetchDetailPreview(
+  toolName: string,
+  args: unknown
+): Promise<DetailPreview | null> {
+  try {
+    const input = args as Record<string, unknown>
+
+    switch (toolName) {
+      case "deleteRecord":
+      case "updateRecord": {
+        const result = await helpers.getRecord(input.recordId as string)
+        if (!result.success) return null
+        const data = result.data as Record<string, unknown>
+        return {
+          title: extractRecordTitle(data),
+          type: "record",
+          fields: Object.entries(data)
+            .filter(([k]) => k !== "id" && k !== "tableId")
+            .filter(([_, v]) => v != null && v !== "")
+            .map(([key, value]) => ({
+              label: key,
+              value: formatFieldValue(value),
+            })),
+        }
+      }
+
+      case "importPaper": {
+        const paperData = input.paperData as Record<string, unknown>
+        const authors = input.authors as Array<Record<string, unknown>>
+        return {
+          title: `论文: ${(paperData.title_en as string) || (paperData.title_cn as string) || "未知"}`,
+          type: "paper",
+          fields: [
+            { label: "英文标题", value: (paperData.title_en as string) || "-" },
+            { label: "中文标题", value: (paperData.title_cn as string) || "-" },
+            { label: "年份", value: paperData.publish_year ? String(paperData.publish_year) : "-" },
+            { label: "期刊/会议", value: (paperData.venue_name as string) || "-" },
+            { label: "DOI", value: (paperData.doi as string) || "-" },
+          ].filter((f) => f.value !== "-"),
+          summary: `共 ${authors.length} 位作者: ${authors.map((a) => a.name).join(", ")}`,
+        }
+      }
+
+      case "generateDocument": {
+        const result = await helpers.getTemplateDetail(input.templateId as string)
+        if (!result.success) return null
+        const formData = input.formData as Record<string, unknown>
+        return {
+          title: `模板: ${result.data.name}`,
+          type: "template",
+          fields: result.data.placeholders.map((p) => ({
+            label: p.key,
+            value: formatFieldValue(formData?.[p.key]) || "(空)",
+          })),
+        }
+      }
+
+      case "batchDeleteRecords":
+      case "batchUpdateRecords": {
+        const ids = (
+          toolName === "batchDeleteRecords"
+            ? input.recordIds
+            : (input.updates as Array<{ recordId: string }>)?.map((u) => u.recordId)
+        ) as string[]
+        if (!ids || ids.length === 0) return null
+
+        const previews = await Promise.all(
+          ids.slice(0, 10).map(async (id) => {
+            const result = await helpers.getRecord(id)
+            return {
+              id,
+              label: result.success ? extractRecordTitle(result.data as Record<string, unknown>) : id,
+            }
+          })
+        )
+        return {
+          title: `批量操作 ${ids.length} 条记录`,
+          type: "record",
+          recordCount: ids.length,
+          items: previews,
+        }
+      }
+
+      default:
+        return null
+    }
+  } catch {
+    return null
+  }
+}

--- a/src/lib/agent2/doi-service.ts
+++ b/src/lib/agent2/doi-service.ts
@@ -1,0 +1,124 @@
+// src/lib/agent2/doi-service.ts
+
+export interface DOIPaperResult {
+  title: string;
+  authors: Array<{ name: string; orcid?: string }>;
+  year?: number;
+  publishDate?: string;
+  venueName?: string;
+  doi: string;
+  paperType?: "journal" | "conference";
+  volume?: string;
+  issue?: string;
+  pages?: string;
+  issn?: string;
+  url?: string;
+}
+
+/**
+ * 通过 DOI 从 Crossref API 获取论文元数据
+ * API: https://api.crossref.org/works/{doi}
+ */
+export async function fetchPaperByDOI(
+  doi: string
+): Promise<{ success: true; data: DOIPaperResult } | { success: false; error: string }> {
+  // 清理 DOI：移除 URL 前缀
+  const cleanDOI = doi
+    .replace(/^https?:\/\/doi\.org\//i, "")
+    .replace(/^DOI:\s*/i, "")
+    .trim();
+
+  try {
+    const response = await fetch(
+      `https://api.crossref.org/works/${encodeURIComponent(cleanDOI)}`,
+      {
+        headers: { "User-Agent": "IDRL-DocxTemplateSystem/1.0 (mailto:admin@example.com)" },
+        signal: AbortSignal.timeout(15_000),
+      }
+    );
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        return { success: false, error: `未找到 DOI "${cleanDOI}" 对应的论文，请检查 DOI 是否正确` };
+      }
+      return { success: false, error: `Crossref API 返回错误 (${response.status})` };
+    }
+
+    const json = (await response.json()) as { message: CrossrefWork };
+    const item = json.message;
+
+    // 提取作者
+    const authors = (item.author ?? []).map((a) => ({
+      name: [a.given, a.family].filter(Boolean).join(" "),
+      orcid: a.ORCID?.replace("http://orcid.org/", ""),
+    }));
+
+    // 提取年份和日期
+    const year = item.published?.["date-parts"]?.[0]?.[0]
+      ?? item.created?.["date-parts"]?.[0]?.[0];
+    const publishDate = item.published?.["date-parts"]?.[0]
+      ? formatDateParts(item.published["date-parts"][0])
+      : undefined;
+
+    // 提取期刊/会议名
+    const venueName = item["container-title"]?.[0] ?? item["event"]?.name ?? undefined;
+
+    // 判断论文类型
+    const paperType = inferPaperType(item.type);
+
+    return {
+      success: true,
+      data: {
+        title: item.title?.[0] ?? "",
+        authors,
+        year,
+        publishDate,
+        venueName,
+        doi: cleanDOI,
+        paperType,
+        volume: item.volume ?? undefined,
+        issue: item.issue ?? undefined,
+        pages: item.page ?? undefined,
+        issn: item.ISSN?.[0] ?? undefined,
+        url: item.URL ?? `https://doi.org/${cleanDOI}`,
+      },
+    };
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "TimeoutError") {
+      return { success: false, error: "Crossref API 请求超时，请稍后重试或手动输入论文信息" };
+    }
+    return { success: false, error: `DOI 查询失败: ${err instanceof Error ? err.message : "未知错误"}` };
+  }
+}
+
+// ── Crossref API 类型 ──
+
+interface CrossrefWork {
+  title?: string[];
+  author?: Array<{ given?: string; family?: string; ORCID?: string }>;
+  published?: { "date-parts": number[][] };
+  created?: { "date-parts": number[][] };
+  "container-title"?: string[];
+  event?: { name?: string };
+  type?: string;
+  volume?: string;
+  issue?: string;
+  page?: string;
+  ISSN?: string[];
+  URL?: string;
+}
+
+function formatDateParts(parts: number[]): string {
+  const [y, m, d] = parts;
+  if (d && m) return `${y}-${String(m).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+  if (m) return `${y}-${String(m).padStart(2, "0")}`;
+  return String(y);
+}
+
+function inferPaperType(type?: string): "journal" | "conference" | undefined {
+  if (!type) return undefined;
+  const lower = type.toLowerCase();
+  if (lower.includes("proceedings") || lower.includes("conference")) return "conference";
+  if (lower.includes("journal") || lower.includes("article")) return "journal";
+  return undefined;
+}

--- a/src/lib/agent2/mcp-client.ts
+++ b/src/lib/agent2/mcp-client.ts
@@ -108,8 +108,7 @@ function wrapMcpToolWithConfirm(
   prefixedName: string,
   rawTool: Tool,
   conversationId: string,
-  messageId: string,
-  autoConfirm: Record<string, boolean>
+  messageId: string
 ): Tool {
   if (!rawTool.execute) return rawTool;
   const originalExecute = rawTool.execute;
@@ -118,11 +117,6 @@ function wrapMcpToolWithConfirm(
     description: rawTool.description,
     inputSchema: rawTool.inputSchema ?? z.object({}),
     execute: async (args: unknown, context: ToolExecutionOptions) => {
-      const isAutoConfirmed = autoConfirm["mcp"] === true;
-      if (isAutoConfirmed) {
-        return originalExecute(args, context);
-      }
-
       const tokenResult = await createConfirmToken(
         conversationId,
         messageId,
@@ -149,8 +143,7 @@ function wrapMcpToolWithConfirm(
  */
 export async function getEnabledMcpTools(
   conversationId: string,
-  messageId: string,
-  autoConfirm: Record<string, boolean>
+  messageId: string
 ): Promise<McpToolsResult> {
   const result: McpToolsResult = {
     tools: {},
@@ -179,8 +172,7 @@ export async function getEnabledMcpTools(
           toolName,
           rawTool,
           conversationId,
-          messageId,
-          autoConfirm
+          messageId
         );
       }
       result.clients.push(connection.client);

--- a/src/lib/agent2/message-persistence.ts
+++ b/src/lib/agent2/message-persistence.ts
@@ -138,6 +138,7 @@ export function getLatestPersistableMessages(
 
   return {
     userMessage: {
+      id: userMessage.id,
       role: "user",
       parts: userMessage.parts,
       attachments: "experimental_attachments" in userMessage
@@ -145,6 +146,7 @@ export function getLatestPersistableMessages(
         : undefined,
     },
     assistantMessage: {
+      id: assistantMessage.id,
       role: "assistant",
       parts: assistantMessage.parts.flatMap((part): UIMessage['parts'] => {
         if (part.type !== "text") {

--- a/src/lib/agent2/paper-import-executor.ts
+++ b/src/lib/agent2/paper-import-executor.ts
@@ -64,11 +64,15 @@ function normalizeName(name: string): string {
     .replace(/[\u0300-\u036f]/g, "");
 }
 
-/** 获取当前论文表中最大的 paper_id（数字）+1 */
-async function nextPaperId(paperTableId: string): Promise<string> {
-  const result = await db.$queryRawUnsafe<Array<{ max_id: string | null }>>(
+/**
+ * 在事务内安全生成下一个 paper_id。
+ * 使用 FOR UPDATE 锁定扫描范围，防止并发重复。
+ */
+async function nextPaperId(tx: Prisma.TransactionClient, paperTableId: string): Promise<string> {
+  const result = await tx.$queryRawUnsafe<Array<{ max_id: string | null }>>(
     `SELECT MAX(CAST(data->>'paper_id' AS INTEGER)) as max_id
-     FROM "DataRecord" WHERE "tableId" = $1`,
+     FROM "DataRecord" WHERE "tableId" = $1
+     FOR UPDATE`,
     paperTableId
   );
   const maxId = result[0]?.max_id;
@@ -99,15 +103,16 @@ async function findPaperAndAuthorTables(): Promise<{
   };
 }
 
-/** 在作者表中按标准化姓名匹配作者 */
+/** 在事务内按标准化姓名匹配或创建作者 */
 async function matchOrCreateAuthor(
+  tx: Prisma.TransactionClient,
   authorTableId: string,
   name: string,
   userId: string
 ): Promise<{ id: string; status: "matched" | "created" }> {
   const norm = normalizeName(name);
 
-  const existing = await db.dataRecord.findFirst({
+  const existing = await tx.dataRecord.findFirst({
     where: {
       tableId: authorTableId,
       OR: [
@@ -122,7 +127,7 @@ async function matchOrCreateAuthor(
     return { id: existing.id, status: "matched" };
   }
 
-  const record = await db.dataRecord.create({
+  const record = await tx.dataRecord.create({
     data: {
       tableId: authorTableId,
       data: {
@@ -152,85 +157,90 @@ export async function importPaper(
 
     const { paperTableId, authorTableId } = tables;
 
-    // 1. 匹配/创建所有作者
-    const authorResults: ImportResult["authors"] = [];
+    // 整个导入流程在单一事务内执行，任一步失败全部回滚
+    const result = await db.$transaction(async (tx) => {
+      // 1. 在事务内安全生成 paper_id
+      const paperId = await nextPaperId(tx, paperTableId);
 
-    for (const author of authors) {
-      const result = await matchOrCreateAuthor(authorTableId, author.name, userId);
-      authorResults.push({
-        name: author.name,
-        status: result.status,
-        authorId: result.id,
-      });
-    }
+      // 2. 匹配/创建所有作者
+      const authorResults: ImportResult["authors"] = [];
+      for (const author of authors) {
+        const matchResult = await matchOrCreateAuthor(tx, authorTableId, author.name, userId);
+        authorResults.push({
+          name: author.name,
+          status: matchResult.status,
+          authorId: matchResult.id,
+        });
+      }
 
-    // 2. 创建论文记录
-    const paperRecord = await db.dataRecord.create({
-      data: {
-        tableId: paperTableId,
+      // 3. 创建论文记录
+      const paperRecord = await tx.dataRecord.create({
         data: {
-          paper_id: await nextPaperId(paperTableId),
-          title_en: paperData.title_en,
-          title_cn: paperData.title_cn ?? "",
-          paper_type: paperData.paper_type ?? "",
-          group_name: paperData.group_name ?? "",
-          publish_year: paperData.publish_year ?? null,
-          publish_date: paperData.publish_date ?? "",
-          conf_start_date: paperData.conf_start_date ?? "",
-          conf_end_date: paperData.conf_end_date ?? "",
-          venue_name: paperData.venue_name ?? "",
-          venue_name_cn: paperData.venue_name_cn ?? "",
-          conf_location: paperData.conf_location ?? "",
-          doi: paperData.doi ?? "",
-          index_type: paperData.index_type ?? "",
-          pub_status: paperData.pub_status ?? "",
-          archive_status: paperData.archive_status ?? "",
-          corr_authors: paperData.corr_authors ?? "",
-          inst_rank: paperData.inst_rank ?? null,
-          fund_no: paperData.fund_no ?? "",
-          paper_url: paperData.paper_url ?? "",
-          volume: paperData.volume ?? "",
-          issue: paperData.issue ?? "",
-          pages: paperData.pages ?? "",
-          impact_factor: paperData.impact_factor ?? null,
-          issn_isbn: paperData.issn_isbn ?? "",
-          ccf_category: paperData.ccf_category ?? "",
-          cas_partition: paperData.cas_partition ?? "",
-          jcr_partition: paperData.jcr_partition ?? "",
-          sci_partition: paperData.sci_partition ?? "",
-        } as unknown as Prisma.InputJsonValue,
-        createdById: userId,
-      },
-    });
-
-    // 3. 建立论文-作者关联（RELATION_SUBTABLE）
-    if (authors.length > 0) {
-      const relationItems: RelationSubtableValueItem[] = authors.map((author, idx) => ({
-        targetRecordId: authorResults[idx].authorId,
-        displayValue: author.name,
-        attributes: {
-          author_order: author.author_order,
-          is_first_author: author.is_first_author,
-          is_corresponding_author: author.is_corresponding_author,
+          tableId: paperTableId,
+          data: {
+            paper_id: paperId,
+            title_en: paperData.title_en,
+            title_cn: paperData.title_cn ?? "",
+            paper_type: paperData.paper_type ?? "",
+            group_name: paperData.group_name ?? "",
+            publish_year: paperData.publish_year ?? null,
+            publish_date: paperData.publish_date ?? "",
+            conf_start_date: paperData.conf_start_date ?? "",
+            conf_end_date: paperData.conf_end_date ?? "",
+            venue_name: paperData.venue_name ?? "",
+            venue_name_cn: paperData.venue_name_cn ?? "",
+            conf_location: paperData.conf_location ?? "",
+            doi: paperData.doi ?? "",
+            index_type: paperData.index_type ?? "",
+            pub_status: paperData.pub_status ?? "",
+            archive_status: paperData.archive_status ?? "",
+            corr_authors: paperData.corr_authors ?? "",
+            inst_rank: paperData.inst_rank ?? null,
+            fund_no: paperData.fund_no ?? "",
+            paper_url: paperData.paper_url ?? "",
+            volume: paperData.volume ?? "",
+            issue: paperData.issue ?? "",
+            pages: paperData.pages ?? "",
+            impact_factor: paperData.impact_factor ?? null,
+            issn_isbn: paperData.issn_isbn ?? "",
+            ccf_category: paperData.ccf_category ?? "",
+            cas_partition: paperData.cas_partition ?? "",
+            jcr_partition: paperData.jcr_partition ?? "",
+            sci_partition: paperData.sci_partition ?? "",
+          } as unknown as Prisma.InputJsonValue,
+          createdById: userId,
         },
-        sortOrder: author.author_order,
-      }));
+      });
 
-      await db.$transaction(async (tx) => {
+      // 4. 建立论文-作者关联（在同一事务内）
+      if (authors.length > 0) {
+        const relationItems: RelationSubtableValueItem[] = authors.map((author, idx) => ({
+          targetRecordId: authorResults[idx].authorId,
+          displayValue: author.name,
+          attributes: {
+            author_order: author.author_order,
+            is_first_author: author.is_first_author,
+            is_corresponding_author: author.is_corresponding_author,
+          },
+          sortOrder: author.author_order,
+        }));
+
         await syncRelationSubtableValues({
           tx,
           sourceRecordId: paperRecord.id,
           tableId: paperTableId,
           relationPayload: { authors: relationItems },
         });
-      });
-    }
+      }
+
+      return { paperRecord, authorResults };
+    });
 
     return {
       success: true,
       data: {
-        paperId: paperRecord.id,
-        authors: authorResults,
+        paperId: result.paperRecord.id,
+        authors: result.authorResults,
       },
     };
   } catch (err) {

--- a/src/lib/agent2/paper-import-executor.ts
+++ b/src/lib/agent2/paper-import-executor.ts
@@ -64,6 +64,17 @@ function normalizeName(name: string): string {
     .replace(/[\u0300-\u036f]/g, "");
 }
 
+/** 获取当前论文表中最大的 paper_id（数字）+1 */
+async function nextPaperId(paperTableId: string): Promise<string> {
+  const result = await db.$queryRawUnsafe<Array<{ max_id: string | null }>>(
+    `SELECT MAX(CAST(data->>'paper_id' AS INTEGER)) as max_id
+     FROM "DataRecord" WHERE "tableId" = $1`,
+    paperTableId
+  );
+  const maxId = result[0]?.max_id;
+  return maxId ? String(Number(maxId) + 1) : "1";
+}
+
 /** 按名称查找"作者"表和"论文"表 */
 async function findPaperAndAuthorTables(): Promise<{
   paperTableId: string;
@@ -158,7 +169,7 @@ export async function importPaper(
       data: {
         tableId: paperTableId,
         data: {
-          paper_id: `paper-${Date.now()}`,
+          paper_id: await nextPaperId(paperTableId),
           title_en: paperData.title_en,
           title_cn: paperData.title_cn ?? "",
           paper_type: paperData.paper_type ?? "",

--- a/src/lib/agent2/paper-import-executor.ts
+++ b/src/lib/agent2/paper-import-executor.ts
@@ -1,0 +1,231 @@
+// src/lib/agent2/paper-import-executor.ts
+import { db } from "@/lib/db";
+import type { Prisma } from "@/generated/prisma/client";
+import { syncRelationSubtableValues } from "@/lib/services/data-relation.service";
+import type { RelationSubtableValueItem } from "@/types/data-table";
+
+// ── Types ──
+
+export interface PaperInput {
+  title_en: string;
+  title_cn?: string;
+  paper_type?: "journal" | "conference";
+  group_name?: string;
+  publish_year?: number;
+  publish_date?: string;
+  conf_start_date?: string;
+  conf_end_date?: string;
+  venue_name?: string;
+  venue_name_cn?: string;
+  conf_location?: string;
+  doi?: string;
+  index_type?: string;
+  pub_status?: string;
+  archive_status?: string;
+  corr_authors?: string;
+  inst_rank?: number;
+  fund_no?: string;
+  paper_url?: string;
+  volume?: string;
+  issue?: string;
+  pages?: string;
+  impact_factor?: number;
+  issn_isbn?: string;
+  ccf_category?: string;
+  cas_partition?: string;
+  jcr_partition?: string;
+  sci_partition?: string;
+}
+
+export interface AuthorInput {
+  name: string;
+  author_order: number;
+  is_first_author: "Y" | "N";
+  is_corresponding_author: "Y" | "N";
+}
+
+export interface ImportResult {
+  paperId: string;
+  authors: Array<{
+    name: string;
+    status: "matched" | "created";
+    authorId: string;
+  }>;
+}
+
+// ── Helpers ──
+
+/** 标准化姓名：小写、去空格标点 */
+function normalizeName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[\s\-,.]+/g, "")
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "");
+}
+
+/** 按名称查找"作者"表和"论文"表 */
+async function findPaperAndAuthorTables(): Promise<{
+  paperTableId: string;
+  authorTableId: string;
+  authorsFieldId: string;
+} | null> {
+  const paperTable = await db.dataTable.findFirst({
+    where: { name: { contains: "论文" } },
+    include: { fields: true },
+  });
+  if (!paperTable) return null;
+
+  const authorsField = paperTable.fields.find(
+    (f) => f.key === "authors" && f.type === "RELATION_SUBTABLE"
+  );
+  if (!authorsField || !authorsField.relationTo) return null;
+
+  return {
+    paperTableId: paperTable.id,
+    authorTableId: authorsField.relationTo,
+    authorsFieldId: authorsField.id,
+  };
+}
+
+/** 在作者表中按标准化姓名匹配作者 */
+async function matchOrCreateAuthor(
+  authorTableId: string,
+  name: string,
+  userId: string
+): Promise<{ id: string; status: "matched" | "created" }> {
+  const norm = normalizeName(name);
+
+  const existing = await db.dataRecord.findFirst({
+    where: {
+      tableId: authorTableId,
+      OR: [
+        { data: { path: ["name_norm"], string_contains: norm } },
+        { data: { path: ["name_cn"], string_contains: norm } },
+        { data: { path: ["name_en"], string_contains: norm } },
+      ],
+    },
+  });
+
+  if (existing) {
+    return { id: existing.id, status: "matched" };
+  }
+
+  const record = await db.dataRecord.create({
+    data: {
+      tableId: authorTableId,
+      data: {
+        name_cn: name,
+        name_en: name,
+        name_norm: norm,
+      } as unknown as Prisma.InputJsonValue,
+      createdById: userId,
+    },
+  });
+
+  return { id: record.id, status: "created" };
+}
+
+// ── Main executor ──
+
+export async function importPaper(
+  paperData: PaperInput,
+  authors: AuthorInput[],
+  userId: string
+): Promise<{ success: true; data: ImportResult } | { success: false; error: string }> {
+  try {
+    const tables = await findPaperAndAuthorTables();
+    if (!tables) {
+      return { success: false, error: "未找到论文表或作者表，请确保已运行 seed-papers 初始化" };
+    }
+
+    const { paperTableId, authorTableId } = tables;
+
+    // 1. 匹配/创建所有作者
+    const authorResults: ImportResult["authors"] = [];
+
+    for (const author of authors) {
+      const result = await matchOrCreateAuthor(authorTableId, author.name, userId);
+      authorResults.push({
+        name: author.name,
+        status: result.status,
+        authorId: result.id,
+      });
+    }
+
+    // 2. 创建论文记录
+    const paperRecord = await db.dataRecord.create({
+      data: {
+        tableId: paperTableId,
+        data: {
+          paper_id: `paper-${Date.now()}`,
+          title_en: paperData.title_en,
+          title_cn: paperData.title_cn ?? "",
+          paper_type: paperData.paper_type ?? "",
+          group_name: paperData.group_name ?? "",
+          publish_year: paperData.publish_year ?? null,
+          publish_date: paperData.publish_date ?? "",
+          conf_start_date: paperData.conf_start_date ?? "",
+          conf_end_date: paperData.conf_end_date ?? "",
+          venue_name: paperData.venue_name ?? "",
+          venue_name_cn: paperData.venue_name_cn ?? "",
+          conf_location: paperData.conf_location ?? "",
+          doi: paperData.doi ?? "",
+          index_type: paperData.index_type ?? "",
+          pub_status: paperData.pub_status ?? "",
+          archive_status: paperData.archive_status ?? "",
+          corr_authors: paperData.corr_authors ?? "",
+          inst_rank: paperData.inst_rank ?? null,
+          fund_no: paperData.fund_no ?? "",
+          paper_url: paperData.paper_url ?? "",
+          volume: paperData.volume ?? "",
+          issue: paperData.issue ?? "",
+          pages: paperData.pages ?? "",
+          impact_factor: paperData.impact_factor ?? null,
+          issn_isbn: paperData.issn_isbn ?? "",
+          ccf_category: paperData.ccf_category ?? "",
+          cas_partition: paperData.cas_partition ?? "",
+          jcr_partition: paperData.jcr_partition ?? "",
+          sci_partition: paperData.sci_partition ?? "",
+        } as unknown as Prisma.InputJsonValue,
+        createdById: userId,
+      },
+    });
+
+    // 3. 建立论文-作者关联（RELATION_SUBTABLE）
+    if (authors.length > 0) {
+      const relationItems: RelationSubtableValueItem[] = authors.map((author, idx) => ({
+        targetRecordId: authorResults[idx].authorId,
+        displayValue: author.name,
+        attributes: {
+          author_order: author.author_order,
+          is_first_author: author.is_first_author,
+          is_corresponding_author: author.is_corresponding_author,
+        },
+        sortOrder: author.author_order,
+      }));
+
+      await db.$transaction(async (tx) => {
+        await syncRelationSubtableValues({
+          tx,
+          sourceRecordId: paperRecord.id,
+          tableId: paperTableId,
+          relationPayload: { authors: relationItems },
+        });
+      });
+    }
+
+    return {
+      success: true,
+      data: {
+        paperId: paperRecord.id,
+        authors: authorResults,
+      },
+    };
+  } catch (err) {
+    return {
+      success: false,
+      error: `导入论文失败: ${err instanceof Error ? err.message : "未知错误"}`,
+    };
+  }
+}

--- a/src/lib/agent2/tool-executor.ts
+++ b/src/lib/agent2/tool-executor.ts
@@ -1,5 +1,6 @@
 // src/lib/agent2/tool-executor.ts
 import * as helpers from "./tool-helpers";
+import { importPaper } from "./paper-import-executor";
 import { invalidateSchemaCache } from "./tool-helpers";
 import { invalidateSyspromptCache } from "./context-builder";
 import * as recordService from "@/lib/services/data-record.service";
@@ -135,6 +136,17 @@ export async function executeToolAction(
       if (!result.success)
         return { success: false, error: result.error.message, errorDetails: result.error };
       invalidateSchemaCache(toolInput.tableId as string);
+      invalidateSyspromptCache();
+      return { success: true, data: result.data };
+    }
+
+    case "importPaper": {
+      const paperData = toolInput.paperData as Parameters<typeof importPaper>[0];
+      const authors = toolInput.authors as Parameters<typeof importPaper>[1];
+      const result = await importPaper(paperData, authors, userId);
+      if (!result.success) {
+        return { success: false, error: result.error };
+      }
       invalidateSyspromptCache();
       return { success: true, data: result.data };
     }

--- a/src/lib/agent2/tools.ts
+++ b/src/lib/agent2/tools.ts
@@ -3,6 +3,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import * as helpers from "./tool-helpers";
 import { fetchPaperByDOI } from "./doi-service";
+import { fetchDetailPreview } from "./detail-preview";
 import { importPaper as executeImportPaper } from "./paper-import-executor";
 import {
   createConfirmToken,
@@ -143,6 +144,7 @@ export function createTools(
           toolName,
           toolInput: args,
           riskMessage: getRiskMessage(toolName),
+          detailPreview: await fetchDetailPreview(toolName, args),
         };
       },
     });

--- a/src/lib/agent2/tools.ts
+++ b/src/lib/agent2/tools.ts
@@ -9,8 +9,6 @@ import {
   getRiskMessage,
 } from "./confirm-store";
 
-type AutoConfirmMap = Record<string, boolean>;
-
 // ── ECharts option generator for generateChart ──
 
 function generateEChartsOption(args: {
@@ -115,13 +113,11 @@ function generateEChartsOption(args: {
 export function createTools(
   conversationId: string,
   messageId: string,
-  autoConfirm: AutoConfirmMap,
   userId?: string
 ) {
   // Helper to wrap tools that need confirmation
   function wrapConfirm<T>(
     toolName: string,
-    category: string,
     schema: z.ZodType<T>,
     description: string,
     executeFn: (args: T) => Promise<unknown>
@@ -130,12 +126,6 @@ export function createTools(
       description,
       inputSchema: schema,
       execute: async (args: T) => {
-        // Check auto-confirm for this category
-        const isAutoConfirmed = autoConfirm[category] === true;
-        if (isAutoConfirmed) {
-          return executeFn(args);
-        }
-
         // Create confirm token
         const tokenResult = await createConfirmToken(
           conversationId,
@@ -153,7 +143,6 @@ export function createTools(
           toolName,
           toolInput: args,
           riskMessage: getRiskMessage(toolName),
-          toolCategory: category,
         };
       },
     });
@@ -305,7 +294,6 @@ export function createTools(
 
     generateDocument: wrapConfirm(
       "generateDocument",
-      "write",
       z.object({
         templateId: z.string().describe("模板 ID"),
         formData: z
@@ -314,7 +302,6 @@ export function createTools(
       }),
       "根据模板和表单数据生成文档（需要确认）",
       async (args) => {
-        // Placeholder: actual generation will be implemented later
         return { message: "文档生成功能暂未完全实现", args };
       }
     ),
@@ -334,7 +321,6 @@ export function createTools(
 
     createRecord: wrapConfirm(
       "createRecord",
-      "write",
       z.object({
         tableId: z.string().describe("目标数据表 ID"),
         data: z
@@ -343,15 +329,12 @@ export function createTools(
       }),
       "在数据表中创建新记录（需要确认）",
       async (args) => {
-        // When auto-confirmed, we still need userId — this will be handled
-        // by the caller (tool-executor) when processing confirmed tokens
         return { message: "记录创建待确认", args };
       }
     ),
 
     updateRecord: wrapConfirm(
       "updateRecord",
-      "write",
       z.object({
         recordId: z.string().describe("要更新的记录 ID"),
         data: z
@@ -366,7 +349,6 @@ export function createTools(
 
     deleteRecord: wrapConfirm(
       "deleteRecord",
-      "delete",
       z.object({
         recordId: z.string().describe("要删除的记录 ID"),
       }),
@@ -379,7 +361,6 @@ export function createTools(
     // ── Batch operation tools ──
     batchCreateRecords: wrapConfirm(
       "batchCreateRecords",
-      "write",
       z.object({
         tableId: z.string().describe("目标数据表 ID"),
         records: z
@@ -395,7 +376,6 @@ export function createTools(
 
     batchUpdateRecords: wrapConfirm(
       "batchUpdateRecords",
-      "write",
       z.object({
         tableId: z.string().describe("目标数据表 ID"),
         updates: z
@@ -418,7 +398,6 @@ export function createTools(
 
     batchDeleteRecords: wrapConfirm(
       "batchDeleteRecords",
-      "delete",
       z.object({
         tableId: z.string().describe("目标数据表 ID"),
         recordIds: z
@@ -451,7 +430,6 @@ export function createTools(
 
     executeCode: wrapConfirm(
       "executeCode",
-      "execute",
       z.object({
         language: z
           .enum(["python", "javascript"])
@@ -534,7 +512,6 @@ export function createTools(
 
     importPaper: wrapConfirm(
       "importPaper",
-      "write",
       z.object({
         paperData: z.object({
           title_en: z.string().describe("英文标题"),

--- a/src/lib/agent2/tools.ts
+++ b/src/lib/agent2/tools.ts
@@ -2,6 +2,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import * as helpers from "./tool-helpers";
+import { fetchPaperByDOI } from "./doi-service";
 import {
   createConfirmToken,
   getRiskMessage,
@@ -487,5 +488,94 @@ export function createTools(
         return generateEChartsOption(args);
       },
     }),
+
+    // ── Paper import tools ──
+    parsePaperText: tool({
+      description:
+        "将用户输入的论文文本解析为结构化的论文元数据。当用户粘贴论文信息（标题、作者、年份等）时使用此工具。返回解析后的字段供用户确认。",
+      inputSchema: z.object({
+        rawText: z.string().describe("用户粘贴的论文信息原始文本"),
+      }),
+      execute: async (args) => {
+        return {
+          message: "请根据以下原始文本提取结构化论文信息，确保字段准确。提取后展示给用户确认。",
+          rawText: args.rawText,
+          fields: [
+            "title_en", "title_cn", "paper_type", "group_name",
+            "publish_year", "publish_date", "venue_name", "venue_name_cn",
+            "doi", "index_type", "volume", "issue", "pages",
+            "ccf_category", "cas_partition", "corr_authors",
+          ],
+          authorFields: ["name", "author_order", "is_first_author", "is_corresponding_author"],
+        };
+      },
+    }),
+
+    fetchPaperByDOI: tool({
+      description:
+        "通过 DOI 从 Crossref 学术数据库获取论文元数据。当用户提供 DOI 编号时使用此工具自动获取论文信息。",
+      inputSchema: z.object({
+        doi: z.string().describe("论文 DOI 编号，如 10.1038/nature14539"),
+      }),
+      execute: async (args) => {
+        const result = await fetchPaperByDOI(args.doi);
+        if (!result.success) {
+          return { error: result.error };
+        }
+        return {
+          paper: result.data,
+          message: "请将以上信息展示给用户确认，并根据需要补充 group_name、index_type 等本地字段。",
+        };
+      },
+    }),
+
+    importPaper: wrapConfirm(
+      "importPaper",
+      "write",
+      z.object({
+        paperData: z.object({
+          title_en: z.string().describe("英文标题"),
+          title_cn: z.string().optional().describe("中文标题"),
+          paper_type: z.enum(["journal", "conference"]).optional().describe("论文类型"),
+          group_name: z.string().optional().describe("组别"),
+          publish_year: z.number().optional().describe("发表年份"),
+          publish_date: z.string().optional().describe("发表日期"),
+          conf_start_date: z.string().optional().describe("会议开始日期"),
+          conf_end_date: z.string().optional().describe("会议结束日期"),
+          venue_name: z.string().optional().describe("期刊/会议名"),
+          venue_name_cn: z.string().optional().describe("期刊/会议中文名"),
+          conf_location: z.string().optional().describe("会议地点"),
+          doi: z.string().optional().describe("DOI"),
+          index_type: z.string().optional().describe("收录类型"),
+          pub_status: z.string().optional().describe("刊出状态"),
+          archive_status: z.string().optional().describe("归档状态"),
+          corr_authors: z.string().optional().describe("通讯作者"),
+          inst_rank: z.number().optional().describe("机构排名"),
+          fund_no: z.string().optional().describe("基金编号"),
+          paper_url: z.string().optional().describe("论文链接"),
+          volume: z.string().optional().describe("卷"),
+          issue: z.string().optional().describe("期"),
+          pages: z.string().optional().describe("页码"),
+          impact_factor: z.number().optional().describe("影响因子"),
+          issn_isbn: z.string().optional().describe("ISSN/ISBN"),
+          ccf_category: z.string().optional().describe("CCF分类"),
+          cas_partition: z.string().optional().describe("中科院分区"),
+          jcr_partition: z.string().optional().describe("JCR分区"),
+          sci_partition: z.string().optional().describe("SCI分区"),
+        }).describe("论文元数据"),
+        authors: z.array(
+          z.object({
+            name: z.string().describe("作者姓名"),
+            author_order: z.number().describe("作者顺序"),
+            is_first_author: z.enum(["Y", "N"]).describe("是否第一作者"),
+            is_corresponding_author: z.enum(["Y", "N"]).describe("是否通讯作者"),
+          })
+        ).describe("作者列表"),
+      }),
+      "导入论文到论文表（需要确认）",
+      async (args) => {
+        return { message: "论文导入待确认", args };
+      }
+    ),
   };
 }

--- a/src/lib/agent2/tools.ts
+++ b/src/lib/agent2/tools.ts
@@ -3,6 +3,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import * as helpers from "./tool-helpers";
 import { fetchPaperByDOI } from "./doi-service";
+import { importPaper as executeImportPaper } from "./paper-import-executor";
 import {
   createConfirmToken,
   getRiskMessage,
@@ -114,7 +115,8 @@ function generateEChartsOption(args: {
 export function createTools(
   conversationId: string,
   messageId: string,
-  autoConfirm: AutoConfirmMap
+  autoConfirm: AutoConfirmMap,
+  userId?: string
 ) {
   // Helper to wrap tools that need confirmation
   function wrapConfirm<T>(
@@ -151,6 +153,7 @@ export function createTools(
           toolName,
           toolInput: args,
           riskMessage: getRiskMessage(toolName),
+          toolCategory: category,
         };
       },
     });
@@ -574,7 +577,11 @@ export function createTools(
       }),
       "导入论文到论文表（需要确认）",
       async (args) => {
-        return { message: "论文导入待确认", args };
+        // auto-confirm 模式下直接执行导入
+        if (!userId) throw new Error("用户未登录");
+        const result = await executeImportPaper(args.paperData, args.authors, userId);
+        if (!result.success) throw new Error(result.error);
+        return result.data;
       }
     ),
   };

--- a/src/lib/services/agent2-message.service.ts
+++ b/src/lib/services/agent2-message.service.ts
@@ -5,12 +5,13 @@ import type { ServiceResult } from "@/types/data-table";
 
 export async function saveMessages(
   conversationId: string,
-  userMessage: { role: string; parts: unknown[]; attachments?: unknown },
-  assistantMessage: { role: string; parts: unknown[] }
+  userMessage: { id?: string; role: string; parts: unknown[]; attachments?: unknown },
+  assistantMessage: { id?: string; role: string; parts: unknown[] }
 ): Promise<ServiceResult<Agent2MessageItem[]>> {
   const [user, assistant] = await db.$transaction([
     db.agent2Message.create({
       data: {
+        ...(userMessage.id ? { id: userMessage.id } : {}),
         conversationId,
         role: userMessage.role,
         parts: userMessage.parts as Prisma.InputJsonValue,
@@ -21,6 +22,7 @@ export async function saveMessages(
     }),
     db.agent2Message.create({
       data: {
+        ...(assistantMessage.id ? { id: assistantMessage.id } : {}),
         conversationId,
         role: assistantMessage.role,
         parts: assistantMessage.parts as Prisma.InputJsonValue,

--- a/src/validators/agent2.ts
+++ b/src/validators/agent2.ts
@@ -24,6 +24,7 @@ export const chatRequestSchema = z.object({
 
 export const toolConfirmSchema = z.object({
   approved: z.boolean(),
+  toolCallId: z.string().optional(),
 });
 
 export const createModelSchema = z.object({


### PR DESCRIPTION
## Summary
- 注册论文导入工具链（parsePaperText, fetchPaperByDOI, importPaper），支持 DOI 查询、作者匹配/创建、论文-作者关联
- 重构确认流程：移除 auto-confirm，所有写/删操作强制确认
- 修复确认后 AI 重复调用工具的问题：chat route 改用客户端消息避免竞态条件
- importPaper 改为原子事务 + FOR UPDATE 锁防止 paper_id 并发重复
- confirm route 精确匹配 toolCallId 替代启发式匹配
- 确认对话框增加详情预取（detailPreview）和受控展开

## Test plan
- [x] 浏览器测试：删除论文 → AI 展示详情 → 用户确认 → AI 生成总结（不再重复调用工具）
- [ ] 测试论文导入流程
- [ ] 测试并发导入 paper_id 不重复

Closes #20