### PR TITLE
[Feature] 支持行高调整四档

### DIFF
--- a/src/components/data/record-table.tsx
+++ b/src/components/data/record-table.tsx
@@ -11,7 +11,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Download, Plus, X } from "lucide-react";
+import { ArrowUpDown, Download, Plus, X } from "lucide-react";
 import type {
   DataFieldItem,
   DataViewItem,
@@ -219,6 +219,15 @@ export function RecordTable({
     [currentConfig.viewOptions, setViewOptions]
   );
 
+  const rowHeight = (currentConfig.viewOptions.rowHeight as number) ?? 40;
+
+  const handleRowHeightChange = useCallback(
+    (h: number) => {
+      setViewOptions({ ...currentConfig.viewOptions, rowHeight: h });
+    },
+    [currentConfig.viewOptions, setViewOptions]
+  );
+
   // ── Row reorder ────────────────────────────────────────────────────────
   const reorderRecords = useCallback(
     async (orderedIds: string[]) => {
@@ -301,6 +310,7 @@ export function RecordTable({
             columnAggregations={columnAggregations}
             onColumnAggregationsChange={setColumnAggregations}
             onOpenFieldsConfig={handleOpenFieldsConfig}
+            rowHeight={rowHeight}
           />
         );
       case "KANBAN":
@@ -393,6 +403,32 @@ export function RecordTable({
           </form>
         </div>
         <div className="flex items-center gap-2 w-full sm:w-auto">
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <Button variant="outline" size="sm">
+                  <ArrowUpDown className="h-4 w-4 mr-1" />
+                  行高
+                </Button>
+              }
+            />
+            <DropdownMenuContent align="end">
+              {([
+                [24, "紧凑"],
+                [32, "标准"],
+                [40, "宽松"],
+                [56, "超高"],
+              ] as const).map(([h, label]) => (
+                <DropdownMenuItem
+                  key={h}
+                  onClick={() => handleRowHeightChange(h)}
+                  className={rowHeight === h ? "font-bold bg-muted" : ""}
+                >
+                  {label}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
           <FieldConfigPopover
             fields={fields}
             visibleFields={currentConfig.visibleFields}

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -85,6 +85,7 @@ interface GridViewProps {
   onQuickFormat?: (fieldKey: string, value: string) => void;
   columnAggregations?: Record<string, AggregateType>;
   onColumnAggregationsChange?: (aggregations: Record<string, AggregateType>) => void;
+  rowHeight?: number;
 }
 
 // ─── Grouping helpers ───────────────────────────────────────────────────────
@@ -119,6 +120,17 @@ function groupRecords(
   }
 
   return groups;
+}
+
+// ─── Row height style helper ────────────────────────────────────────────────
+
+function getRowHeightClasses(h: number) {
+  switch (h) {
+    case 24: return { td: "p-0.5", text: "text-xs" };
+    case 32: return { td: "p-1", text: "" };
+    case 56: return { td: "p-3 whitespace-normal", text: "" };
+    default: return { td: "p-2", text: "" }; // 40px
+  }
 }
 
 // ─── Frozen style helper ──────────────────────────────────────────────────
@@ -250,6 +262,7 @@ export function GridView({
   onDeleteField,
   columnAggregations,
   onColumnAggregationsChange,
+  rowHeight,
 }: GridViewProps) {
   const frozenFieldCountValue = frozenFieldCount ?? 0;
 
@@ -579,7 +592,7 @@ export function GridView({
   }, [groupedRecords, collapsedGroups, records]);
 
   const { startIndex, endIndex, topPadding, bottomPadding, scrollRef } =
-    useVirtualRows(flatRecords.length);
+    useVirtualRows(flatRecords.length, undefined, rowHeight);
   const visibleFlatRecords = flatRecords.slice(startIndex, endIndex);
 
   // ── Group row indices (for skipping in keyboard nav) ─────────────────────
@@ -1017,7 +1030,7 @@ export function GridView({
       }
 
       return (
-        <span className="block truncate px-1">
+        <span className="block px-1 truncate">
           {formatCellValue(field, record.data[field.key])}
         </span>
       );
@@ -1082,6 +1095,7 @@ export function GridView({
           )}
           {orderedVisibleFields.map((field, fieldIndex) => {
             const frozenTdStyle = getFrozenStyle(fieldIndex, frozenFieldCountValue, orderedVisibleFields, columnWidths);
+            const rhClasses = getRowHeightClasses(rowHeight ?? 40);
             const isActive =
               stableActiveCell?.rowIndex === flatRowIndex &&
               stableActiveCell?.colIndex === fieldIndex;
@@ -1102,7 +1116,9 @@ export function GridView({
                 data-col={fieldIndex}
                 style={Object.keys(mergedStyle).length > 0 ? mergedStyle : undefined}
                 className={cn(
-                  "p-2 align-middle whitespace-nowrap",
+                  "align-middle overflow-hidden", rhClasses.td,
+                  (rowHeight ?? 40) < 56 && "whitespace-nowrap",
+                  rhClasses.text,
                   frozenTdStyle && "bg-background",
                   frozenFieldCountValue > 0 &&
                     fieldIndex === frozenFieldCountValue - 1 &&
@@ -1194,6 +1210,7 @@ export function GridView({
       cellRuleMapByRecord,
       captureRowHeader,
       captureCell,
+      rowHeight,
     ]
   );
 

--- a/src/hooks/use-virtual-rows.ts
+++ b/src/hooks/use-virtual-rows.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-const ROW_HEIGHT = 40; // px, matches h-10 tailwind class
+const DEFAULT_ROW_HEIGHT = 40;
 const BUFFER = 5; // extra rows above/below viewport
 
 export interface VirtualRowsResult {
@@ -15,7 +15,8 @@ export interface VirtualRowsResult {
 
 export function useVirtualRows(
   totalRows: number,
-  containerHeight?: number
+  containerHeight?: number,
+  rowHeight?: number
 ): VirtualRowsResult {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const [scrollTop, setScrollTop] = useState(0);
@@ -35,11 +36,12 @@ export function useVirtualRows(
 
   // Re-calc on totalRows change (e.g. data loaded)
   const { startIndex, endIndex, topPadding, bottomPadding } = useMemo(() => {
+    const h = rowHeight ?? DEFAULT_ROW_HEIGHT;
     const viewportHeight =
       scrollRef.current?.clientHeight ?? containerHeight ?? 600;
-    const maxVisible = Math.ceil(viewportHeight / ROW_HEIGHT);
+    const maxVisible = Math.ceil(viewportHeight / h);
 
-    const rawStart = Math.floor(scrollTop / ROW_HEIGHT);
+    const rawStart = Math.floor(scrollTop / h);
     const rawEnd = rawStart + maxVisible;
 
     const start = Math.max(0, rawStart - BUFFER);
@@ -48,10 +50,10 @@ export function useVirtualRows(
     return {
       startIndex: start,
       endIndex: end,
-      topPadding: start * ROW_HEIGHT,
-      bottomPadding: Math.max(0, (totalRows - end) * ROW_HEIGHT),
+      topPadding: start * h,
+      bottomPadding: Math.max(0, (totalRows - end) * h),
     };
-  }, [scrollTop, totalRows, containerHeight]);
+  }, [scrollTop, totalRows, containerHeight, rowHeight]);
 
   return { startIndex, endIndex, topPadding, bottomPadding, scrollRef };
 }


### PR DESCRIPTION
## Summary
- 工具栏新增行高切换器（紧凑24px / 标准32px / 宽松40px / 超高56px）
- 行高设置保存在视图配置中，切换视图后保留
- 超高模式下长文本自动换行显示
- 虚拟滚动适配动态行高参数

## Test plan
- [x] 工具栏行高切换器四档可切换
- [x] 紧凑模式 p-0.5 text-xs
- [x] 标准模式 p-1
- [x] 宽松模式 p-2（默认）
- [x] 超高模式 p-3 whitespace-normal
- [x] 虚拟滚动在各档行高下正常工作

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)