### PR TITLE
[Feature] 虚拟滚动替代分页，全量加载+自定义行窗口化

### DIFF
--- a/src/app/api/data-tables/[id]/records/route.ts
+++ b/src/app/api/data-tables/[id]/records/route.ts
@@ -25,8 +25,9 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   const { id } = await params;
   const searchParams = request.nextUrl.searchParams;
 
+  const hasPage = searchParams.has("page") || searchParams.has("pageSize");
   const page = parseInt(searchParams.get("page") || "1", 10);
-  const pageSize = parseInt(searchParams.get("pageSize") || "20", 10);
+  const pageSize = parseInt(searchParams.get("pageSize") || "10000", 10);
   const search = searchParams.get("search") || undefined;
 
   // P2: 解析字段筛选参数

--- a/src/components/data/record-table.tsx
+++ b/src/components/data/record-table.tsx
@@ -11,7 +11,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Download, Plus, X, ChevronsLeft, ChevronsRight } from "lucide-react";
+import { Download, Plus, X } from "lucide-react";
 import type {
   DataFieldItem,
   DataViewItem,
@@ -77,11 +77,7 @@ export function RecordTable({
   const {
     records,
     totalCount,
-    totalPages,
     isLoading,
-    page,
-    pageSize,
-    setPageSize,
     search,
     searchInput,
     setSearchInput,
@@ -244,25 +240,7 @@ export function RecordTable({
     [viewId, tableId, refresh]
   );
 
-  // ── Pagination href builder ──────────────────────────────────────────────
-  const buildPageHref = (nextPage: number) => {
-    const params = new URLSearchParams();
-    if (nextPage > 1) {
-      params.set("page", String(nextPage));
-    }
-    if (search) {
-      params.set("search", search);
-    }
-    if (viewId) {
-      params.set("viewId", viewId);
-    }
-    if (pageSize !== 20) {
-      params.set("pageSize", String(pageSize));
-    }
-
-    const query = params.toString();
-    return query ? `/data/${tableId}?${query}` : `/data/${tableId}`;
-  };
+  // ── Record count ──────────────────────────────────────────────────────
 
   // ── Empty state ──────────────────────────────────────────────────────────
   if (fields.length === 0) {
@@ -314,7 +292,6 @@ export function RecordTable({
             frozenFieldCount={frozenFieldCount}
             onFrozenFieldCountChange={handleFrozenFieldCountChange}
             viewId={viewId}
-            page={page}
             onReorderRecords={reorderRecords}
             conditionalFormatRules={conditionalFormatRules}
             onQuickFormat={(fieldKey, value) => {
@@ -468,15 +445,12 @@ export function RecordTable({
       {/* View content */}
       {renderView()}
 
-      {/* Pagination */}
-      <Pagination
-        page={page}
-        totalPages={Math.max(totalPages, 1)}
-        totalCount={totalCount}
-        pageSize={pageSize}
-        onPageSizeChange={setPageSize}
-        buildPageHref={buildPageHref}
-      />
+      {/* Record count */}
+      {!isLoading && (
+        <div className="text-sm text-zinc-500 flex-shrink-0">
+          共 {totalCount} 条
+        </div>
+      )}
 
       {/* Save View Dialog */}
       <SaveViewDialog
@@ -486,132 +460,6 @@ export function RecordTable({
         currentConfig={currentConfig}
         onSaved={switchView}
       />
-    </div>
-  );
-}
-
-// ─── Pagination Component ────────────────────────────────────────────────────
-
-/** Generate visible page number list with ellipsis */
-function getPageNumbers(current: number, total: number): (number | "ellipsis")[] {
-  if (total <= 7) {
-    return Array.from({ length: total }, (_, i) => i + 1);
-  }
-  const pages: (number | "ellipsis")[] = [1];
-  const left = Math.max(2, current - 1);
-  const right = Math.min(total - 1, current + 1);
-
-  if (left > 2) pages.push("ellipsis");
-  for (let i = left; i <= right; i++) pages.push(i);
-  if (right < total - 1) pages.push("ellipsis");
-  pages.push(total);
-  return pages;
-}
-
-const PAGE_SIZE_OPTIONS = [10, 20, 50, 100];
-
-function Pagination({
-  page,
-  totalPages,
-  totalCount,
-  pageSize,
-  onPageSizeChange,
-  buildPageHref,
-}: {
-  page: number;
-  totalPages: number;
-  totalCount: number;
-  pageSize: number;
-  onPageSizeChange: (ps: number) => void;
-  buildPageHref: (page: number) => string;
-}) {
-  const [jumpValue, setJumpValue] = useState("");
-  const router = useRouter();
-
-  const handleJump = () => {
-    const target = parseInt(jumpValue, 10);
-    if (Number.isFinite(target) && target >= 1 && target <= totalPages && target !== page) {
-      router.push(buildPageHref(target));
-    }
-    setJumpValue("");
-  };
-
-  const pages = getPageNumbers(page, totalPages);
-
-  return (
-    <div className="flex items-center justify-between text-sm text-zinc-500 flex-shrink-0">
-      <div className="flex items-center gap-2">
-        <span>共 {totalCount} 条</span>
-        <DropdownMenu>
-          <DropdownMenuTrigger
-            render={
-              <Button variant="outline" size="sm" className="h-8 gap-1">
-                {pageSize} 条/页
-              </Button>
-            }
-          />
-          <DropdownMenuContent align="start">
-            {PAGE_SIZE_OPTIONS.map((opt) => (
-              <DropdownMenuItem
-                key={opt}
-                onClick={() => onPageSizeChange(opt)}
-              >
-                {opt} 条/页
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-      <div className="flex items-center gap-1">
-        {/* First page */}
-        <Link href={buildPageHref(1)}>
-          <Button variant="outline" size="sm" className="h-8 px-2" disabled={page <= 1}>
-            <ChevronsLeft className="h-3.5 w-3.5" />
-          </Button>
-        </Link>
-        {/* Previous */}
-        <Link href={buildPageHref(page - 1)}>
-          <Button variant="outline" size="sm" disabled={page <= 1}>上一页</Button>
-        </Link>
-        {/* Page numbers */}
-        {pages.map((p, i) =>
-          p === "ellipsis" ? (
-            <span key={`e${i}`} className="px-1 text-muted-foreground select-none">…</span>
-          ) : (
-            <Link key={p} href={buildPageHref(p)}>
-              <Button
-                variant={p === page ? "default" : "outline"}
-                size="sm"
-                className="h-8 w-8 p-0"
-              >
-                {p}
-              </Button>
-            </Link>
-          )
-        )}
-        {/* Next */}
-        <Link href={buildPageHref(page + 1)}>
-          <Button variant="outline" size="sm" disabled={page >= totalPages}>下一页</Button>
-        </Link>
-        {/* Last page */}
-        <Link href={buildPageHref(totalPages)}>
-          <Button variant="outline" size="sm" className="h-8 px-2" disabled={page >= totalPages}>
-            <ChevronsRight className="h-3.5 w-3.5" />
-          </Button>
-        </Link>
-        {/* Jump to page */}
-        <div className="flex items-center gap-1 ml-2">
-          <span className="text-muted-foreground">跳至</span>
-          <Input
-            className="h-8 w-14 text-center text-sm"
-            value={jumpValue}
-            onChange={(e) => setJumpValue(e.target.value.replace(/\D/g, ""))}
-            onKeyDown={(e) => e.key === "Enter" && handleJump()}
-            placeholder={String(page)}
-          />
-          <span className="text-muted-foreground">页</span>
-        </div>
-      </div>
     </div>
   );
 }

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -25,6 +25,7 @@ import { useKeyboardNav, type ActiveCell } from "@/hooks/use-keyboard-nav";
 import { useUndoManager } from "@/hooks/use-undo-manager";
 import { cn } from "@/lib/utils";
 import { useSummaryRow } from "@/hooks/use-summary-row";
+import { useVirtualRows } from "@/hooks/use-virtual-rows";
 import {
   TextCellEditor,
   NumberCellEditor,
@@ -79,7 +80,6 @@ interface GridViewProps {
   frozenFieldCount?: number;
   onFrozenFieldCountChange?: (count: number) => void;
   viewId?: string | null;
-  page?: number;
   onReorderRecords?: (orderedIds: string[]) => void;
   conditionalFormatRules?: ConditionalFormatRule[];
   onQuickFormat?: (fieldKey: string, value: string) => void;
@@ -243,7 +243,6 @@ export function GridView({
   frozenFieldCount,
   onFrozenFieldCountChange,
   viewId,
-  page,
   onReorderRecords,
   conditionalFormatRules,
   onQuickFormat,
@@ -374,7 +373,6 @@ export function GridView({
 
   // ── Keyboard nav: active cell state (for rendering) ──────────────────────
   const [activeCell, setActiveCellState] = useState<ActiveCell | null>(null);
-  const [activeCellPage, setActiveCellPage] = useState(page);
 
   const toggleGroup = useCallback((groupValue: string) => {
     setCollapsedGroups((prev) => {
@@ -389,39 +387,19 @@ export function GridView({
   }, []);
 
   // ── Batch toggle handlers ─────────────────────────────────────────────
-  // selectedIds is scoped to current page; we store {page, ids} so page
-  // changes automatically clear the selection.
-  const [selectionState, setSelectionState] = useState<{
-    page: number | undefined;
-    ids: Set<string>;
-  }>({ page, ids: new Set() });
-
-  // Keep in sync with prop changes
-  const currentSelectedIds =
-    selectionState.page === page ? selectionState.ids : new Set<string>();
-  const updateSelectedIds = useCallback(
-    (updater: (prev: Set<string>) => Set<string>) => {
-      setSelectionState((prev) => ({
-        page,
-        ids: updater(prev.page === page ? prev.ids : new Set()),
-      }));
-    },
-    [page]
-  );
+  const [selectedIdsSet, setSelectedIdsSet] = useState<Set<string>>(new Set());
 
   const toggleAll = useCallback(() => {
-    const current =
-      selectionState.page === page ? selectionState.ids : new Set<string>();
-    if (current.size === records.length) {
-      updateSelectedIds(() => new Set());
+    if (selectedIdsSet.size === records.length) {
+      setSelectedIdsSet(new Set());
     } else {
-      updateSelectedIds(() => new Set(records.map((r) => r.id)));
+      setSelectedIdsSet(new Set(records.map((r) => r.id)));
     }
-  }, [records, page, selectionState, updateSelectedIds]);
+  }, [records, selectedIdsSet]);
 
   const toggleRow = useCallback(
     (recordId: string) => {
-      updateSelectedIds((prev) => {
+      setSelectedIdsSet((prev) => {
         const next = new Set(prev);
         if (next.has(recordId)) {
           next.delete(recordId);
@@ -431,10 +409,8 @@ export function GridView({
         return next;
       });
     },
-    [updateSelectedIds]
+    []
   );
-
-  const selectedIdsSet = currentSelectedIds;
 
   // ── Ordered visible fields ──────────────────────────────────────────────
   const fieldMap = useMemo(
@@ -484,7 +460,7 @@ export function GridView({
   const handleBatchDelete = useCallback(async () => {
     if (!confirm(`确定删除 ${selectedIdsSet.size} 条记录？`)) return;
     const ids = [...selectedIdsSet];
-    updateSelectedIds(() => new Set());
+    setSelectedIdsSet(new Set());
     const results = await Promise.allSettled(
       ids.map((id) =>
         fetch(`/api/data-tables/${tableId}/records/${id}`, {
@@ -497,13 +473,13 @@ export function GridView({
       alert(`${failedCount} 条记录删除失败，请重试`);
     }
     onRefresh();
-  }, [selectedIdsSet, tableId, onRefresh, updateSelectedIds]);
+  }, [selectedIdsSet, tableId, onRefresh]);
 
   // ── Batch edit handler ────────────────────────────────────────────────
   const handleBatchEdit = useCallback(
     async (fieldKey: string, value: unknown) => {
       const ids = [...selectedIdsSet];
-      updateSelectedIds(() => new Set());
+      setSelectedIdsSet(new Set());
       const BATCH_SIZE = 10;
       for (let i = 0; i < ids.length; i += BATCH_SIZE) {
         const batch = ids.slice(i, i + BATCH_SIZE);
@@ -519,7 +495,7 @@ export function GridView({
       }
       onRefresh();
     },
-    [selectedIdsSet, tableId, onRefresh, updateSelectedIds]
+    [selectedIdsSet, tableId, onRefresh]
   );
 
   // ── Column drag end handler ──────────────────────────────────────
@@ -582,15 +558,16 @@ export function GridView({
     return groupRecords(records, groupField);
   }, [groupField, records]);
 
-  // ── Flat records for keyboard nav (maps flat index → record or group) ────
+  // ── Virtual scrolling ────────────────────────────────────────────────────
   const flatRecords = useMemo(() => {
     if (groupedRecords) {
       const flat: Array<{
         type: "group" | "record";
         record?: DataRecordItem;
+        group?: { value: string; label: string; records: DataRecordItem[] };
       }> = [];
       for (const group of groupedRecords) {
-        flat.push({ type: "group" });
+        flat.push({ type: "group", group });
         if (!collapsedGroups.has(group.value)) {
           for (const r of group.records)
             flat.push({ type: "record", record: r });
@@ -600,6 +577,10 @@ export function GridView({
     }
     return records.map((r) => ({ type: "record" as const, record: r }));
   }, [groupedRecords, collapsedGroups, records]);
+
+  const { startIndex, endIndex, topPadding, bottomPadding, scrollRef } =
+    useVirtualRows(flatRecords.length);
+  const visibleFlatRecords = flatRecords.slice(startIndex, endIndex);
 
   // ── Group row indices (for skipping in keyboard nav) ─────────────────────
   const groupRowIndices = useMemo(() => {
@@ -775,9 +756,8 @@ export function GridView({
     (cell: ActiveCell | null) => {
       setActiveCellRef(cell);
       setActiveCellState(cell);
-      if (cell) setActiveCellPage(page);
     },
-    [setActiveCellRef, page]
+    [setActiveCellRef]
   );
 
   // ── Quick add row ────────────────────────────────────────────────────────
@@ -818,7 +798,7 @@ export function GridView({
 
   // When activeCell is set, remember which page it was on.
   // If page changed, activeCell becomes stale — use derived value instead.
-  const stableActiveCell = activeCell && activeCellPage === page ? activeCell : null;
+  const stableActiveCell = activeCell;
 
   // Auto-scroll on stableActiveCell change
   useEffect(() => {
@@ -1163,7 +1143,7 @@ export function GridView({
           selectedCount={selectedIdsSet.size}
           onBatchDelete={handleBatchDelete}
           onBatchEdit={() => setBatchEditOpen(true)}
-          onClearSelection={() => updateSelectedIds(() => new Set())}
+          onClearSelection={() => setSelectedIdsSet(new Set())}
         />
       )}
       <BatchEditDialog
@@ -1239,7 +1219,7 @@ export function GridView({
           <Redo2 className="h-3.5 w-3.5" />
         </Button>
       </div>
-      <div className="flex-1 min-h-0 overflow-auto">
+      <div className="flex-1 min-h-0 overflow-auto" ref={scrollRef}>
         <table
           className="w-full caption-bottom text-sm outline-none"
           style={{ tableLayout: "fixed" }}
@@ -1331,20 +1311,23 @@ export function GridView({
                 暂无记录
               </td>
             </tr>
-          ) : groupedRecords ? (
-            // ── Grouped rendering ────────────────────────────────────────
-            (() => {
-              let flatIdx = 0;
-              return groupedRecords.map((group) => {
-                const isCollapsed = collapsedGroups.has(group.value);
-                flatIdx += 1; // group header row
-                const startRecordFlatIdx = flatIdx;
-                if (!isCollapsed) {
-                  flatIdx += group.records.length;
-                }
-                return (
-                  <Fragment key={`group-${group.value}`}>
+          ) : (
+            <>
+              {/* Top padding for virtual scroll */}
+              {topPadding > 0 && (
+                <tr aria-hidden="true">
+                  <td colSpan={colCount} style={{ height: topPadding, padding: 0 }} />
+                </tr>
+              )}
+              {/* Visible rows only */}
+              {visibleFlatRecords.map((entry, visibleIdx) => {
+                const globalIdx = startIndex + visibleIdx;
+                if (entry.type === "group" && entry.group) {
+                  const group = entry.group;
+                  const isCollapsed = collapsedGroups.has(group.value);
+                  return (
                     <tr
+                      key={`group-${group.value}`}
                       className="border-b transition-colors bg-muted/50 hover:bg-muted/70 cursor-pointer select-none sticky top-[41px] z-[5]"
                       onClick={() => toggleGroup(group.value)}
                     >
@@ -1360,35 +1343,43 @@ export function GridView({
                         </div>
                       </td>
                     </tr>
-                    {!isCollapsed &&
-                      group.records.map((record, idx) =>
-                        renderRecordRow(record, idx, startRecordFlatIdx + idx)
-                      )}
-                  </Fragment>
-                );
-              });
-            })()
-          ) : (
-            // ── Flat rendering ────────────────────────────────────────────
-            records.map((record, idx) => renderRecordRow(record, idx, idx))
-          )}
-          {!isLoading && records.length > 0 && isAdmin && (
-            <tr
-              className="border-b hover:bg-muted/30 cursor-pointer group"
-              onClick={handleQuickAddRow}
-            >
-              <td className="w-10 sticky left-0 z-[5] bg-background border-r" />
-              {canDragSort && <td className="w-8" />}
-              <td
-                colSpan={orderedVisibleFields.length + 1}
-                className="p-1 align-middle text-muted-foreground text-sm"
-              >
-                <span className="flex items-center gap-1.5 px-2 py-1 rounded hover:bg-muted/50 transition-colors">
-                  <Plus className="h-3.5 w-3.5" />
-                  <span className="opacity-60 group-hover:opacity-100 transition-opacity">新建行</span>
-                </span>
-              </td>
-            </tr>
+                  );
+                }
+                if (entry.record) {
+                  return renderRecordRow(
+                    entry.record,
+                    visibleIdx,
+                    globalIdx
+                  );
+                }
+                return null;
+              })}
+              {/* Bottom padding for virtual scroll */}
+              {bottomPadding > 0 && (
+                <tr aria-hidden="true">
+                  <td colSpan={colCount} style={{ height: bottomPadding, padding: 0 }} />
+                </tr>
+              )}
+              {/* Quick add row */}
+              {isAdmin && (
+                <tr
+                  className="border-b hover:bg-muted/30 cursor-pointer group"
+                  onClick={handleQuickAddRow}
+                >
+                  <td className="w-10 sticky left-0 z-[5] bg-background border-r" />
+                  {canDragSort && <td className="w-8" />}
+                  <td
+                    colSpan={orderedVisibleFields.length + 1}
+                    className="p-1 align-middle text-muted-foreground text-sm"
+                  >
+                    <span className="flex items-center gap-1.5 px-2 py-1 rounded hover:bg-muted/50 transition-colors">
+                      <Plus className="h-3.5 w-3.5" />
+                      <span className="opacity-60 group-hover:opacity-100 transition-opacity">新建行</span>
+                    </span>
+                  </td>
+                </tr>
+              )}
+            </>
           )}
           </DragDropProvider>
         </tbody>

--- a/src/hooks/use-table-data.ts
+++ b/src/hooks/use-table-data.ts
@@ -18,18 +18,12 @@ import { useDebouncedCallback } from "@/hooks/use-debounce";
 export interface UseTableDataOptions {
   tableId: string;
   fields: DataFieldItem[];
-  pageSize?: number;
 }
 
 export interface UseTableDataReturn {
   records: DataRecordItem[];
   totalCount: number;
-  totalPages: number;
   isLoading: boolean;
-  page: number;
-  setPage: (p: number) => void;
-  pageSize: number;
-  setPageSize: (ps: number) => void;
   search: string;
   searchInput: string;
   setSearchInput: (v: string) => void;
@@ -56,38 +50,23 @@ export interface UseTableDataReturn {
   refresh: () => void;
 }
 
-function parsePageValue(value: string | null): number {
-  const page = Number.parseInt(value ?? "1", 10);
-  return Number.isFinite(page) && page > 0 ? page : 1;
-}
-
 function buildTablePath(tableId: string, params: URLSearchParams): string {
   const query = params.toString();
   return query ? `/data/${tableId}?${query}` : `/data/${tableId}`;
 }
 
 function buildQueryKey(
-  page: number,
-  pageSize: number,
   search: string,
   viewId: string | null,
   filters: FilterGroup[],
   sorts: SortConfig[]
 ): string {
-  return JSON.stringify({
-    page,
-    pageSize,
-    search,
-    viewId,
-    filters,
-    sorts,
-  });
+  return JSON.stringify({ search, viewId, filters, sorts });
 }
 
 export function useTableData({
   tableId,
   fields,
-  pageSize: defaultPageSize = 20,
 }: UseTableDataOptions): UseTableDataReturn {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -102,13 +81,6 @@ export function useTableData({
   const [viewId, setViewId] = useState<string | null>(
     searchParams.get("viewId") ?? null
   );
-  const [page, setPageState] = useState(() =>
-    parsePageValue(searchParams.get("page"))
-  );
-  const [pageSize, setPageSizeState] = useState(() => {
-    const ps = Number.parseInt(searchParams.get("pageSize") ?? "", 10);
-    return [10, 20, 50, 100].includes(ps) ? ps : defaultPageSize;
-  });
   const [views, setViews] = useState<DataViewItem[]>([]);
   const [isViewConfigReady, setIsViewConfigReady] = useState(
     () => searchParams.get("viewId") === null
@@ -129,8 +101,8 @@ export function useTableData({
   const latestFetchIdRef = useRef(0);
 
   const currentQueryKey = useMemo(
-    () => buildQueryKey(page, pageSize, search, viewId, filters, sorts),
-    [filters, page, pageSize, search, sorts, viewId]
+    () => buildQueryKey(search, viewId, filters, sorts),
+    [filters, search, sorts, viewId]
   );
   const latestQueryKeyRef = useRef(currentQueryKey);
 
@@ -141,10 +113,8 @@ export function useTableData({
   const syncUrlQuery = useCallback(
     (
       nextQuery: Partial<{
-        page: number;
         search: string;
         viewId: string | null;
-        pageSize: number;
       }>,
       mode: "push" | "replace"
     ) => {
@@ -168,24 +138,6 @@ export function useTableData({
         }
       }
 
-      if (Object.hasOwn(nextQuery, "page")) {
-        const nextPage = nextQuery.page ?? 1;
-        if (nextPage > 1) {
-          params.set("page", String(nextPage));
-        } else {
-          params.delete("page");
-        }
-      }
-
-      if (Object.hasOwn(nextQuery, "pageSize")) {
-        const nextPageSize = nextQuery.pageSize ?? 20;
-        if (nextPageSize !== 20) {
-          params.set("pageSize", String(nextPageSize));
-        } else {
-          params.delete("pageSize");
-        }
-      }
-
       const href = buildTablePath(tableId, params);
       if (mode === "replace") {
         router.replace(href, { scroll: false });
@@ -196,31 +148,10 @@ export function useTableData({
     [router, searchParams, tableId]
   );
 
-  const setPage = useCallback(
-    (nextPage: number) => {
-      const normalizedPage = Number.isFinite(nextPage)
-        ? Math.max(1, Math.trunc(nextPage))
-        : 1;
-      setPageState(normalizedPage);
-      syncUrlQuery({ page: normalizedPage }, "push");
-    },
-    [syncUrlQuery]
-  );
-
-  const setPageSize = useCallback(
-    (nextPageSize: number) => {
-      setPageSizeState(nextPageSize);
-      setPageState(1);
-      syncUrlQuery({ pageSize: nextPageSize, page: 1 }, "push");
-    },
-    [syncUrlQuery]
-  );
-
   const debouncedSyncSearch = useDebouncedCallback((value: unknown) => {
     const nextSearch = String(value ?? "");
     setSearch(nextSearch);
-    setPageState(1);
-    syncUrlQuery({ search: nextSearch, page: 1 }, "replace");
+    syncUrlQuery({ search: nextSearch }, "replace");
   }, 300);
 
   const setSearchInput = useCallback(
@@ -237,8 +168,7 @@ export function useTableData({
       setIsViewConfigReady(nextViewId === null);
       setIsLoading(true);
       setViewId(nextViewId);
-      setPageState(1);
-      syncUrlQuery({ viewId: nextViewId, page: 1 }, "push");
+      syncUrlQuery({ viewId: nextViewId }, "push");
     },
     [syncUrlQuery]
   );
@@ -331,11 +261,6 @@ export function useTableData({
       setIsLoading(true);
     }
     setViewId(nextViewId);
-    setPageState(parsePageValue(searchParams.get("page")));
-    const ps = Number.parseInt(searchParams.get("pageSize") ?? "", 10);
-    if ([10, 20, 50, 100].includes(ps)) {
-      setPageSizeState(ps);
-    }
   }, [searchParams, viewId]);
 
   useEffect(() => {
@@ -406,6 +331,7 @@ export function useTableData({
     };
   }, [defaultFieldKeys, tableId, viewId]);
 
+  // ── Fetch all records (no pagination) ──────────────────────────────────────
   const fetchData = useCallback(async () => {
     if (!isViewConfigReady) return;
 
@@ -414,10 +340,7 @@ export function useTableData({
     setIsLoading(true);
 
     try {
-      const params = new URLSearchParams({
-        page: String(page),
-        pageSize: String(pageSize),
-      });
+      const params = new URLSearchParams();
 
       if (search) params.set("search", search);
       if (viewId) params.set("viewId", viewId);
@@ -453,8 +376,6 @@ export function useTableData({
   }, [
     filters,
     isViewConfigReady,
-    page,
-    pageSize,
     search,
     sorts,
     tableId,
@@ -571,12 +492,7 @@ export function useTableData({
   return {
     records: recordsData?.records ?? [],
     totalCount: recordsData?.total ?? 0,
-    totalPages: recordsData?.totalPages ?? 1,
     isLoading,
-    page,
-    setPage,
-    pageSize,
-    setPageSize,
     search,
     searchInput: searchInputState,
     setSearchInput,

--- a/src/hooks/use-virtual-rows.ts
+++ b/src/hooks/use-virtual-rows.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+const ROW_HEIGHT = 40; // px, matches h-10 tailwind class
+const BUFFER = 5; // extra rows above/below viewport
+
+export interface VirtualRowsResult {
+  startIndex: number;
+  endIndex: number;
+  topPadding: number;
+  bottomPadding: number;
+  scrollRef: React.RefObject<HTMLDivElement | null>;
+}
+
+export function useVirtualRows(
+  totalRows: number,
+  containerHeight?: number
+): VirtualRowsResult {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setScrollTop(el.scrollTop);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.addEventListener("scroll", handleScroll, { passive: true });
+    return () => el.removeEventListener("scroll", handleScroll);
+  }, [handleScroll]);
+
+  // Re-calc on totalRows change (e.g. data loaded)
+  const { startIndex, endIndex, topPadding, bottomPadding } = useMemo(() => {
+    const viewportHeight =
+      scrollRef.current?.clientHeight ?? containerHeight ?? 600;
+    const maxVisible = Math.ceil(viewportHeight / ROW_HEIGHT);
+
+    const rawStart = Math.floor(scrollTop / ROW_HEIGHT);
+    const rawEnd = rawStart + maxVisible;
+
+    const start = Math.max(0, rawStart - BUFFER);
+    const end = Math.min(totalRows, rawEnd + BUFFER);
+
+    return {
+      startIndex: start,
+      endIndex: end,
+      topPadding: start * ROW_HEIGHT,
+      bottomPadding: Math.max(0, (totalRows - end) * ROW_HEIGHT),
+    };
+  }, [scrollTop, totalRows, containerHeight]);
+
+  return { startIndex, endIndex, topPadding, bottomPadding, scrollRef };
+}


### PR DESCRIPTION
## Summary
- 移除分页机制，改为一次性加载全部记录
- 新增 `use-virtual-rows.ts` hook，根据滚动位置只渲染可视区域行（~30行）
- 上下用占位 `<tr>` 维持完整滚动高度
- 移除 Pagination 组件及相关状态

## Test plan
- [x] 全量加载 165 条记录，无分页 UI
- [x] 虚拟滚动 DOM 只渲染可见行
- [x] 滚动后正确渲染新行
- [x] 双击编辑正常
- [x] "+ 新建行" 按钮正常
- [x] 零控制台错误

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)