### PR TITLE
[Fix] 数据表单元格交互优化：单击选中 + 编辑后无刷新更新

### DIFF
--- a/src/components/data/record-table.tsx
+++ b/src/components/data/record-table.tsx
@@ -98,6 +98,7 @@ export function RecordTable({
     setColumnAggregations,
     deleteRecord,
     deletingIds,
+    updateRecordField,
     switchView,
     refresh,
   } = useTableData({ tableId, fields });
@@ -122,9 +123,9 @@ export function RecordTable({
         const data = await res.json();
         throw new Error(data.error ?? "保存失败");
       }
-      refresh();
+      updateRecordField(recordId, fieldKey, value);
     },
-    [tableId, refresh]
+    [tableId, updateRecordField]
   );
 
   // ── Filter change handler ────────────────────────────────────────────────
@@ -299,6 +300,7 @@ export function RecordTable({
             onDeleteRecord={deleteRecord}
             deletingIds={deletingIds}
             onRefresh={refresh}
+            onUpdateRecordField={updateRecordField}
             onOpenDetail={onOpenDetail}
             columnWidths={columnWidths}
             onColumnWidthsChange={handleColumnWidthsChange}

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -69,6 +69,7 @@ interface GridViewProps {
   onDeleteRecord: (recordId: string) => Promise<void>;
   deletingIds: Set<string>;
   onRefresh: () => void;
+  onUpdateRecordField: (recordId: string, fieldKey: string, value: unknown) => void;
   onOpenDetail?: (recordId: string) => void;
   onOpenFieldsConfig?: () => void;
   onDeleteField?: (fieldKey: string) => void;
@@ -233,6 +234,7 @@ export function GridView({
   onDeleteRecord,
   deletingIds,
   onRefresh,
+  onUpdateRecordField,
   onOpenDetail,
   columnWidths,
   onColumnWidthsChange,
@@ -624,9 +626,9 @@ export function GridView({
       if (!response.ok) {
         throw new Error("保存失败");
       }
-      onRefresh();
+      onUpdateRecordField(recordId, fieldKey, value);
     },
-    [tableId, onRefresh]
+    [tableId, onUpdateRecordField]
   );
 
   const handleCommitWithUndo = useCallback(
@@ -660,7 +662,12 @@ export function GridView({
       const entry = flatRecords[activeCell.rowIndex];
       if (entry?.type !== "record" || !entry.record) return;
       const field = orderedVisibleFields[activeCell.colIndex];
-      if (field && field.type !== FieldType.RELATION_SUBTABLE) {
+      if (!field || field.type === FieldType.RELATION_SUBTABLE) return;
+      if (field.type === FieldType.BOOLEAN) {
+        const currentValue = entry.record.data[field.key];
+        const newValue = !(!!currentValue && currentValue !== "false" && currentValue !== 0);
+        void handleCommitWithUndo(entry.record.id, field.key, newValue);
+      } else {
         startEditing(entry.record.id, field.key);
       }
     },
@@ -730,15 +737,26 @@ export function GridView({
     el?.scrollIntoView({ block: "nearest", inline: "nearest" });
   }, [stableActiveCell]);
 
-  // Click handler to set activeCell
+  // Click handler to set activeCell + boolean toggle
   const handleCellClick = useCallback(
     (rowIndex: number, colIndex: number, e: React.MouseEvent) => {
       const target = e.target as HTMLElement;
       if (target.closest('button, [role="checkbox"], input, select')) return;
       setActiveCell({ rowIndex, colIndex });
       tableRef.current?.focus();
+
+      // Boolean toggle on single click
+      const entry = flatRecords[rowIndex];
+      if (entry?.type === "record" && entry.record) {
+        const field = orderedVisibleFields[colIndex];
+        if (field?.type === FieldType.BOOLEAN) {
+          const currentValue = entry.record.data[field.key];
+          const newValue = !(!!currentValue && currentValue !== "false" && currentValue !== 0);
+          void handleCommitWithUndo(entry.record.id, field.key, newValue);
+        }
+      }
     },
-    [setActiveCell]
+    [setActiveCell, flatRecords, orderedVisibleFields, handleCommitWithUndo]
   );
 
   // ── Editor rendering ────────────────────────────────────────────────────
@@ -863,35 +881,17 @@ export function GridView({
         editingCell?.fieldKey === field.key;
 
       // RELATION_SUBTABLE does not support inline editing
-      const canEdit = field.type !== FieldType.RELATION_SUBTABLE
-        && field.type !== FieldType.AUTO_NUMBER
-        && field.type !== FieldType.SYSTEM_TIMESTAMP
-        && field.type !== FieldType.SYSTEM_USER
-        && field.type !== FieldType.FORMULA;
-
       if (isEditing) {
         return renderEditor(field, record);
       }
 
       return (
-        <span
-          className={`block truncate ${
-            canEdit ? "cursor-pointer hover:bg-muted/30 rounded px-1" : ""
-          }`}
-          onClick={
-            canEdit
-              ? (e: React.MouseEvent) => {
-                  e.stopPropagation();
-                  startEditing(record.id, field.key);
-                }
-              : undefined
-          }
-        >
+        <span className="block truncate px-1">
           {formatCellValue(field, record.data[field.key])}
         </span>
       );
     },
-    [editingCell, renderEditor, startEditing]
+    [editingCell, renderEditor]
   );
 
   // ── Per-record cell-level conditional format map ────────────────────────
@@ -974,6 +974,17 @@ export function GridView({
                   isActive && "ring-2 ring-primary ring-inset"
                 )}
                 onClick={(e) => handleCellClick(flatRowIndex, fieldIndex, e)}
+                onDoubleClick={() => {
+                  const canEdit = field.type !== FieldType.RELATION_SUBTABLE
+                    && field.type !== FieldType.AUTO_NUMBER
+                    && field.type !== FieldType.SYSTEM_TIMESTAMP
+                    && field.type !== FieldType.SYSTEM_USER
+                    && field.type !== FieldType.FORMULA
+                    && field.type !== FieldType.BOOLEAN;
+                  if (canEdit) {
+                    startEditing(record.id, field.key);
+                  }
+                }}
                 onContextMenu={(e) => captureCell(e, record.id, field.key, flatRowIndex, fieldIndex)}
               >
                 {renderCell(field, record)}
@@ -1041,6 +1052,7 @@ export function GridView({
       toggleRow,
       stableActiveCell,
       handleCellClick,
+      startEditing,
       recordStyles,
       cellRuleMapByRecord,
       captureRowHeader,

--- a/src/hooks/use-table-data.ts
+++ b/src/hooks/use-table-data.ts
@@ -49,6 +49,7 @@ export interface UseTableDataReturn {
   setColumnAggregations: (aggregations: Record<string, AggregateType>) => void;
   deleteRecord: (recordId: string) => Promise<void>;
   deletingIds: Set<string>;
+  updateRecordField: (recordId: string, fieldKey: string, value: unknown) => void;
   refresh: () => void;
 }
 
@@ -236,6 +237,23 @@ export function useTableData({
   const refresh = useCallback(() => {
     setRefreshTick((value) => value + 1);
   }, []);
+
+  const updateRecordField = useCallback(
+    (recordId: string, fieldKey: string, value: unknown) => {
+      setRecordsData((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          records: prev.records.map((record) =>
+            record.id === recordId
+              ? { ...record, data: { ...record.data, [fieldKey]: value } }
+              : record
+          ),
+        };
+      });
+    },
+    []
+  );
 
   const setFilters = useCallback((nextFilters: FilterGroup[]) => {
     setFiltersState(nextFilters);
@@ -534,6 +552,7 @@ export function useTableData({
     setColumnAggregations,
     deleteRecord,
     deletingIds,
+    updateRecordField,
     refresh,
   };
 }


### PR DESCRIPTION
## Summary

- 单击单元格改为选中（高亮），双击进入编辑模式，与 Airtable 交互一致
- 布尔字段单击/Enter 直接切换值，不走编辑流程
- 编辑后本地乐观更新（`updateRecordField`），不再触发全量数据刷新
- 消除编辑后的 loading 骨架屏闪烁、选中状态丢失和滚动位置重置

## Test plan

- [ ] 单击单元格仅选中（蓝色边框高亮），不进入编辑
- [ ] 双击单元格进入编辑模式
- [ ] 选中后按 Enter/F2 进入编辑
- [ ] 布尔字段单击直接切换勾选状态
- [ ] 编辑单元格提交后无 loading 闪烁，值立即更新
- [ ] 撤销/重做仍正常工作
- [ ] 右键菜单"编辑单元格"仍可正常进入编辑

Closes #43