### PR TITLE
[Feature] Shift+Space 快捷键打开记录详情抽屉

### DIFF
--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -759,6 +759,13 @@ export function GridView({
         }
       }
     },
+    onExpandRecord: () => {
+      if (!stableActiveCell) return;
+      const entry = flatRecords[stableActiveCell.rowIndex];
+      if (entry?.type === "record" && entry.record && onOpenDetail) {
+        onOpenDetail(entry.record.id);
+      }
+    },
   });
 
   // Wrapper that syncs both ref and state

--- a/src/hooks/use-keyboard-nav.ts
+++ b/src/hooks/use-keyboard-nav.ts
@@ -21,6 +21,7 @@ interface UseKeyboardNavOptions {
   onUndo?: () => void;
   onRedo?: () => void;
   onEditNavigate?: (direction: "left" | "right" | "down") => void;
+  onExpandRecord?: () => void;
 }
 
 export function useKeyboardNav({
@@ -37,6 +38,7 @@ export function useKeyboardNav({
   onUndo,
   onRedo,
   onEditNavigate,
+  onExpandRecord,
 }: UseKeyboardNavOptions) {
   const activeCellRef = useRef<ActiveCell | null>(null);
 
@@ -178,6 +180,12 @@ export function useKeyboardNav({
           onStartEdit();
           e.preventDefault();
           break;
+        case " ":
+          if (e.shiftKey) {
+            onExpandRecord?.();
+            e.preventDefault();
+          }
+          break;
         case "Escape":
           activeCellRef.current = null;
           onCancelEdit();
@@ -219,6 +227,7 @@ export function useKeyboardNav({
       onUndo,
       onRedo,
       onEditNavigate,
+      onExpandRecord,
     ]
   );
 


### PR DESCRIPTION
## Summary

- 选中单元格后按 `Shift+Space` 打开当前行的记录详情抽屉
- 分组视图下自动跳过分组头行，仅在数据行上触发

## Test plan

- [ ] 选中单元格后按 Shift+Space 打开记录详情抽屉
- [ ] 未选中单元格时按 Shift+Space 无反应
- [ ] 分组视图中分组头行上按 Shift+Space 无反应
- [ ] 抽屉中修改字段后网格数据同步更新

Closes #48