### PR TITLE
[Feature] 多单元格区域选择和批量复制粘贴

### DIFF
--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -21,7 +21,7 @@ import type {
 import { ColumnHeader } from "@/components/data/column-header";
 import { formatCellValue } from "@/lib/format-cell";
 import { useInlineEdit } from "@/hooks/use-inline-edit";
-import { useKeyboardNav, type ActiveCell } from "@/hooks/use-keyboard-nav";
+import { useKeyboardNav, type ActiveCell, type CellRange } from "@/hooks/use-keyboard-nav";
 import { useUndoManager } from "@/hooks/use-undo-manager";
 import { cn } from "@/lib/utils";
 import { useSummaryRow } from "@/hooks/use-summary-row";
@@ -635,7 +635,8 @@ export function GridView({
     useInlineEdit({ tableId, onCommit: handleCommitWithUndo });
 
   // ── Keyboard navigation ──────────────────────────────────────────────────
-  const { handleKeyDown, setActiveCell: setActiveCellRef } = useKeyboardNav({
+  const [selectionRange, setSelectionRangeState] = useState<CellRange | null>(null);
+  const { handleKeyDown, setActiveCell: setActiveCellRef, setSelectionRange: setSelectionRangeRef } = useKeyboardNav({
     rowCount: flatRecords.length,
     colCount: orderedVisibleFields.length,
     editingCell,
@@ -690,6 +691,46 @@ export function GridView({
         field.key,
         field.type === FieldType.NUMBER ? Number(text) : text
       );
+    },
+    onCopyRange: (range: CellRange) => {
+      const minRow = Math.min(range.startRow, range.endRow);
+      const maxRow = Math.max(range.startRow, range.endRow);
+      const minCol = Math.min(range.startCol, range.endCol);
+      const maxCol = Math.max(range.startCol, range.endCol);
+      const lines: string[] = [];
+      for (let r = minRow; r <= maxRow; r++) {
+        const entry = flatRecords[r];
+        if (entry?.type !== "record" || !entry.record) { lines.push(""); continue; }
+        const cells: string[] = [];
+        for (let c = minCol; c <= maxCol; c++) {
+          const field = orderedVisibleFields[c];
+          cells.push(field ? String(entry.record.data[field.key] ?? "") : "");
+        }
+        lines.push(cells.join("\t"));
+      }
+      navigator.clipboard.writeText(lines.join("\n"));
+    },
+    onPasteRange: (text: string, startRow: number, startCol: number) => {
+      const rows = text.split(/\r?\n/).filter(line => line.length > 0);
+      const parsed = rows.map(row => row.split("\t"));
+      for (let dr = 0; dr < parsed.length; dr++) {
+        const targetRow = startRow + dr;
+        const entry = flatRecords[targetRow];
+        if (!entry || entry.type !== "record" || !entry.record) continue;
+        for (let dc = 0; dc < parsed[dr].length; dc++) {
+          const targetCol = startCol + dc;
+          const field = orderedVisibleFields[targetCol];
+          if (!field) continue;
+          if (field.type === FieldType.RELATION_SUBTABLE || field.type === FieldType.AUTO_NUMBER || field.type === FieldType.SYSTEM_TIMESTAMP || field.type === FieldType.SYSTEM_USER || field.type === FieldType.FORMULA) continue;
+          const rawValue = parsed[dr][dc];
+          const value = field.type === FieldType.NUMBER ? Number(rawValue) : rawValue;
+          if (field.type === FieldType.NUMBER && isNaN(value as number)) continue;
+          handleCommit(entry.record.id, field.key, value);
+        }
+      }
+    },
+    onSelectionChange: (range: CellRange | null) => {
+      setSelectionRangeState(range);
     },
     isGroupRow: (rowIndex: number) =>
       groupRowIndices.has(rowIndex),
@@ -814,21 +855,39 @@ export function GridView({
     (rowIndex: number, colIndex: number, e: React.MouseEvent) => {
       const target = e.target as HTMLElement;
       if (target.closest('button, [role="checkbox"], input, select')) return;
-      setActiveCell({ rowIndex, colIndex });
+
+      if (e.shiftKey && stableActiveCell) {
+        // Shift+click: extend selection
+        e.preventDefault();
+        const range: CellRange = {
+          startRow: stableActiveCell.rowIndex,
+          startCol: stableActiveCell.colIndex,
+          endRow: rowIndex,
+          endCol: colIndex,
+        };
+        setSelectionRangeRef(range);
+        setSelectionRangeState(range);
+      } else {
+        setActiveCell({ rowIndex, colIndex });
+        setSelectionRangeRef(null);
+        setSelectionRangeState(null);
+      }
       tableRef.current?.focus();
 
-      // Boolean toggle on single click
-      const entry = flatRecords[rowIndex];
-      if (entry?.type === "record" && entry.record) {
-        const field = orderedVisibleFields[colIndex];
-        if (field?.type === FieldType.BOOLEAN) {
-          const currentValue = entry.record.data[field.key];
-          const newValue = !(!!currentValue && currentValue !== "false" && currentValue !== 0);
-          void handleCommitWithUndo(entry.record.id, field.key, newValue);
+      // Boolean toggle on single click (only without Shift)
+      if (!e.shiftKey) {
+        const entry = flatRecords[rowIndex];
+        if (entry?.type === "record" && entry.record) {
+          const field = orderedVisibleFields[colIndex];
+          if (field?.type === FieldType.BOOLEAN) {
+            const currentValue = entry.record.data[field.key];
+            const newValue = !(!!currentValue && currentValue !== "false" && currentValue !== 0);
+            void handleCommitWithUndo(entry.record.id, field.key, newValue);
+          }
         }
       }
     },
-    [setActiveCell, flatRecords, orderedVisibleFields, handleCommitWithUndo]
+    [setActiveCell, setSelectionRangeRef, stableActiveCell, flatRecords, orderedVisibleFields, handleCommitWithUndo]
   );
 
   // ── Editor rendering ────────────────────────────────────────────────────
@@ -1026,6 +1085,11 @@ export function GridView({
             const isActive =
               stableActiveCell?.rowIndex === flatRowIndex &&
               stableActiveCell?.colIndex === fieldIndex;
+            const isInRange = selectionRange &&
+              flatRowIndex >= Math.min(selectionRange.startRow, selectionRange.endRow) &&
+              flatRowIndex <= Math.max(selectionRange.startRow, selectionRange.endRow) &&
+              fieldIndex >= Math.min(selectionRange.startCol, selectionRange.endCol) &&
+              fieldIndex <= Math.max(selectionRange.startCol, selectionRange.endCol);
             const cellStyle = cellRuleMap[field.key];
             const mergedStyle: React.CSSProperties = {
               ...(frozenTdStyle ?? {}),
@@ -1043,7 +1107,8 @@ export function GridView({
                   frozenFieldCountValue > 0 &&
                     fieldIndex === frozenFieldCountValue - 1 &&
                     "frozen-last-col relative",
-                  isActive && "ring-2 ring-primary ring-inset"
+                  isActive && "ring-2 ring-primary ring-inset",
+                  isInRange && !isActive && "bg-primary/20 ring-1 ring-inset ring-primary/40"
                 )}
                 onClick={(e) => handleCellClick(flatRowIndex, fieldIndex, e)}
                 onDoubleClick={() => {
@@ -1221,7 +1286,7 @@ export function GridView({
       </div>
       <div className="flex-1 min-h-0 overflow-auto" ref={scrollRef}>
         <table
-          className="w-full caption-bottom text-sm outline-none"
+          className="w-full caption-bottom text-sm outline-none select-none"
           style={{ tableLayout: "fixed" }}
           ref={tableRef}
           tabIndex={0}

--- a/src/hooks/use-keyboard-nav.ts
+++ b/src/hooks/use-keyboard-nav.ts
@@ -7,6 +7,13 @@ export interface ActiveCell {
   colIndex: number;
 }
 
+export interface CellRange {
+  startRow: number;
+  startCol: number;
+  endRow: number;
+  endCol: number;
+}
+
 interface UseKeyboardNavOptions {
   rowCount: number;
   colCount: number;
@@ -17,6 +24,9 @@ interface UseKeyboardNavOptions {
   onClearCell: () => void;
   onCopyCell: () => string | null;
   onPasteCell: (text: string) => void;
+  onCopyRange?: (range: CellRange) => void;
+  onPasteRange?: (text: string, startRow: number, startCol: number) => void;
+  onSelectionChange?: (range: CellRange | null) => void;
   isGroupRow?: (rowIndex: number) => boolean;
   onUndo?: () => void;
   onRedo?: () => void;
@@ -34,6 +44,9 @@ export function useKeyboardNav({
   onClearCell,
   onCopyCell,
   onPasteCell,
+  onCopyRange,
+  onPasteRange,
+  onSelectionChange,
   isGroupRow,
   onUndo,
   onRedo,
@@ -41,10 +54,16 @@ export function useKeyboardNav({
   onExpandRecord,
 }: UseKeyboardNavOptions) {
   const activeCellRef = useRef<ActiveCell | null>(null);
+  const selectionRangeRef = useRef<CellRange | null>(null);
 
   const setActiveCell = useCallback((cell: ActiveCell | null) => {
     activeCellRef.current = cell;
   }, []);
+
+  const setSelectionRange = useCallback((range: CellRange | null) => {
+    selectionRangeRef.current = range;
+    onSelectionChange?.(range);
+  }, [onSelectionChange]);
 
   const skipGroupRow = useCallback(
     (targetRow: number, direction: 1 | -1): number => {
@@ -72,7 +91,6 @@ export function useKeyboardNav({
       }
 
       if (editingCell) {
-        // During editing, handle Tab/Enter for navigation after commit
         if (e.key === "Tab") {
           e.preventDefault();
           onEditNavigate?.(e.shiftKey ? "left" : "right");
@@ -104,12 +122,20 @@ export function useKeyboardNav({
 
       const maxRow = rowCount - 1;
       const maxCol = colCount - 1;
+      const shift = e.shiftKey;
 
       switch (e.key) {
         case "ArrowUp": {
           const next = skipGroupRow(active.rowIndex - 1, -1);
           if (next >= 0) {
             activeCellRef.current = { ...active, rowIndex: next };
+            if (shift) {
+              const range = selectionRangeRef.current ?? { startRow: active.rowIndex, startCol: active.colIndex, endRow: active.rowIndex, endCol: active.colIndex };
+              selectionRangeRef.current = { ...range, endRow: next };
+              onSelectionChange?.(selectionRangeRef.current);
+            } else {
+              setSelectionRange(null);
+            }
             onMoveTo(activeCellRef.current);
           }
           e.preventDefault();
@@ -119,6 +145,13 @@ export function useKeyboardNav({
           const next = skipGroupRow(active.rowIndex + 1, 1);
           if (next <= maxRow) {
             activeCellRef.current = { ...active, rowIndex: next };
+            if (shift) {
+              const range = selectionRangeRef.current ?? { startRow: active.rowIndex, startCol: active.colIndex, endRow: active.rowIndex, endCol: active.colIndex };
+              selectionRangeRef.current = { ...range, endRow: next };
+              onSelectionChange?.(selectionRangeRef.current);
+            } else {
+              setSelectionRange(null);
+            }
             onMoveTo(activeCellRef.current);
           }
           e.preventDefault();
@@ -126,47 +159,50 @@ export function useKeyboardNav({
         }
         case "ArrowRight":
           if (active.colIndex < maxCol) {
-            activeCellRef.current = {
-              ...active,
-              colIndex: active.colIndex + 1,
-            };
+            activeCellRef.current = { ...active, colIndex: active.colIndex + 1 };
           } else if (active.rowIndex < maxRow) {
             const next = skipGroupRow(active.rowIndex + 1, 1);
             activeCellRef.current = { rowIndex: next, colIndex: 0 };
+          }
+          if (shift) {
+            const range = selectionRangeRef.current ?? { startRow: active.rowIndex, startCol: active.colIndex, endRow: active.rowIndex, endCol: active.colIndex };
+            selectionRangeRef.current = { ...range, endRow: activeCellRef.current!.rowIndex, endCol: activeCellRef.current!.colIndex };
+            onSelectionChange?.(selectionRangeRef.current);
+          } else {
+            setSelectionRange(null);
           }
           onMoveTo(activeCellRef.current!);
           e.preventDefault();
           break;
         case "ArrowLeft":
           if (active.colIndex > 0) {
-            activeCellRef.current = {
-              ...active,
-              colIndex: active.colIndex - 1,
-            };
+            activeCellRef.current = { ...active, colIndex: active.colIndex - 1 };
           } else if (active.rowIndex > 0) {
             const next = skipGroupRow(active.rowIndex - 1, -1);
             activeCellRef.current = { rowIndex: next, colIndex: maxCol };
+          }
+          if (shift) {
+            const range = selectionRangeRef.current ?? { startRow: active.rowIndex, startCol: active.colIndex, endRow: active.rowIndex, endCol: active.colIndex };
+            selectionRangeRef.current = { ...range, endRow: activeCellRef.current!.rowIndex, endCol: activeCellRef.current!.colIndex };
+            onSelectionChange?.(selectionRangeRef.current);
+          } else {
+            setSelectionRange(null);
           }
           onMoveTo(activeCellRef.current!);
           e.preventDefault();
           break;
         case "Tab":
+          setSelectionRange(null);
           if (e.shiftKey) {
             if (active.colIndex > 0) {
-              activeCellRef.current = {
-                ...active,
-                colIndex: active.colIndex - 1,
-              };
+              activeCellRef.current = { ...active, colIndex: active.colIndex - 1 };
             } else if (active.rowIndex > 0) {
               const next = skipGroupRow(active.rowIndex - 1, -1);
               activeCellRef.current = { rowIndex: next, colIndex: maxCol };
             }
           } else {
             if (active.colIndex < maxCol) {
-              activeCellRef.current = {
-                ...active,
-                colIndex: active.colIndex + 1,
-              };
+              activeCellRef.current = { ...active, colIndex: active.colIndex + 1 };
             } else if (active.rowIndex < maxRow) {
               const next = skipGroupRow(active.rowIndex + 1, 1);
               activeCellRef.current = { rowIndex: next, colIndex: 0 };
@@ -177,6 +213,7 @@ export function useKeyboardNav({
           break;
         case "Enter":
         case "F2":
+          setSelectionRange(null);
           onStartEdit();
           e.preventDefault();
           break;
@@ -188,6 +225,7 @@ export function useKeyboardNav({
           break;
         case "Escape":
           activeCellRef.current = null;
+          setSelectionRange(null);
           onCancelEdit();
           e.preventDefault();
           break;
@@ -198,15 +236,28 @@ export function useKeyboardNav({
           break;
         default:
           if ((e.ctrlKey || e.metaKey) && e.key === "c") {
-            const text = onCopyCell();
-            if (text !== null) navigator.clipboard.writeText(text);
+            const range = selectionRangeRef.current;
+            if (range && onCopyRange) {
+              onCopyRange(range);
+            } else {
+              const text = onCopyCell();
+              if (text !== null) navigator.clipboard.writeText(text);
+            }
             e.preventDefault();
           }
           if ((e.ctrlKey || e.metaKey) && e.key === "v") {
             navigator.clipboard
               .readText()
               .then((text) => {
-                if (text) onPasteCell(text);
+                if (!text) return;
+                const range = selectionRangeRef.current;
+                if (range && onPasteRange) {
+                  onPasteRange(text, Math.min(range.startRow, range.endRow), Math.min(range.startCol, range.endCol));
+                } else if (onPasteRange && activeCellRef.current) {
+                  onPasteRange(text, activeCellRef.current.rowIndex, activeCellRef.current.colIndex);
+                } else {
+                  onPasteCell(text);
+                }
               })
               .catch(() => {});
             e.preventDefault();
@@ -214,22 +265,12 @@ export function useKeyboardNav({
       }
     },
     [
-      editingCell,
-      rowCount,
-      colCount,
-      onMoveTo,
-      onStartEdit,
-      onCancelEdit,
-      onClearCell,
-      onCopyCell,
-      onPasteCell,
-      skipGroupRow,
-      onUndo,
-      onRedo,
-      onEditNavigate,
-      onExpandRecord,
+      editingCell, rowCount, colCount, onMoveTo, onStartEdit, onCancelEdit,
+      onClearCell, onCopyCell, onPasteCell, onCopyRange, onPasteRange,
+      onSelectionChange, skipGroupRow, onUndo, onRedo, onEditNavigate,
+      onExpandRecord, setSelectionRange,
     ]
   );
 
-  return { handleKeyDown, setActiveCell };
+  return { handleKeyDown, setActiveCell, setSelectionRange };
 }


### PR DESCRIPTION
## Summary
- 支持 Shift+方向键/Shift+点击选中矩形区域（高亮显示）
- 支持 Ctrl+C 批量复制选区为 TSV 格式（与 Excel 兼容）
- 支持 Ctrl+V 从剪贴板粘贴 TSV 数据到表格区域
- 扩展 `use-keyboard-nav` hook 支持 CellRange 选区状态和回调

## Test plan
- [x] Shift+Arrow 选中区域并高亮
- [x] Shift+Click 选中区域并高亮
- [x] Ctrl+C 复制选区为 TSV
- [x] Ctrl+V 粘贴 TSV 到正确位置
- [ ] 从 Excel 粘贴多行数据
- [ ] 单元格复制/粘贴仍正常
- [ ] 双击编辑不受影响

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)