### PR TITLE
[Feature] 记录级别变更历史审计

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,6 +48,7 @@ model User {
   collectionSubmissionVersions DocumentCollectionSubmissionVersion[] @relation("CollectionSubmissionVersions")
   notifications                 Notification[]                       @relation("UserNotifications")
   apiTokens                     ApiToken[]
+  changeHistories               DataRecordChangeHistory[]
 }
 
 enum TemplateStatus {
@@ -365,6 +366,26 @@ model DataRecord {
   @@index([updatedById])
   @@index([tableId, createdAt(sort: Desc)])  // 复合索引加速列表查询
   @@index([tableId, createdById])             // 复合索引加速用户记录查询
+  changeHistories DataRecordChangeHistory[]
+}
+
+model DataRecordChangeHistory {
+  id          String    @id @default(cuid())
+  recordId    String
+  record      DataRecord @relation(fields: [recordId], references: [id], onDelete: Cascade)
+  tableId     String
+  fieldKey    String
+  fieldLabel  String
+  oldValue    Json?
+  newValue    Json?
+  changedById String
+  changedBy   User      @relation(fields: [changedById], references: [id], onDelete: SetNull)
+  changedAt   DateTime  @default(now())
+
+  @@index([recordId, changedAt(sort: Desc)])
+  @@index([tableId, changedAt(sort: Desc)])
+  @@index([changedById])
+  @@map("data_record_change_history")
 }
 
 model DataRelationRow {

--- a/src/app/api/data-tables/[id]/records/[recordId]/history/route.ts
+++ b/src/app/api/data-tables/[id]/records/[recordId]/history/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { getRecordChangeHistory } from "@/lib/services/data-record-change-history.service";
+
+interface RouteParams {
+  params: Promise<{ id: string; recordId: string }>;
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "未授权" }, { status: 401 });
+  }
+
+  const { recordId } = await params;
+  const searchParams = request.nextUrl.searchParams;
+
+  const page = parseInt(searchParams.get("page") || "1", 10);
+  const pageSize = parseInt(searchParams.get("pageSize") || "50", 10);
+  const startDate = searchParams.get("startDate") || undefined;
+  const endDate = searchParams.get("endDate") || undefined;
+
+  const result = await getRecordChangeHistory(recordId, {
+    page,
+    pageSize,
+    startDate,
+    endDate,
+  });
+
+  if (!result.success) {
+    return NextResponse.json({ error: result.error.message }, { status: 400 });
+  }
+
+  return NextResponse.json(result.data);
+}

--- a/src/components/data/record-detail-drawer.tsx
+++ b/src/components/data/record-detail-drawer.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
-import { Pencil, Trash2 } from "lucide-react";
+import { Pencil, Trash2, History } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import {
   Sheet,
@@ -12,8 +13,10 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { Spinner } from "@/components/ui/spinner";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { formatCellValue } from "@/lib/format-cell";
 import type { DataFieldItem, DataRecordItem } from "@/types/data-table";
+import type { ChangeHistoryEntry } from "@/lib/services/data-record-change-history.service";
 
 export interface RecordDetailDrawerProps {
   open: boolean;
@@ -30,12 +33,27 @@ function formatDateTime(value: string | Date): string {
   return new Date(value).toLocaleString("zh-CN");
 }
 
+function formatChangeValue(value: unknown): string {
+  if (value === null || value === undefined) return "(空)";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
 export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
   const { open, onOpenChange, recordId, tableId, fields, isAdmin, onDelete } =
     props;
 
   const [record, setRecord] = useState<DataRecordItem | null>(null);
   const [loading, setLoading] = useState(false);
+  const [activeTab, setActiveTab] = useState("fields");
+
+  // History state
+  const [historyEntries, setHistoryEntries] = useState<ChangeHistoryEntry[]>([]);
+  const [historyTotal, setHistoryTotal] = useState(0);
+  const [historyPage, setHistoryPage] = useState(1);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
 
   useEffect(() => {
     if (!open || !recordId) {
@@ -86,6 +104,58 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
     };
   }, [open, recordId, tableId]);
 
+  const loadHistory = useCallback(async (page: number, append = false) => {
+    if (!recordId) return;
+    setHistoryLoading(true);
+    try {
+      const params = new URLSearchParams({ page: String(page), pageSize: "20" });
+      if (startDate) params.set("startDate", startDate);
+      if (endDate) params.set("endDate", endDate);
+
+      const response = await fetch(
+        `/api/data-tables/${tableId}/records/${recordId}/history?${params}`,
+        { cache: "no-store" }
+      );
+      if (response.ok) {
+        const data = await response.json();
+        setHistoryEntries((prev) => append ? [...prev, ...data.entries] : data.entries);
+        setHistoryTotal(data.total);
+        setHistoryPage(page);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setHistoryLoading(false);
+    }
+  }, [recordId, tableId, startDate, endDate]);
+
+  // Load history when tab switches to history
+  useEffect(() => {
+    if (open && activeTab === "history" && recordId) {
+      setHistoryEntries([]);
+      setHistoryPage(1);
+      void loadHistory(1);
+    }
+  }, [open, activeTab, recordId, loadHistory]);
+
+  const handleDateFilter = () => {
+    setHistoryEntries([]);
+    setHistoryPage(1);
+    void loadHistory(1);
+  };
+
+  // Reset tab when drawer closes
+  useEffect(() => {
+    if (!open) {
+      setActiveTab("fields");
+      setHistoryEntries([]);
+      setHistoryTotal(0);
+      setHistoryPage(1);
+      setStartDate("");
+      setEndDate("");
+    }
+  }, [open]);
+
   const handleDelete = () => {
     if (!record) return;
 
@@ -105,69 +175,157 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
             记录不存在
           </div>
         ) : (
-          <div className="space-y-6">
+          <div className="space-y-4">
             <SheetHeader className="border-b">
               <SheetTitle className="text-lg">记录详情</SheetTitle>
             </SheetHeader>
 
-            <div className="space-y-6 px-4 pb-4">
-              {isAdmin && (
-                <div className="flex flex-wrap gap-2">
+            <Tabs value={activeTab} onValueChange={setActiveTab}>
+              <TabsList className="mx-4">
+                <TabsTrigger value="fields">字段</TabsTrigger>
+                <TabsTrigger value="history">
+                  <History className="h-3.5 w-3.5" />
+                  变更历史
+                </TabsTrigger>
+              </TabsList>
+
+              <TabsContent value="fields" className="space-y-6 px-4 pb-4 pt-4">
+                {isAdmin && (
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      nativeButton={false}
+                      render={<Link href={`/data/${tableId}/${record.id}/edit`} />}
+                    >
+                      <Pencil className="h-4 w-4" />
+                      编辑
+                    </Button>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={handleDelete}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      删除
+                    </Button>
+                  </div>
+                )}
+
+                <div className="space-y-4">
+                  {fields.map((field) => (
+                    <div key={field.id} className="space-y-1.5">
+                      <div className="text-xs font-medium text-muted-foreground">
+                        {field.label}
+                      </div>
+                      <div className="break-words text-sm">
+                        {formatCellValue(field, record.data[field.key])}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+
+                <Separator />
+
+                <div className="space-y-3">
+                  <div className="text-xs font-medium text-muted-foreground">
+                    元信息
+                  </div>
+                  <div className="grid gap-2 text-sm">
+                    <div className="grid grid-cols-[88px_1fr] gap-2">
+                      <span className="text-muted-foreground">创建人</span>
+                      <span>{record.createdByName || "-"}</span>
+                    </div>
+                    <div className="grid grid-cols-[88px_1fr] gap-2">
+                      <span className="text-muted-foreground">创建时间</span>
+                      <span>{formatDateTime(record.createdAt)}</span>
+                    </div>
+                    <div className="grid grid-cols-[88px_1fr] gap-2">
+                      <span className="text-muted-foreground">更新时间</span>
+                      <span>{formatDateTime(record.updatedAt)}</span>
+                    </div>
+                  </div>
+                </div>
+              </TabsContent>
+
+              <TabsContent value="history" className="space-y-4 px-4 pb-4 pt-4">
+                {/* Date range filter */}
+                <div className="flex gap-2 items-center text-xs">
+                  <Input
+                    type="date"
+                    value={startDate}
+                    onChange={(e) => setStartDate(e.target.value)}
+                    className="h-7 text-xs"
+                  />
+                  <span className="text-muted-foreground shrink-0">至</span>
+                  <Input
+                    type="date"
+                    value={endDate}
+                    onChange={(e) => setEndDate(e.target.value)}
+                    className="h-7 text-xs"
+                  />
                   <Button
                     variant="outline"
                     size="sm"
-                    nativeButton={false}
-                    render={<Link href={`/data/${tableId}/${record.id}/edit`} />}
+                    className="h-7 px-2 text-xs shrink-0"
+                    onClick={handleDateFilter}
                   >
-                    <Pencil className="h-4 w-4" />
-                    编辑
-                  </Button>
-                  <Button
-                    variant="destructive"
-                    size="sm"
-                    onClick={handleDelete}
-                  >
-                    <Trash2 className="h-4 w-4" />
-                    删除
+                    筛选
                   </Button>
                 </div>
-              )}
 
-              <div className="space-y-4">
-                {fields.map((field) => (
-                  <div key={field.id} className="space-y-1.5">
-                    <div className="text-xs font-medium text-muted-foreground">
-                      {field.label}
+                {historyLoading && historyEntries.length === 0 ? (
+                  <div className="flex items-center justify-center py-12">
+                    <Spinner className="size-5" />
+                  </div>
+                ) : historyEntries.length === 0 ? (
+                  <div className="text-sm text-muted-foreground text-center py-12">
+                    暂无变更记录
+                  </div>
+                ) : (
+                  <>
+                    <div className="relative space-y-0">
+                      {historyEntries.map((entry) => (
+                        <div key={entry.id} className="flex gap-3 text-sm">
+                          <div className="flex flex-col items-center">
+                            <div className="w-2 h-2 rounded-full bg-blue-500 mt-1.5 shrink-0" />
+                            <div className="w-px flex-1 bg-border" />
+                          </div>
+                          <div className="flex-1 pb-4">
+                            <div className="text-muted-foreground text-xs">
+                              {formatDateTime(entry.changedAt)} · {entry.changedByName}
+                            </div>
+                            <div className="mt-1">
+                              <span className="font-medium">{entry.fieldLabel}</span>
+                              {" : "}
+                              <span className="text-red-500/80 line-through">
+                                {formatChangeValue(entry.oldValue)}
+                              </span>
+                              {" → "}
+                              <span className="text-green-600">
+                                {formatChangeValue(entry.newValue)}
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      ))}
                     </div>
-                    <div className="break-words text-sm">
-                      {formatCellValue(field, record.data[field.key])}
-                    </div>
-                  </div>
-                ))}
-              </div>
 
-              <Separator />
-
-              <div className="space-y-3">
-                <div className="text-xs font-medium text-muted-foreground">
-                  元信息
-                </div>
-                <div className="grid gap-2 text-sm">
-                  <div className="grid grid-cols-[88px_1fr] gap-2">
-                    <span className="text-muted-foreground">创建人</span>
-                    <span>{record.createdByName || "-"}</span>
-                  </div>
-                  <div className="grid grid-cols-[88px_1fr] gap-2">
-                    <span className="text-muted-foreground">创建时间</span>
-                    <span>{formatDateTime(record.createdAt)}</span>
-                  </div>
-                  <div className="grid grid-cols-[88px_1fr] gap-2">
-                    <span className="text-muted-foreground">更新时间</span>
-                    <span>{formatDateTime(record.updatedAt)}</span>
-                  </div>
-                </div>
-              </div>
-            </div>
+                    {historyEntries.length < historyTotal && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="w-full"
+                        disabled={historyLoading}
+                        onClick={() => loadHistory(historyPage + 1, true)}
+                      >
+                        {historyLoading ? "加载中..." : "加载更多"}
+                      </Button>
+                    )}
+                  </>
+                )}
+              </TabsContent>
+            </Tabs>
           </div>
         )}
       </SheetContent>

--- a/src/components/layout/theme-toggle.tsx
+++ b/src/components/layout/theme-toggle.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useTheme } from "next-themes";
 import { Sun, Moon, Monitor } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -14,6 +15,11 @@ const icons = {
 
 export function ThemeToggle() {
   const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const current = themes.includes(theme as typeof themes[number])
     ? (theme as typeof themes[number])
@@ -22,9 +28,17 @@ export function ThemeToggle() {
   const Icon = icons[current];
 
   const toggle = () => {
-    const next = themes[(themes.indexOf(current) + 1) % themes.length];
+    const next = themes[(themes.indexOf(current) + themes.length + 1) % themes.length];
     setTheme(next);
   };
+
+  if (!mounted) {
+    return (
+      <Button variant="ghost" size="icon" className="shrink-0">
+        <Monitor className="h-4 w-4" />
+      </Button>
+    );
+  }
 
   return (
     <Button

--- a/src/lib/services/data-record-change-history.service.ts
+++ b/src/lib/services/data-record-change-history.service.ts
@@ -1,0 +1,88 @@
+import { db } from "@/lib/db";
+import type { ServiceResult } from "@/types/data-table";
+
+export interface ChangeHistoryEntry {
+  id: string;
+  recordId: string;
+  fieldKey: string;
+  fieldLabel: string;
+  oldValue: unknown;
+  newValue: unknown;
+  changedByName: string;
+  changedAt: Date;
+}
+
+export interface PaginatedChangeHistory {
+  entries: ChangeHistoryEntry[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+export async function getRecordChangeHistory(
+  recordId: string,
+  options?: {
+    page?: number;
+    pageSize?: number;
+    startDate?: string;
+    endDate?: string;
+  }
+): Promise<ServiceResult<PaginatedChangeHistory>> {
+  try {
+    const page = options?.page ?? 1;
+    const pageSize = options?.pageSize ?? 50;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const where: Record<string, any> = { recordId };
+
+    if (options?.startDate || options?.endDate) {
+      const changedAt: Record<string, Date> = {};
+      if (options.startDate) changedAt.gte = new Date(options.startDate);
+      if (options.endDate) {
+        const end = new Date(options.endDate);
+        end.setHours(23, 59, 59, 999);
+        changedAt.lte = end;
+      }
+      where.changedAt = changedAt;
+    }
+
+    const [rows, total] = await Promise.all([
+      db.dataRecordChangeHistory.findMany({
+        where,
+        orderBy: { changedAt: "desc" },
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+        include: {
+          changedBy: { select: { name: true } },
+        },
+      }),
+      db.dataRecordChangeHistory.count({ where }),
+    ]);
+
+    const entries: ChangeHistoryEntry[] = rows.map((row) => ({
+      id: row.id,
+      recordId: row.recordId,
+      fieldKey: row.fieldKey,
+      fieldLabel: row.fieldLabel,
+      oldValue: row.oldValue,
+      newValue: row.newValue,
+      changedByName: row.changedBy?.name ?? "未知",
+      changedAt: row.changedAt,
+    }));
+
+    return {
+      success: true,
+      data: {
+        entries,
+        total,
+        page,
+        pageSize,
+        totalPages: Math.ceil(total / pageSize),
+      },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "获取变更历史失败";
+    return { success: false, error: { code: "HISTORY_FAILED", message } };
+  }
+}

--- a/src/lib/services/data-record.service.ts
+++ b/src/lib/services/data-record.service.ts
@@ -20,6 +20,69 @@ import {
   syncRelationSubtableValues,
 } from "./data-relation.service";
 
+// ── Change history helpers ──
+
+interface FieldChange {
+  fieldKey: string;
+  fieldLabel: string;
+  oldValue: unknown;
+  newValue: unknown;
+}
+
+const SKIP_HISTORY_FIELD_TYPES = new Set([
+  "RELATION_SUBTABLE", "SYSTEM_TIMESTAMP", "SYSTEM_USER", "FORMULA",
+]);
+
+function detectFieldChanges(
+  oldData: Record<string, unknown>,
+  newData: Record<string, unknown>,
+  fields: DataFieldItem[]
+): FieldChange[] {
+  const fieldMap = new Map(fields.map((f) => [f.key, f]));
+  const changes: FieldChange[] = [];
+  const allKeys = new Set([...Object.keys(oldData), ...Object.keys(newData)]);
+
+  for (const key of allKeys) {
+    const field = fieldMap.get(key);
+    if (field && SKIP_HISTORY_FIELD_TYPES.has(field.type)) continue;
+
+    const oldVal = oldData[key];
+    const newVal = newData[key];
+    if (JSON.stringify(oldVal) !== JSON.stringify(newVal)) {
+      changes.push({
+        fieldKey: key,
+        fieldLabel: field?.label ?? key,
+        oldValue: oldVal ?? null,
+        newValue: newVal ?? null,
+      });
+    }
+  }
+  return changes;
+}
+
+type PrismaTx = Parameters<Parameters<typeof db.$transaction>[0]>[0];
+
+async function recordChangeHistory(
+  tx: PrismaTx,
+  recordId: string,
+  tableId: string,
+  changes: FieldChange[],
+  userId: string
+): Promise<void> {
+  if (changes.length === 0) return;
+  await tx.dataRecordChangeHistory.createMany({
+    data: changes.map((c) => ({
+      recordId,
+      tableId,
+      fieldKey: c.fieldKey,
+      fieldLabel: c.fieldLabel,
+      oldValue: c.oldValue != null ? JSON.parse(JSON.stringify(c.oldValue)) : null,
+      newValue: c.newValue != null ? JSON.parse(JSON.stringify(c.newValue)) : null,
+      changedById: userId,
+    })),
+  });
+}
+
 // Helper to convert Record<string, unknown> to Prisma JSON input
 export function toJsonInput(data: Record<string, unknown>): Prisma.InputJsonValue {
   return JSON.parse(JSON.stringify(data));
@@ -653,16 +716,25 @@ async function doUpdateRecord(
     tableResult.data.fields
   );
 
+  const mergedData = {
+    ...(existingRecord.data as Record<string, unknown>),
+    ...scalarData,
+  };
+  const changes = detectFieldChanges(
+    existingRecord.data as Record<string, unknown>,
+    mergedData,
+    tableResult.data.fields
+  );
+
   await tx.dataRecord.update({
     where: { id },
     data: {
-      data: toJsonInput({
-        ...(existingRecord.data as Record<string, unknown>),
-        ...scalarData,
-      }),
+      data: toJsonInput(mergedData),
       updatedById: userId,
     },
   });
+
+  await recordChangeHistory(tx, id, existingRecord.tableId, changes, userId);
 
   if (Object.keys(scalarData).length > 0) {
     const refreshResult = await refreshSnapshotsForTargetRecord({
@@ -791,27 +863,31 @@ export async function patchField(
 
     const enrichedData = computeFormulaValues(updatedData, tableResult.data.fields);
 
-    await db.dataRecord.update({
-      where: { id: recordId },
-      data: {
-        data: toJsonInput(enrichedData),
-        updatedById: userId,
-      },
-    });
+    const changes = detectFieldChanges(currentData, enrichedData, tableResult.data.fields);
 
-    // Refresh snapshots only for relation fields
-    if (field.type === "RELATION" || field.type === "RELATION_SUBTABLE") {
-      try {
-        await db.$transaction(async (tx) => {
+    await db.$transaction(async (tx) => {
+      await tx.dataRecord.update({
+        where: { id: recordId },
+        data: {
+          data: toJsonInput(enrichedData),
+          updatedById: userId,
+        },
+      });
+
+      await recordChangeHistory(tx, recordId, existingRecord.tableId, changes, userId);
+
+      // Refresh snapshots only for relation fields
+      if (field.type === "RELATION" || field.type === "RELATION_SUBTABLE") {
+        try {
           const refreshResult = await refreshSnapshotsForTargetRecord({ tx, recordId });
           if (!refreshResult.success) {
             throw new Error(`${refreshResult.error.code}:${refreshResult.error.message}`);
           }
-        });
-      } catch {
-        // Snapshot refresh failure should not block the patch
+        } catch {
+          // Snapshot refresh failure should not block the patch
+        }
       }
-    }
+    });
 
     // Fetch updated record with relations
     const updatedRecord = await db.dataRecord.findUnique({


### PR DESCRIPTION
## Summary
- 新增 `DataRecordChangeHistory` Prisma 模型，存储字段级变更（旧值/新值/操作人/时间）
- `doUpdateRecord` 和 `patchField` 中自动检测字段变更并写入历史
- 新增 API 路由 `GET /api/data-tables/[id]/records/[recordId]/history`，支持分页和日期范围筛选
- 记录详情抽屉添加"变更历史"标签页，展示变更时间线（操作人·时间 + 字段名: 旧值→新值）
- 跳过 RELATION_SUBTABLE / SYSTEM_TIMESTAMP / SYSTEM_USER / FORMULA 等系统字段

## Test plan
- [ ] 编辑单元格后打开记录详情 → 变更历史标签页显示变更记录
- [ ] 批量更新记录后查看变更历史
- [ ] 日期范围筛选功能
- [ ] "加载更多"分页
- [ ] 删除记录后变更历史级联删除

Closes #52