### PR TITLE
[Feature] 网格视图底部快捷新建行入口

### DIFF
--- a/src/app/api/data-tables/[id]/records/route.ts
+++ b/src/app/api/data-tables/[id]/records/route.ts
@@ -130,7 +130,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const body = await request.json();
     const validated = createRecordSchema.parse(body);
 
-    const result = await createRecord(user.id, id, validated.data);
+    const result = await createRecord(user.id, id, validated.data, {
+      skipRequiredValidation: validated.skipRequiredValidation,
+    });
 
     if (!result.success) {
       if (result.error.code === "NOT_FOUND") {

--- a/src/components/data/record-table.tsx
+++ b/src/components/data/record-table.tsx
@@ -99,6 +99,7 @@ export function RecordTable({
     deleteRecord,
     deletingIds,
     updateRecordField,
+    addRecord,
     switchView,
     refresh,
   } = useTableData({ tableId, fields });
@@ -301,6 +302,7 @@ export function RecordTable({
             deletingIds={deletingIds}
             onRefresh={refresh}
             onUpdateRecordField={updateRecordField}
+            onAddRecord={addRecord}
             onOpenDetail={onOpenDetail}
             columnWidths={columnWidths}
             onColumnWidthsChange={handleColumnWidthsChange}

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -3,7 +3,7 @@
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { ChevronDown, ChevronRight, Expand, GripVertical, Loader2, Redo2, Trash2, Undo2 } from "lucide-react";
+import { ChevronDown, ChevronRight, Expand, GripVertical, Loader2, Plus, Redo2, Trash2, Undo2 } from "lucide-react";
 import { BatchActionBar } from "@/components/data/batch-action-bar";
 import { BatchEditDialog } from "@/components/data/batch-edit-dialog";
 import { DragDropProvider } from "@dnd-kit/react";
@@ -70,6 +70,7 @@ interface GridViewProps {
   deletingIds: Set<string>;
   onRefresh: () => void;
   onUpdateRecordField: (recordId: string, fieldKey: string, value: unknown) => void;
+  onAddRecord: (record: DataRecordItem) => void;
   onOpenDetail?: (recordId: string) => void;
   onOpenFieldsConfig?: () => void;
   onDeleteField?: (fieldKey: string) => void;
@@ -235,6 +236,7 @@ export function GridView({
   deletingIds,
   onRefresh,
   onUpdateRecordField,
+  onAddRecord,
   onOpenDetail,
   columnWidths,
   onColumnWidthsChange,
@@ -777,6 +779,42 @@ export function GridView({
     },
     [setActiveCellRef, page]
   );
+
+  // ── Quick add row ────────────────────────────────────────────────────────
+  const handleQuickAddRow = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/data-tables/${tableId}/records`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ data: {} }),
+      });
+      if (!res.ok) {
+        toast.error("新建行失败");
+        return;
+      }
+      const record = (await res.json()) as DataRecordItem;
+      onAddRecord(record);
+      // Move activeCell to new row, start editing first editable field
+      const newRowIndex = flatRecords.length;
+      const firstEditableField = orderedVisibleFields.find(
+        (f) => f.type !== FieldType.RELATION_SUBTABLE
+          && f.type !== FieldType.AUTO_NUMBER
+          && f.type !== FieldType.SYSTEM_TIMESTAMP
+          && f.type !== FieldType.SYSTEM_USER
+          && f.type !== FieldType.FORMULA
+          && f.type !== FieldType.BOOLEAN
+      );
+      if (firstEditableField) {
+        const colIndex = orderedVisibleFields.indexOf(firstEditableField);
+        setTimeout(() => {
+          setActiveCell({ rowIndex: newRowIndex, colIndex });
+          startEditing(record.id, firstEditableField.key);
+        }, 0);
+      }
+    } catch {
+      toast.error("新建行失败");
+    }
+  }, [tableId, onAddRecord, flatRecords.length, orderedVisibleFields, setActiveCell, startEditing]);
 
   // When activeCell is set, remember which page it was on.
   // If page changed, activeCell becomes stale — use derived value instead.
@@ -1333,6 +1371,24 @@ export function GridView({
           ) : (
             // ── Flat rendering ────────────────────────────────────────────
             records.map((record, idx) => renderRecordRow(record, idx, idx))
+          )}
+          {!isLoading && records.length > 0 && isAdmin && (
+            <tr
+              className="border-b hover:bg-muted/30 cursor-pointer group"
+              onClick={handleQuickAddRow}
+            >
+              <td className="w-10 sticky left-0 z-[5] bg-background border-r" />
+              {canDragSort && <td className="w-8" />}
+              <td
+                colSpan={orderedVisibleFields.length + 1}
+                className="p-1 align-middle text-muted-foreground text-sm"
+              >
+                <span className="flex items-center gap-1.5 px-2 py-1 rounded hover:bg-muted/50 transition-colors">
+                  <Plus className="h-3.5 w-3.5" />
+                  <span className="opacity-60 group-hover:opacity-100 transition-opacity">新建行</span>
+                </span>
+              </td>
+            </tr>
           )}
           </DragDropProvider>
         </tbody>

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -786,7 +786,7 @@ export function GridView({
       const res = await fetch(`/api/data-tables/${tableId}/records`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ data: {} }),
+        body: JSON.stringify({ data: {}, skipRequiredValidation: true }),
       });
       if (!res.ok) {
         toast.error("新建行失败");

--- a/src/hooks/use-table-data.ts
+++ b/src/hooks/use-table-data.ts
@@ -50,6 +50,7 @@ export interface UseTableDataReturn {
   deleteRecord: (recordId: string) => Promise<void>;
   deletingIds: Set<string>;
   updateRecordField: (recordId: string, fieldKey: string, value: unknown) => void;
+  addRecord: (record: DataRecordItem) => void;
   refresh: () => void;
 }
 
@@ -249,6 +250,20 @@ export function useTableData({
               ? { ...record, data: { ...record.data, [fieldKey]: value } }
               : record
           ),
+        };
+      });
+    },
+    []
+  );
+
+  const addRecord = useCallback(
+    (record: DataRecordItem) => {
+      setRecordsData((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          records: [...prev.records, record],
+          total: prev.total + 1,
         };
       });
     },
@@ -553,6 +568,7 @@ export function useTableData({
     deleteRecord,
     deletingIds,
     updateRecordField,
+    addRecord,
     refresh,
   };
 }

--- a/src/lib/services/data-record.service.ts
+++ b/src/lib/services/data-record.service.ts
@@ -487,7 +487,8 @@ export async function getRecord(id: string): Promise<ServiceResult<DataRecordIte
 export async function createRecord(
   userId: string,
   tableId: string,
-  data: Record<string, unknown>
+  data: Record<string, unknown>,
+  options?: { skipRequiredValidation?: boolean }
 ): Promise<ServiceResult<DataRecordItem>> {
   try {
     // Get table and validate data against fields
@@ -496,9 +497,11 @@ export async function createRecord(
       return { success: false, error: tableResult.error };
     }
 
-    const validation = validateRecordData(data, tableResult.data.fields);
-    if (!validation.success) {
-      return validation;
+    if (!options?.skipRequiredValidation) {
+      const validation = validateRecordData(data, tableResult.data.fields);
+      if (!validation.success) {
+        return validation;
+      }
     }
 
     normalizeBooleanFields(data, tableResult.data.fields);

--- a/src/validators/data-table.ts
+++ b/src/validators/data-table.ts
@@ -86,6 +86,7 @@ export const recordQuerySchema = z.object({
 
 export const createRecordSchema = z.object({
   data: z.record(z.string(), z.unknown()),
+  skipRequiredValidation: z.boolean().optional().default(false),
 });
 
 export const updateRecordSchema = createRecordSchema;


### PR DESCRIPTION
## Summary

- 网格最后一行下方显示 `+ 新建行` 按钮（仅管理员可见）
- 点击后创建空记录，通过乐观更新（`addRecord`）直接追加到本地数据
- 自动聚焦第一个可编辑字段，进入内联编辑状态
- 保留现有的表单页面创建方式不受影响

## Test plan

- [ ] 管理员可见底部「+ 新建行」入口
- [ ] 点击后创建空记录并自动聚焦第一个可编辑字段
- [ ] 非管理员看不到新建行入口
- [ ] 无数据时显示"暂无记录"而非新建行
- [ ] 现有表单页面创建方式不受影响
- [ ] 新建行后撤销/重做正常

Closes #45