### PR TITLE
[Feature] Tab/Enter 连续编辑：提交后自动跳到下一个单元格

### DIFF
--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -712,6 +712,53 @@ export function GridView({
       groupRowIndices.has(rowIndex),
     onUndo: () => void undoManager.undo(),
     onRedo: () => void undoManager.redo(),
+    onEditNavigate: (direction) => {
+      // Navigate synchronously — the cell editor's onCommit is already in flight
+      if (!stableActiveCell) return;
+      const { rowIndex, colIndex } = stableActiveCell;
+      const maxRow = flatRecords.length - 1;
+      const maxCol = orderedVisibleFields.length - 1;
+      let nextRow = rowIndex;
+      let nextCol = colIndex;
+
+      if (direction === "right") {
+        if (colIndex < maxCol) {
+          nextCol = colIndex + 1;
+        } else {
+          let r = rowIndex + 1;
+          while (r <= maxRow && groupRowIndices.has(r)) r++;
+          if (r <= maxRow) { nextRow = r; nextCol = 0; }
+        }
+      } else if (direction === "left") {
+        if (colIndex > 0) {
+          nextCol = colIndex - 1;
+        } else {
+          let r = rowIndex - 1;
+          while (r >= 0 && groupRowIndices.has(r)) r--;
+          if (r >= 0) { nextRow = r; nextCol = maxCol; }
+        }
+      } else if (direction === "down") {
+        let r = rowIndex + 1;
+        while (r <= maxRow && groupRowIndices.has(r)) r++;
+        if (r <= maxRow) nextRow = r;
+      }
+
+      if (nextRow !== rowIndex || nextCol !== colIndex) {
+        setActiveCell({ rowIndex: nextRow, colIndex: nextCol });
+        const entry = flatRecords[nextRow];
+        if (entry?.type === "record" && entry.record) {
+          const field = orderedVisibleFields[nextCol];
+          if (field && field.type !== FieldType.RELATION_SUBTABLE
+            && field.type !== FieldType.AUTO_NUMBER
+            && field.type !== FieldType.SYSTEM_TIMESTAMP
+            && field.type !== FieldType.SYSTEM_USER
+            && field.type !== FieldType.FORMULA
+            && field.type !== FieldType.BOOLEAN) {
+            startEditing(entry.record.id, field.key);
+          }
+        }
+      }
+    },
   });
 
   // Wrapper that syncs both ref and state

--- a/src/hooks/use-inline-edit.ts
+++ b/src/hooks/use-inline-edit.ts
@@ -29,26 +29,37 @@ export function useInlineEdit({
   const onCommitRef = useRef(onCommit);
   onCommitRef.current = onCommit;
 
+  // Ref guard prevents double-commits from stale closures (e.g. onBlur during navigation)
+  const isCommittingRef = useRef(false);
+
   const startEditing = useCallback((recordId: string, fieldKey: string) => {
     setEditingCell({ recordId, fieldKey });
   }, []);
 
   const commitEdit = useCallback(
     async (value: unknown) => {
-      if (!editingCell || isCommitting) return;
+      if (!editingCell || isCommittingRef.current) return;
 
+      const currentCell = editingCell;
+      isCommittingRef.current = true;
       setIsCommitting(true);
       try {
-        await onCommitRef.current(editingCell.recordId, editingCell.fieldKey, value);
-        setEditingCell(null);
+        await onCommitRef.current(currentCell.recordId, currentCell.fieldKey, value);
+        // Only clear if editingCell hasn't been changed by navigation
+        setEditingCell((prev) =>
+          prev?.recordId === currentCell.recordId && prev?.fieldKey === currentCell.fieldKey
+            ? null
+            : prev
+        );
       } catch (error) {
         console.error("内联编辑保存失败:", error);
         // Keep editing on error so user can retry
       } finally {
+        isCommittingRef.current = false;
         setIsCommitting(false);
       }
     },
-    [editingCell, isCommitting]
+    [editingCell]
   );
 
   const cancelEdit = useCallback(() => {

--- a/src/hooks/use-keyboard-nav.ts
+++ b/src/hooks/use-keyboard-nav.ts
@@ -20,6 +20,7 @@ interface UseKeyboardNavOptions {
   isGroupRow?: (rowIndex: number) => boolean;
   onUndo?: () => void;
   onRedo?: () => void;
+  onEditNavigate?: (direction: "left" | "right" | "down") => void;
 }
 
 export function useKeyboardNav({
@@ -35,6 +36,7 @@ export function useKeyboardNav({
   isGroupRow,
   onUndo,
   onRedo,
+  onEditNavigate,
 }: UseKeyboardNavOptions) {
   const activeCellRef = useRef<ActiveCell | null>(null);
 
@@ -67,7 +69,20 @@ export function useKeyboardNav({
         return;
       }
 
-      if (editingCell) return;
+      if (editingCell) {
+        // During editing, handle Tab/Enter for navigation after commit
+        if (e.key === "Tab") {
+          e.preventDefault();
+          onEditNavigate?.(e.shiftKey ? "left" : "right");
+          return;
+        }
+        if (e.key === "Enter") {
+          e.preventDefault();
+          onEditNavigate?.("down");
+          return;
+        }
+        return;
+      }
 
       const active = activeCellRef.current;
 
@@ -203,6 +218,7 @@ export function useKeyboardNav({
       skipGroupRow,
       onUndo,
       onRedo,
+      onEditNavigate,
     ]
   );
 


### PR DESCRIPTION
## Summary

- 编辑中按 Tab 提交当前值并自动跳到右侧单元格继续编辑
- 编辑中按 Shift+Tab 提交并跳到左侧单元格
- 编辑中按 Enter 提交并跳到下方单元格
- 行末自动换行到下一行首，分组视图自动跳过分组头行
- `useInlineEdit` 使用 ref 防止 onBlur 双重提交
- `useInlineEdit` 使用 functional state update 防止旧异步提交覆盖导航后的新编辑状态

## 技术要点

**事件流：**
1. Cell editor 的 onKeyDown 捕获 Tab/Enter → `e.preventDefault()` + `onCommit(draft)` 启动异步提交
2. 事件冒泡到 `<table>` 的 onKeyDown → `handleKeyDown` 检测到编辑中的 Tab/Enter
3. 调用 `onEditNavigate(direction)` → 同步设置 activeCell + startEditing 下一个单元格
4. 异步提交完成后，functional `setEditingCell` 检测到 editingCell 已变，不覆盖

**防双重提交：** `isCommittingRef`（ref 而非 state）确保 onBlur 等场景下的旧闭包也能正确读取到正在提交的状态。

## Test plan

- [ ] 编辑中按 Tab 提交并自动跳到右侧单元格继续编辑
- [ ] 编辑中按 Shift+Tab 提交并跳到左侧
- [ ] 编辑中按 Enter 提交并跳到下方
- [ ] 行末 Tab 自动换到下一行首
- [ ] 最后一行最后一列 Tab 不越界
- [ ] 分组视图下跳过分组头行
- [ ] 布尔/系统字段单元格仅选中不进入编辑
- [ ] 撤销/重做正常工作

Closes #44