### PR TITLE
[Feature] 扩展筛选运算符支持更多过滤条件

### DIFF
--- a/src/components/data/column-header.tsx
+++ b/src/components/data/column-header.tsx
@@ -48,38 +48,44 @@ const OPERATOR_LABELS: Record<FilterOperator, string> = {
   gte: "大于等于",
   lte: "小于等于",
   contains: "包含",
+  notcontains: "不包含",
+  startswith: "开头是",
+  endswith: "结尾是",
   isempty: "为空",
   isnotempty: "不为空",
+  between: "范围",
+  in: "属于",
+  notin: "不属于",
 };
 
 function getOperatorsForType(type: FieldType): FilterOperator[] {
   switch (type) {
     case FieldType.TEXT:
-      return ["eq", "ne", "contains", "isempty", "isnotempty"];
+      return ["eq", "ne", "contains", "notcontains", "startswith", "endswith", "in", "notin", "isempty", "isnotempty"];
     case FieldType.NUMBER:
-      return ["eq", "ne", "gt", "lt", "gte", "lte", "isempty"];
+      return ["eq", "ne", "gt", "lt", "gte", "lte", "between", "isempty"];
     case FieldType.DATE:
-      return ["eq", "gt", "lt", "gte", "lte", "isempty"];
+      return ["eq", "gt", "lt", "gte", "lte", "between", "isempty"];
     case FieldType.SELECT:
-      return ["eq", "ne", "isempty"];
+      return ["eq", "ne", "in", "notin", "isempty"];
     case FieldType.MULTISELECT:
       return ["contains", "isempty"];
     case FieldType.EMAIL:
     case FieldType.PHONE:
-      return ["eq", "contains", "isempty"];
+      return ["eq", "contains", "notcontains", "startswith", "endswith", "isempty"];
     case FieldType.RELATION:
       return ["eq", "isempty"];
     case FieldType.FILE:
     case FieldType.URL:
-      return ["eq", "ne", "contains", "isempty", "isnotempty"];
+      return ["eq", "ne", "contains", "notcontains", "isempty", "isnotempty"];
     case FieldType.BOOLEAN:
       return ["eq", "isempty"];
     case FieldType.AUTO_NUMBER:
-      return ["eq", "ne", "gt", "lt", "gte", "lte", "isempty"];
+      return ["eq", "ne", "gt", "lt", "gte", "lte", "between", "isempty"];
     case FieldType.SYSTEM_TIMESTAMP:
-      return ["eq", "gt", "lt", "gte", "lte", "isempty"];
+      return ["eq", "gt", "lt", "gte", "lte", "between", "isempty"];
     case FieldType.FORMULA:
-      return ["eq", "ne", "gt", "lt", "gte", "lte", "isempty", "isnotempty"];
+      return ["eq", "ne", "gt", "lt", "gte", "lte", "between", "isempty", "isnotempty"];
     default:
       return ["eq", "ne", "contains", "isempty", "isnotempty"];
   }
@@ -104,7 +110,13 @@ export function ColumnHeader({
     filter?.op ?? getOperatorsForType(field.type)[0]
   );
   const [filterValue, setFilterValue] = useState<string>(
-    filter ? String(filter.value) : ""
+    filter
+      ? filter.op === "between"
+        ? `${(filter.value as { min: unknown; max: unknown }).min ?? ""}-${(filter.value as { min: unknown; max: unknown }).max ?? ""}`
+        : Array.isArray(filter.value)
+          ? (filter.value as unknown[]).join(",")
+          : String(filter.value)
+      : ""
   );
 
   // When popover opens, sync local state with props
@@ -112,13 +124,34 @@ export function ColumnHeader({
     setOpen(nextOpen);
     if (nextOpen) {
       setFilterOp(filter?.op ?? getOperatorsForType(field.type)[0]);
-      setFilterValue(filter ? String(filter.value) : "");
+      setFilterValue(
+        filter
+          ? filter.op === "between"
+            ? `${(filter.value as { min: unknown; max: unknown }).min ?? ""}-${(filter.value as { min: unknown; max: unknown }).max ?? ""}`
+            : Array.isArray(filter.value)
+              ? (filter.value as unknown[]).join(",")
+              : String(filter.value)
+          : ""
+      );
     }
   };
 
   const handleApplyFilter = () => {
     if (NO_VALUE_OPS.includes(filterOp)) {
       onFilterChange({ fieldKey: field.key, op: filterOp, value: "" });
+    } else if (filterOp === "between") {
+      const parts = filterValue.split("-").map((s) => s.trim());
+      const min = field.type === FieldType.NUMBER ? Number(parts[0]) : parts[0] ?? "";
+      const max = field.type === FieldType.NUMBER ? Number(parts[1]) : parts[1] ?? "";
+      if (!isNaN(Number(min)) && !isNaN(Number(max))) {
+        onFilterChange({ fieldKey: field.key, op: filterOp, value: { min, max } });
+      }
+    } else if (filterOp === "in" || filterOp === "notin") {
+      const items = filterValue.split(",").map((s) => s.trim()).filter(Boolean);
+      if (items.length > 0) {
+        const value = field.type === FieldType.NUMBER ? items.map(Number) : items;
+        onFilterChange({ fieldKey: field.key, op: filterOp, value });
+      }
     } else if (filterValue) {
       const value: string | number =
         field.type === FieldType.NUMBER && !isNaN(Number(filterValue))
@@ -150,21 +183,14 @@ export function ColumnHeader({
   // Build filter summary text
   const getFilterSummary = () => {
     if (!filter) return null;
-    const opLabel =
-      filter.op === "eq"
-        ? "=="
-        : filter.op === "ne"
-          ? "!="
-          : filter.op === "contains"
-            ? "~"
-            : filter.op === "isempty"
-              ? "=空"
-              : filter.op === "isnotempty"
-                ? "=非空"
-                : filter.op;
+    const opLabel = OPERATOR_LABELS[filter.op] ?? filter.op;
     const val = NO_VALUE_OPS.includes(filter.op)
       ? ""
-      : `\"${filter.value}\"`;
+      : filter.op === "between"
+        ? `${(filter.value as { min: unknown; max: unknown }).min}~${(filter.value as { min: unknown; max: unknown }).max}`
+        : Array.isArray(filter.value)
+          ? (filter.value as unknown[]).join(",")
+          : `"${filter.value}"`;
     return `${opLabel}${val}`;
   };
 
@@ -301,7 +327,7 @@ export function ColumnHeader({
           </Select>
 
           {!hideValue &&
-            (field.type === FieldType.SELECT && field.options ? (
+            (field.type === FieldType.SELECT && field.options && filterOp !== "in" && filterOp !== "notin" ? (
               <Select
                 value={filterValue}
                 onValueChange={(v) => {
@@ -322,11 +348,17 @@ export function ColumnHeader({
               </Select>
             ) : (
               <Input
-                placeholder="输入值"
+                placeholder={
+                  filterOp === "between"
+                    ? "最小值-最大值（如 10-100）"
+                    : filterOp === "in" || filterOp === "notin"
+                      ? "多个值，逗号分隔"
+                      : "输入值"
+                }
                 value={filterValue}
                 onChange={(e) => setFilterValue(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && handleApplyFilter()}
-                type={field.type === FieldType.NUMBER ? "number" : "text"}
+                type={field.type === FieldType.NUMBER && filterOp !== "between" ? "number" : "text"}
               />
             ))}
         </div>

--- a/src/components/data/conditional-format-dialog.tsx
+++ b/src/components/data/conditional-format-dialog.tsx
@@ -27,10 +27,15 @@ const OPERATOR_OPTIONS = [
   { value: "eq", label: "等于" },
   { value: "ne", label: "不等于" },
   { value: "contains", label: "包含" },
+  { value: "notcontains", label: "不包含" },
   { value: "isempty", label: "为空" },
   { value: "isnotempty", label: "不为空" },
   { value: "gt", label: "大于" },
   { value: "lt", label: "小于" },
+  { value: "gte", label: "大于等于" },
+  { value: "lte", label: "小于等于" },
+  { value: "startswith", label: "开头是" },
+  { value: "endswith", label: "结尾是" },
 ]
 
 interface ConditionalFormatDialogProps {

--- a/src/components/data/filter-panel.tsx
+++ b/src/components/data/filter-panel.tsx
@@ -13,12 +13,18 @@ const OPERATOR_OPTIONS = [
   { value: "eq", label: "等于" },
   { value: "ne", label: "不等于" },
   { value: "contains", label: "包含" },
+  { value: "notcontains", label: "不包含" },
+  { value: "startswith", label: "开头是" },
+  { value: "endswith", label: "结尾是" },
   { value: "isempty", label: "为空" },
   { value: "isnotempty", label: "不为空" },
   { value: "gt", label: "大于" },
   { value: "lt", label: "小于" },
   { value: "gte", label: "大于等于" },
   { value: "lte", label: "小于等于" },
+  { value: "between", label: "范围" },
+  { value: "in", label: "属于" },
+  { value: "notin", label: "不属于" },
 ]
 
 const NO_VALUE_OPS = ["isempty", "isnotempty"]
@@ -136,9 +142,31 @@ export function FilterPanel({ fields, filters, onChange }: FilterPanelProps) {
                 {!NO_VALUE_OPS.includes(cond.op) && (
                   <Input
                     className="h-7 flex-1 text-xs"
-                    value={String(cond.value)}
-                    onChange={(e) => updateCondition(gi, ci, { value: e.target.value })}
-                    placeholder="值"
+                    value={
+                      cond.op === "between"
+                        ? `${(cond.value as { min: unknown; max: unknown }).min ?? ""}-${(cond.value as { min: unknown; max: unknown }).max ?? ""}`
+                        : Array.isArray(cond.value)
+                          ? cond.value.join(",")
+                          : String(cond.value)
+                    }
+                    onChange={(e) => {
+                      const raw = e.target.value;
+                      if (cond.op === "between") {
+                        const parts = raw.split("-").map(s => s.trim());
+                        updateCondition(gi, ci, { value: { min: parts[0] ?? "", max: parts[1] ?? "" } });
+                      } else if (cond.op === "in" || cond.op === "notin") {
+                        updateCondition(gi, ci, { value: raw.split(",").map(s => s.trim()).filter(Boolean) });
+                      } else {
+                        updateCondition(gi, ci, { value: raw });
+                      }
+                    }}
+                    placeholder={
+                      cond.op === "between"
+                        ? "最小值-最大值"
+                        : cond.op === "in" || cond.op === "notin"
+                          ? "逗号分隔多个值"
+                          : "值"
+                    }
                   />
                 )}
                 <Button variant="ghost" size="sm" className="h-7 px-1" onClick={() => removeCondition(gi, ci)}>

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -357,10 +357,15 @@ export function GridView({
           case "eq": match = String(val ?? "") === String(rule.condition.value); break;
           case "ne": match = String(val ?? "") !== String(rule.condition.value); break;
           case "contains": match = String(val ?? "").includes(String(rule.condition.value)); break;
+          case "notcontains": match = !String(val ?? "").includes(String(rule.condition.value)); break;
+          case "startswith": match = String(val ?? "").startsWith(String(rule.condition.value)); break;
+          case "endswith": match = String(val ?? "").endsWith(String(rule.condition.value)); break;
           case "isempty": match = val === undefined || val === null || val === ""; break;
           case "isnotempty": match = val !== undefined && val !== null && val !== ""; break;
           case "gt": match = Number(val) > Number(rule.condition.value); break;
           case "lt": match = Number(val) < Number(rule.condition.value); break;
+          case "gte": match = Number(val) >= Number(rule.condition.value); break;
+          case "lte": match = Number(val) <= Number(rule.condition.value); break;
         }
         if (match) {
           const style: React.CSSProperties = {
@@ -1233,10 +1238,15 @@ export function GridView({
           case "eq": match = String(val ?? "") === String(rule.condition.value); break;
           case "ne": match = String(val ?? "") !== String(rule.condition.value); break;
           case "contains": match = String(val ?? "").includes(String(rule.condition.value)); break;
+          case "notcontains": match = !String(val ?? "").includes(String(rule.condition.value)); break;
+          case "startswith": match = String(val ?? "").startsWith(String(rule.condition.value)); break;
+          case "endswith": match = String(val ?? "").endsWith(String(rule.condition.value)); break;
           case "isempty": match = val === undefined || val === null || val === ""; break;
           case "isnotempty": match = val !== undefined && val !== null && val !== ""; break;
           case "gt": match = Number(val) > Number(rule.condition.value); break;
           case "lt": match = Number(val) < Number(rule.condition.value); break;
+          case "gte": match = Number(val) >= Number(rule.condition.value); break;
+          case "lte": match = Number(val) <= Number(rule.condition.value); break;
         }
         if (match) {
           const style: React.CSSProperties = { backgroundColor: rule.backgroundColor };

--- a/src/lib/services/data-record.service.ts
+++ b/src/lib/services/data-record.service.ts
@@ -277,19 +277,26 @@ export async function listRecords(
       }
     }
 
-    // 当有 sortBy 时，需要先取全部数据排序再分页，否则排序只在当前页内生效
+    // 当有 sortBy 或内存过滤运算符时，需要先取全部数据再分页
     const hasSort = filters.sortBy && filters.sortBy.length > 0;
     const sortableFields = hasSort
       ? filters.sortBy!.filter((sortConfig) =>
           tableResult.data.fields.some((field) => field.key === sortConfig.fieldKey)
         )
       : [];
+    const memoryFilterGroups = (filters.filterConditions && filters.filterConditions.length > 0)
+      ? normalizeFilters(filters.filterConditions).map(g => ({
+          ...g,
+          conditions: g.conditions.filter(c => c.op === "between" || c.op === "in" || c.op === "notin"),
+        })).filter(g => g.conditions.length > 0)
+      : [];
+    const needsFullFetch = hasSort || memoryFilterGroups.length > 0;
 
     let processedRecords: DataRecordItem[];
-    let total: number;
+    let total = 0;
 
-    if (sortableFields.length > 0) {
-      // 有排序：取全部匹配记录 → 内存排序 → 手动分页
+    if (needsFullFetch) {
+      // 有排序或内存过滤运算符：取全部匹配记录 → 内存排序/过滤 → 手动分页
       const [allRecords, totalCount] = await Promise.all([
         db.dataRecord.findMany({
           where,
@@ -300,16 +307,16 @@ export async function listRecords(
         }),
         db.dataRecord.count({ where }),
       ]);
-      total = totalCount;
-      processedRecords = allRecords.map(mapRecordToItem).sort((a, b) => {
-        for (const { fieldKey, order } of sortableFields) {
-          const result = compareRecordValues(a.data[fieldKey], b.data[fieldKey], order);
-          if (result !== 0) return result;
-        }
-        return 0;
-      });
-      const start = (filters.page - 1) * filters.pageSize;
-      processedRecords = processedRecords.slice(start, start + filters.pageSize);
+      processedRecords = allRecords.map(mapRecordToItem);
+      if (sortableFields.length > 0) {
+        processedRecords.sort((a, b) => {
+          for (const { fieldKey, order } of sortableFields) {
+            const result = compareRecordValues(a.data[fieldKey], b.data[fieldKey], order);
+            if (result !== 0) return result;
+          }
+          return 0;
+        });
+      }
     } else {
       // 无排序：直接 DB 分页（默认按创建时间倒序）
       const [records, totalCount] = await Promise.all([
@@ -446,14 +453,10 @@ export async function listRecords(
     injectSystemFieldValues(processedRecords, tableResult.data.fields);
 
     // ── Memory filtering for operators not supported by Prisma JSONB ──
-    if (filters.filterConditions && filters.filterConditions.length > 0) {
-      const allConditions = normalizeFilters(filters.filterConditions).flatMap(g => g.conditions);
-      const memoryConditions = allConditions.filter(
-        (c) => c.op === "between" || c.op === "in" || c.op === "notin"
-      );
-      if (memoryConditions.length > 0) {
-        processedRecords = processedRecords.filter((record) =>
-          memoryConditions.every((cond) => {
+    if (memoryFilterGroups.length > 0) {
+      processedRecords = processedRecords.filter((record) =>
+        memoryFilterGroups.some((group) =>
+          group.conditions.every((cond) => {
             const raw = record.data[cond.fieldKey];
             const val = typeof raw === "object" && raw !== null && "display" in raw
               ? (raw as { display: unknown }).display
@@ -462,7 +465,14 @@ export async function listRecords(
               case "between": {
                 const range = cond.value as { min: number | string; max: number | string };
                 const num = Number(val);
-                return !isNaN(num) && num >= Number(range.min) && num <= Number(range.max);
+                if (!isNaN(num)) {
+                  return num >= Number(range.min) && num <= Number(range.max);
+                }
+                // Date string comparison
+                const dateVal = new Date(String(val));
+                const dateMin = new Date(String(range.min));
+                const dateMax = new Date(String(range.max));
+                return !isNaN(dateVal.getTime()) && dateVal >= dateMin && dateVal <= dateMax;
               }
               case "in": {
                 const list = Array.isArray(cond.value) ? cond.value.map(String) : [];
@@ -476,9 +486,15 @@ export async function listRecords(
                 return true;
             }
           })
-        );
-        total = processedRecords.length;
-      }
+        )
+      );
+    }
+
+    // Compute total after memory filtering, before pagination
+    if (needsFullFetch) {
+      total = processedRecords.length;
+      const start = (filters.page - 1) * filters.pageSize;
+      processedRecords = processedRecords.slice(start, start + filters.pageSize);
     }
 
     return {

--- a/src/lib/services/data-record.service.ts
+++ b/src/lib/services/data-record.service.ts
@@ -445,6 +445,42 @@ export async function listRecords(
     // Resolve SYSTEM_TIMESTAMP and SYSTEM_USER fields from record metadata
     injectSystemFieldValues(processedRecords, tableResult.data.fields);
 
+    // ── Memory filtering for operators not supported by Prisma JSONB ──
+    if (filters.filterConditions && filters.filterConditions.length > 0) {
+      const allConditions = normalizeFilters(filters.filterConditions).flatMap(g => g.conditions);
+      const memoryConditions = allConditions.filter(
+        (c) => c.op === "between" || c.op === "in" || c.op === "notin"
+      );
+      if (memoryConditions.length > 0) {
+        processedRecords = processedRecords.filter((record) =>
+          memoryConditions.every((cond) => {
+            const raw = record.data[cond.fieldKey];
+            const val = typeof raw === "object" && raw !== null && "display" in raw
+              ? (raw as { display: unknown }).display
+              : raw;
+            switch (cond.op) {
+              case "between": {
+                const range = cond.value as { min: number | string; max: number | string };
+                const num = Number(val);
+                return !isNaN(num) && num >= Number(range.min) && num <= Number(range.max);
+              }
+              case "in": {
+                const list = Array.isArray(cond.value) ? cond.value.map(String) : [];
+                return list.includes(String(val ?? ""));
+              }
+              case "notin": {
+                const list = Array.isArray(cond.value) ? cond.value.map(String) : [];
+                return !list.includes(String(val ?? ""));
+              }
+              default:
+                return true;
+            }
+          })
+        );
+        total = processedRecords.length;
+      }
+    }
+
     return {
       success: true,
       data: {
@@ -1009,6 +1045,12 @@ function buildConditionFromFilter(
       return { NOT: { data: { path: [cond.fieldKey], equals: cond.value } } }
     case "contains":
       return { data: { path: [cond.fieldKey], string_contains: String(cond.value) } }
+    case "notcontains":
+      return { NOT: { data: { path: [cond.fieldKey], string_contains: String(cond.value) } } }
+    case "startswith":
+      return { data: { path: [cond.fieldKey], string_starts_with: String(cond.value) } }
+    case "endswith":
+      return { data: { path: [cond.fieldKey], string_ends_with: String(cond.value) } }
     case "gt":
     case "gte":
     case "lt":

--- a/src/types/data-table.ts
+++ b/src/types/data-table.ts
@@ -180,10 +180,16 @@ export interface BundleImportResult {
 
 // ========== View Types ==========
 
+export type FilterOperator =
+  | 'eq' | 'ne' | 'gt' | 'lt' | 'gte' | 'lte'
+  | 'contains' | 'notcontains' | 'startswith' | 'endswith'
+  | 'isempty' | 'isnotempty'
+  | 'between' | 'in' | 'notin';
+
 export interface FilterCondition {
   fieldKey: string;
-  op: 'eq' | 'ne' | 'gt' | 'lt' | 'gte' | 'lte' | 'contains' | 'isempty' | 'isnotempty';
-  value: string | number;
+  op: FilterOperator;
+  value: string | number | (string | number)[] | { min: number | string; max: number | string };
 }
 
 export interface FilterGroup {

--- a/src/validators/data-table.ts
+++ b/src/validators/data-table.ts
@@ -138,17 +138,16 @@ export const sortConfigSchema = z.object({
 export const filterConditionSchema = z.object({
   fieldKey: z.string(),
   op: z.enum([
-    "eq",
-    "ne",
-    "gt",
-    "lt",
-    "gte",
-    "lte",
-    "contains",
-    "isempty",
-    "isnotempty",
+    "eq", "ne", "gt", "lt", "gte", "lte",
+    "contains", "notcontains", "startswith", "endswith",
+    "isempty", "isnotempty",
+    "between", "in", "notin",
   ]),
-  value: z.union([z.string(), z.number()]),
+  value: z.union([
+    z.string(), z.number(),
+    z.array(z.union([z.string(), z.number()])),
+    z.object({ min: z.union([z.string(), z.number()]), max: z.union([z.string(), z.number()]) }),
+  ]),
 });
 
 export const filterGroupSchema = z.object({


### PR DESCRIPTION
## Summary
- 新增筛选运算符：notcontains、startswith、endswith、between、in、notin
- 各字段类型（文本/数字/日期/选择等）按适用性分配可用运算符
- between/in/notin 因 Prisma JSONB 限制通过内存过滤实现
- 更新 Zod 验证 schema 支持 value 的多种类型（字符串、数字、数组、范围对象）
- 同步更新条件格式对话框的运算符选项

## Test plan
- [ ] 文本字段筛选：不包含/开头是/结尾是
- [ ] 数字字段筛选：范围（如 10-100）
- [ ] 选择字段筛选：属于/不属于（多值逗号分隔）
- [ ] 筛选面板组合条件测试
- [ ] 条件格式规则使用新运算符

Closes #51