### PR TITLE
[Feature] 填表页面 AI 填充助手

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,7 @@ model User {
   dataTables    DataTable[]
   dataRecords   DataRecord[]
   updatedDataRecords DataRecord[]  @relation("UpdatedByUser")
+  changeHistories     DataRecordChangeHistory[]
   batchGenerations BatchGeneration[]
   publishedTemplateVersions TemplateVersion[]
   aiConversations AiConversation[]
@@ -180,8 +181,9 @@ model Template {
   categoryId    String?
   category      Category?       @relation(fields: [categoryId], references: [id], onDelete: SetNull)
   tags          TagOnTemplate[]
-  fieldMapping  Json?
-  placeholders  Placeholder[]
+  fieldMapping     Json?
+  fillAssistPrompt String?
+  placeholders     Placeholder[]
   drafts        Draft[]
   records       Record[]
   batchGenerations BatchGeneration[]
@@ -365,6 +367,26 @@ model DataRecord {
   @@index([updatedById])
   @@index([tableId, createdAt(sort: Desc)])  // 复合索引加速列表查询
   @@index([tableId, createdById])             // 复合索引加速用户记录查询
+  changeHistories DataRecordChangeHistory[]
+}
+
+model DataRecordChangeHistory {
+  id          String    @id @default(cuid())
+  recordId    String
+  record      DataRecord @relation(fields: [recordId], references: [id], onDelete: Cascade)
+  tableId     String
+  fieldKey    String
+  fieldLabel  String
+  oldValue    Json?
+  newValue    Json?
+  changedById String
+  changedBy   User      @relation(fields: [changedById], references: [id], onDelete: SetNull)
+  changedAt   DateTime  @default(now())
+
+  @@index([recordId, changedAt(sort: Desc)])
+  @@index([tableId, changedAt(sort: Desc)])
+  @@index([changedById])
+  @@map("data_record_change_history")
 }
 
 model DataRelationRow {
@@ -705,6 +727,8 @@ enum AuditAction {
   DATA_TABLE_UPDATE
   DATA_TABLE_DELETE
   DATA_RECORD_CREATE
+  DATA_RECORD_UPDATE
+  DATA_RECORD_DELETE
   DATA_IMPORT
   DATA_EXPORT
   USER_CREATE

--- a/src/app/(dashboard)/templates/[id]/page.tsx
+++ b/src/app/(dashboard)/templates/[id]/page.tsx
@@ -37,6 +37,7 @@ import { VersionHistoryDialogWrapper } from "./version-history-wrapper";
 import { PlaceholderEditButton } from "./placeholder-edit-wrapper";
 import { getPlaceholderInputTypeLabel } from "@/lib/placeholder-input-type";
 import { ScreenshotViewer } from "@/components/templates/screenshot-viewer";
+import { FillAssistPromptEditor } from "@/components/templates/fill-assist-prompt-editor";
 
 const STATUS_LABELS: Record<TemplateStatus, string> = {
   DRAFT: "草稿",
@@ -250,6 +251,24 @@ export default async function TemplateDetailPage({
                 label: ph.label,
                 required: ph.required,
               }))}
+            />
+          </CardContent>
+        </Card>
+      )}
+
+      {/* AI Fill Assist Prompt — admin only */}
+      {isAdmin && (
+        <Card>
+          <CardHeader>
+            <CardTitle>AI 填充助手配置</CardTitle>
+            <CardDescription>
+              为此模板配置专属的 AI 填充提示词，指导 AI 助手在用户填表时生成更精准的建议
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <FillAssistPromptEditor
+              templateId={template.id}
+              initialValue={template.fillAssistPrompt}
             />
           </CardContent>
         </Card>

--- a/src/app/api/ai/fill-assist/route.ts
+++ b/src/app/api/ai/fill-assist/route.ts
@@ -5,6 +5,7 @@ import { randomUUID } from "crypto";
 import { z } from "zod";
 import { resolveModel } from "@/lib/agent2/model-resolver";
 import { createTools } from "@/lib/agent2/tools";
+import { db } from "@/lib/db";
 
 const SYSTEM_PROMPT = `你是一个文档表单填充助手。用户正在填写一个文档模板的表单，你需要根据用户的需求，为表单字段生成合适的填充建议。
 
@@ -38,6 +39,7 @@ const fillAssistSchema = z.object({
     })
   ),
   model: z.string().optional(),
+  templateId: z.string().optional(),
   context: z.object({
     templateName: z.string(),
     fields: z.array(
@@ -79,9 +81,21 @@ export async function POST(request: NextRequest) {
       })
       .join("\n");
 
+    // Fetch template-specific prompt if templateId provided
+    let customPrompt = "";
+    if (validated.templateId) {
+      const template = await db.template.findUnique({
+        where: { id: validated.templateId },
+        select: { fillAssistPrompt: true },
+      });
+      if (template?.fillAssistPrompt) {
+        customPrompt = `\n## 模板专属指令\n${template.fillAssistPrompt}\n`;
+      }
+    }
+
     const systemPrompt = [
       SYSTEM_PROMPT,
-      "",
+      customPrompt,
       "## 当前表单信息",
       `模板: ${validated.context.templateName}`,
       "",

--- a/src/app/api/ai/fill-assist/route.ts
+++ b/src/app/api/ai/fill-assist/route.ts
@@ -1,33 +1,33 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { streamText } from "ai";
+import { randomUUID } from "crypto";
 import { z } from "zod";
 import { resolveModel } from "@/lib/agent2/model-resolver";
+import { createTools } from "@/lib/agent2/tools";
 
 const SYSTEM_PROMPT = `你是一个文档表单填充助手。用户正在填写一个文档模板的表单，你需要根据用户的需求，为表单字段生成合适的填充建议。
 
+## 核心能力
+
+你可以使用工具来查询系统中的数据，帮助用户更准确地填写表单：
+- **listTables**: 查看系统中有哪些数据表
+- **getTableSchema**: 查看某个数据表的字段结构
+- **searchRecords**: 搜索数据表中的记录（支持筛选、分页）
+- **getRecord**: 获取单条记录的详情
+
+例如，如果用户说"帮我查找张三的联系方式"，你可以使用 searchRecords 查询用户表，获取张三的信息后填入表单。
+
 ## 规则
 
-1. 根据用户的描述和表单上下文，生成字段填充建议
-2. 你的回复应该包含两部分：
-   - 简短的文字说明你生成了什么
+1. 优先使用工具查询真实数据来填充表单，而不是编造数据
+2. 查询到数据后，将结果映射到表单字段生成填充建议
+3. 你的回复应该包含两部分：
+   - 简短的文字说明你做了什么（如查到了什么数据）
    - 一个 JSON 代码块，格式为 \`\`\`json ... \`\`\`，包含字段填充建议
-3. JSON 格式为 { "field_key": "建议值" }，只包含你能确定值的字段
-4. 对于不确定的字段，不要包含在 JSON 中
-5. 保持专业、简洁的语气
-6. 如果用户只提问而不要求填充，正常回答即可，不需要输出 JSON
-
-## 示例回复
-
-根据您的要求，我为您生成了一份关于人工智能发展趋势的报告摘要。
-
-\`\`\`json
-{
-  "title": "2024年人工智能发展趋势报告",
-  "author": "张三",
-  "abstract": "本报告分析了人工智能在自然语言处理、计算机视觉等领域的最新进展..."
-}
-\`\`\``;
+4. JSON 格式为 { "field_key": "建议值" }，只包含你能确定值的字段
+5. 对于不确定的字段，不要包含在 JSON 中
+6. 如果用户只提问而不要求填充，正常回答即可，不需要输出 JSON`;
 
 const fillAssistSchema = z.object({
   messages: z.array(
@@ -64,7 +64,7 @@ export async function POST(request: NextRequest) {
     const modelId = validated.model || process.env.AI_MODEL || "gpt-4o";
     const model = await resolveModel(modelId, session.user.id);
 
-    // Build context-aware user prompt
+    // Build context-aware system prompt
     const fieldsDescription = validated.context.fields
       .map((f) => {
         const current = validated.context.currentValues[f.key];
@@ -74,27 +74,37 @@ export async function POST(request: NextRequest) {
       })
       .join("\n");
 
-    const contextMessage = {
-      role: "system" as const,
-      content: [
-        SYSTEM_PROMPT,
-        "",
-        "## 当前表单信息",
-        `模板: ${validated.context.templateName}`,
-        "",
-        "## 可填充字段",
-        fieldsDescription,
-      ].join("\n"),
-    };
+    const systemPrompt = [
+      SYSTEM_PROMPT,
+      "",
+      "## 当前表单信息",
+      `模板: ${validated.context.templateName}`,
+      "",
+      "## 可填充字段",
+      fieldsDescription,
+    ].join("\n");
 
-    const messages = [contextMessage, ...validated.messages.map((m) => ({
+    const messages = validated.messages.map((m) => ({
       role: m.role as "user" | "assistant",
       content: m.content,
-    }))];
+    }));
+
+    // Create tools — use a fake conversation/message ID since we don't persist
+    const fakeConversationId = `fill-assist-${randomUUID()}`;
+    const fakeMessageId = randomUUID();
+    const tools = createTools(
+      fakeConversationId,
+      fakeMessageId,
+      session.user.id,
+      session.user.role
+    );
 
     const result = streamText({
       model,
+      system: systemPrompt,
       messages,
+      tools,
+      stopWhen: ({ steps }) => steps.length >= 5,
     });
 
     return result.toTextStreamResponse();

--- a/src/app/api/ai/fill-assist/route.ts
+++ b/src/app/api/ai/fill-assist/route.ts
@@ -27,7 +27,8 @@ const SYSTEM_PROMPT = `你是一个文档表单填充助手。用户正在填写
    - 一个 JSON 代码块，格式为 \`\`\`json ... \`\`\`，包含字段填充建议
 4. JSON 格式为 { "field_key": "建议值" }，只包含你能确定值的字段
 5. 对于不确定的字段，不要包含在 JSON 中
-6. 如果用户只提问而不要求填充，正常回答即可，不需要输出 JSON`;
+6. 如果用户只提问而不要求填充，正常回答即可，不需要输出 JSON
+7. **重要**：对于标记为 [CHOICE_SINGLE] 或 [CHOICE_MULTI] 的字段，其可选值会在字段后列出。你必须且只能从列出的选项中选择，不要使用选项以外的值`;
 
 const fillAssistSchema = z.object({
   messages: z.array(
@@ -45,6 +46,7 @@ const fillAssistSchema = z.object({
         label: z.string(),
         type: z.string(),
         description: z.string().optional(),
+        options: z.array(z.object({ value: z.string(), label: z.string() })).optional(),
       })
     ),
     currentValues: z.record(z.string(), z.string()),
@@ -70,7 +72,10 @@ export async function POST(request: NextRequest) {
         const current = validated.context.currentValues[f.key];
         const suffix = current ? `（当前值: ${current})` : "";
         const desc = f.description ? ` — ${f.description}` : "";
-        return `- ${f.label} (${f.key}) [${f.type}]${desc}${suffix}`;
+        const options = f.options && f.options.length > 0
+          ? `，可选值: [${f.options.map((o) => o.label).join(", ")}]`
+          : "";
+        return `- ${f.label} (${f.key}) [${f.type}]${desc}${suffix}${options}`;
       })
       .join("\n");
 

--- a/src/app/api/ai/fill-assist/route.ts
+++ b/src/app/api/ai/fill-assist/route.ts
@@ -29,7 +29,7 @@ const SYSTEM_PROMPT = `你是一个文档表单填充助手。用户正在填写
 4. JSON 格式为 { "field_key": "建议值" }，只包含你能确定值的字段
 5. 对于不确定的字段，不要包含在 JSON 中
 6. 如果用户只提问而不要求填充，正常回答即可，不需要输出 JSON
-7. **重要**：对于标记为 [CHOICE_SINGLE] 或 [CHOICE_MULTI] 的字段，其可选值会在字段后列出。你必须且只能从列出的选项中选择，不要使用选项以外的值`;
+7. **重要**：对于标记为 [CHOICE_SINGLE] 或 [CHOICE_MULTI] 的字段，其可选值会在字段后列出（格式为"显示名(实际值)"或仅"显示名"当两者相同时）。你必须且只能从列出的选项中选择，并在 JSON 中使用括号内的实际值。对于 CHOICE_MULTI 字段，值应为数组，如 { "field_key": ["value1", "value2"] }`;
 
 const fillAssistSchema = z.object({
   messages: z.array(
@@ -75,7 +75,7 @@ export async function POST(request: NextRequest) {
         const suffix = current ? `（当前值: ${current})` : "";
         const desc = f.description ? ` — ${f.description}` : "";
         const options = f.options && f.options.length > 0
-          ? `，可选值: [${f.options.map((o) => o.label).join(", ")}]`
+          ? `，可选值: [${f.options.map((o) => o.label === o.value ? o.label : `${o.label}(${o.value})`).join(", ")}]`
           : "";
         return `- ${f.label} (${f.key}) [${f.type}]${desc}${suffix}${options}`;
       })

--- a/src/app/api/ai/fill-assist/route.ts
+++ b/src/app/api/ai/fill-assist/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { streamText } from "ai";
+import { z } from "zod";
+import { resolveModel } from "@/lib/agent2/model-resolver";
+
+const SYSTEM_PROMPT = `你是一个文档表单填充助手。用户正在填写一个文档模板的表单，你需要根据用户的需求，为表单字段生成合适的填充建议。
+
+## 规则
+
+1. 根据用户的描述和表单上下文，生成字段填充建议
+2. 你的回复应该包含两部分：
+   - 简短的文字说明你生成了什么
+   - 一个 JSON 代码块，格式为 \`\`\`json ... \`\`\`，包含字段填充建议
+3. JSON 格式为 { "field_key": "建议值" }，只包含你能确定值的字段
+4. 对于不确定的字段，不要包含在 JSON 中
+5. 保持专业、简洁的语气
+6. 如果用户只提问而不要求填充，正常回答即可，不需要输出 JSON
+
+## 示例回复
+
+根据您的要求，我为您生成了一份关于人工智能发展趋势的报告摘要。
+
+\`\`\`json
+{
+  "title": "2024年人工智能发展趋势报告",
+  "author": "张三",
+  "abstract": "本报告分析了人工智能在自然语言处理、计算机视觉等领域的最新进展..."
+}
+\`\`\``;
+
+const fillAssistSchema = z.object({
+  messages: z.array(
+    z.object({
+      role: z.enum(["user", "assistant"]),
+      content: z.string(),
+    })
+  ),
+  model: z.string().optional(),
+  context: z.object({
+    templateName: z.string(),
+    fields: z.array(
+      z.object({
+        key: z.string(),
+        label: z.string(),
+        type: z.string(),
+        description: z.string().optional(),
+      })
+    ),
+    currentValues: z.record(z.string(), z.string()),
+  }),
+});
+
+export async function POST(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "未授权" }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    const validated = fillAssistSchema.parse(body);
+
+    const modelId = validated.model || process.env.AI_MODEL || "gpt-4o";
+    const model = await resolveModel(modelId, session.user.id);
+
+    // Build context-aware user prompt
+    const fieldsDescription = validated.context.fields
+      .map((f) => {
+        const current = validated.context.currentValues[f.key];
+        const suffix = current ? `（当前值: ${current})` : "";
+        const desc = f.description ? ` — ${f.description}` : "";
+        return `- ${f.label} (${f.key}) [${f.type}]${desc}${suffix}`;
+      })
+      .join("\n");
+
+    const contextMessage = {
+      role: "system" as const,
+      content: [
+        SYSTEM_PROMPT,
+        "",
+        "## 当前表单信息",
+        `模板: ${validated.context.templateName}`,
+        "",
+        "## 可填充字段",
+        fieldsDescription,
+      ].join("\n"),
+    };
+
+    const messages = [contextMessage, ...validated.messages.map((m) => ({
+      role: m.role as "user" | "assistant",
+      content: m.content,
+    }))];
+
+    const result = streamText({
+      model,
+      messages,
+    });
+
+    return result.toTextStreamResponse();
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "请求参数无效", details: error.issues },
+        { status: 400 }
+      );
+    }
+    console.error("[fill-assist] Error:", error);
+    return NextResponse.json(
+      { error: "AI 服务暂时不可用" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/templates/[id]/route.ts
+++ b/src/app/api/templates/[id]/route.ts
@@ -69,6 +69,7 @@ export async function PUT(
       fieldMapping?: Record<string, string | null>;
       categoryId?: string | null;
       tagIds?: string[];
+      fillAssistPrompt?: string | null;
     } = {};
 
     if (parsed.name !== undefined) updateData.name = parsed.name;
@@ -78,6 +79,7 @@ export async function PUT(
     if (parsed.fieldMapping !== undefined) updateData.fieldMapping = parsed.fieldMapping;
     if (parsed.categoryId !== undefined) updateData.categoryId = parsed.categoryId;
     if (parsed.tagIds !== undefined) updateData.tagIds = parsed.tagIds;
+    if (parsed.fillAssistPrompt !== undefined) updateData.fillAssistPrompt = parsed.fillAssistPrompt;
 
     // Only call updateTemplate if there's something to update
     if (Object.keys(updateData).length > 0) {

--- a/src/components/forms/ai-fill-assistant.tsx
+++ b/src/components/forms/ai-fill-assistant.tsx
@@ -11,6 +11,7 @@ interface FieldInfo {
   label: string;
   type: string;
   description?: string;
+  options?: { value: string; label: string }[];
 }
 
 interface AiFillAssistantProps {

--- a/src/components/forms/ai-fill-assistant.tsx
+++ b/src/components/forms/ai-fill-assistant.tsx
@@ -15,6 +15,7 @@ interface FieldInfo {
 }
 
 interface AiFillAssistantProps {
+  templateId: string;
   templateName: string;
   fields: FieldInfo[];
   currentValues: Record<string, string>;
@@ -51,6 +52,7 @@ function extractFillValues(text: string): Record<string, string> | null {
 }
 
 export function AiFillAssistant({
+  templateId,
   templateName,
   fields,
   currentValues,
@@ -97,6 +99,7 @@ export function AiFillAssistant({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           messages: newMessages.map((m) => ({ role: m.role, content: m.content })),
+          templateId,
           context: {
             templateName,
             fields,

--- a/src/components/forms/ai-fill-assistant.tsx
+++ b/src/components/forms/ai-fill-assistant.tsx
@@ -19,7 +19,7 @@ interface AiFillAssistantProps {
   templateName: string;
   fields: FieldInfo[];
   currentValues: Record<string, string>;
-  onFill: (values: Record<string, string>) => void;
+  onFill: (values: Record<string, string | string[]>) => void;
 }
 
 interface ChatMessage {
@@ -27,8 +27,10 @@ interface ChatMessage {
   content: string;
 }
 
+type FillValue = string | string[];
+
 /** Extract JSON block from AI response */
-function extractFillValues(text: string): Record<string, string> | null {
+function extractFillValues(text: string): Record<string, FillValue> | null {
   // Try to find ```json ... ``` block
   const jsonMatch = text.match(/```json\s*([\s\S]*?)```/);
   if (!jsonMatch) return null;
@@ -36,11 +38,12 @@ function extractFillValues(text: string): Record<string, string> | null {
   try {
     const parsed = JSON.parse(jsonMatch[1]);
     if (typeof parsed === "object" && parsed !== null) {
-      // Only keep string values
-      const result: Record<string, string> = {};
+      const result: Record<string, FillValue> = {};
       for (const [k, v] of Object.entries(parsed)) {
         if (typeof v === "string" || typeof v === "number") {
           result[k] = String(v);
+        } else if (Array.isArray(v) && v.every((item) => typeof item === "string")) {
+          result[k] = v as string[];
         }
       }
       return Object.keys(result).length > 0 ? result : null;
@@ -62,7 +65,7 @@ export function AiFillAssistant({
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
-  const [suggestions, setSuggestions] = useState<Record<string, string> | null>(null);
+  const [suggestions, setSuggestions] = useState<Record<string, FillValue> | null>(null);
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
   const [applied, setApplied] = useState(false);
 
@@ -160,7 +163,7 @@ export function AiFillAssistant({
 
   const handleApply = () => {
     if (!suggestions) return;
-    const toApply: Record<string, string> = {};
+    const toApply: Record<string, FillValue> = {};
     for (const key of selectedKeys) {
       if (suggestions[key] !== undefined) {
         toApply[key] = suggestions[key];
@@ -277,7 +280,7 @@ export function AiFillAssistant({
                           <span className="text-amber-500 text-[10px]">覆盖</span>
                         )}
                       </div>
-                      <div className="text-muted-foreground truncate">{value}</div>
+                      <div className="text-muted-foreground truncate">{Array.isArray(value) ? value.join(", ") : value}</div>
                     </div>
                   </button>
                 ))}

--- a/src/components/forms/ai-fill-assistant.tsx
+++ b/src/components/forms/ai-fill-assistant.tsx
@@ -192,7 +192,7 @@ export function AiFillAssistant({
       <Button
         size="icon"
         className={cn(
-          "fixed bottom-6 right-6 z-50 rounded-full size-12 shadow-lg transition-transform",
+          "fixed top-20 right-6 z-50 rounded-full size-12 shadow-lg transition-transform",
           open && "scale-0"
         )}
         onClick={() => setOpen(true)}
@@ -202,7 +202,7 @@ export function AiFillAssistant({
 
       {/* Panel */}
       {open && (
-        <div className="fixed bottom-6 right-6 z-50 w-[400px] max-h-[520px] flex flex-col rounded-lg border bg-background shadow-xl">
+        <div className="fixed top-20 right-6 z-50 w-[400px] max-h-[520px] flex flex-col rounded-lg border bg-background shadow-xl">
           {/* Header */}
           <div className="flex items-center justify-between px-4 py-3 border-b">
             <div className="flex items-center gap-2">

--- a/src/components/forms/ai-fill-assistant.tsx
+++ b/src/components/forms/ai-fill-assistant.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { Sparkles, X, Send, Loader2, Check, Undo2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+interface FieldInfo {
+  key: string;
+  label: string;
+  type: string;
+  description?: string;
+}
+
+interface AiFillAssistantProps {
+  templateName: string;
+  fields: FieldInfo[];
+  currentValues: Record<string, string>;
+  onFill: (values: Record<string, string>) => void;
+}
+
+interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+/** Extract JSON block from AI response */
+function extractFillValues(text: string): Record<string, string> | null {
+  // Try to find ```json ... ``` block
+  const jsonMatch = text.match(/```json\s*([\s\S]*?)```/);
+  if (!jsonMatch) return null;
+
+  try {
+    const parsed = JSON.parse(jsonMatch[1]);
+    if (typeof parsed === "object" && parsed !== null) {
+      // Only keep string values
+      const result: Record<string, string> = {};
+      for (const [k, v] of Object.entries(parsed)) {
+        if (typeof v === "string" || typeof v === "number") {
+          result[k] = String(v);
+        }
+      }
+      return Object.keys(result).length > 0 ? result : null;
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return null;
+}
+
+export function AiFillAssistant({
+  templateName,
+  fields,
+  currentValues,
+  onFill,
+}: AiFillAssistantProps) {
+  const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [suggestions, setSuggestions] = useState<Record<string, string> | null>(null);
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
+  const [applied, setApplied] = useState(false);
+
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Scroll to bottom on new messages
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, loading]);
+
+  // Reset suggestions when new messages arrive
+  useEffect(() => {
+    setSuggestions(null);
+    setSelectedKeys(new Set());
+    setApplied(false);
+  }, [messages.length]);
+
+  const handleSend = useCallback(async () => {
+    const trimmed = input.trim();
+    if (!trimmed || loading) return;
+
+    const userMessage: ChatMessage = { role: "user", content: trimmed };
+    const newMessages = [...messages, userMessage];
+    setMessages(newMessages);
+    setInput("");
+    setLoading(true);
+
+    try {
+      abortRef.current = new AbortController();
+
+      const res = await fetch("/api/ai/fill-assist", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: newMessages.map((m) => ({ role: m.role, content: m.content })),
+          context: {
+            templateName,
+            fields,
+            currentValues,
+          },
+        }),
+        signal: abortRef.current.signal,
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: "请求失败" }));
+        setMessages((prev) => [
+          ...prev,
+          { role: "assistant", content: `出错了: ${err.error || "请稍后重试"}` },
+        ]);
+        return;
+      }
+
+      // Read stream
+      const reader = res.body?.getReader();
+      if (!reader) return;
+
+      const decoder = new TextDecoder();
+      let fullContent = "";
+
+      setMessages((prev) => [...prev, { role: "assistant", content: "" }]);
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        const chunk = decoder.decode(value, { stream: true });
+        fullContent += chunk;
+
+        setMessages((prev) => {
+          const updated = [...prev];
+          updated[updated.length - 1] = { role: "assistant", content: fullContent };
+          return updated;
+        });
+      }
+
+      // Try to extract fill values from the response
+      const values = extractFillValues(fullContent);
+      if (values) {
+        setSuggestions(values);
+        setSelectedKeys(new Set(Object.keys(values)));
+      }
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      setMessages((prev) => [
+        ...prev,
+        { role: "assistant", content: "网络错误，请稍后重试" },
+      ]);
+    } finally {
+      setLoading(false);
+      abortRef.current = null;
+    }
+  }, [input, loading, messages, templateName, fields, currentValues]);
+
+  const handleApply = () => {
+    if (!suggestions) return;
+    const toApply: Record<string, string> = {};
+    for (const key of selectedKeys) {
+      if (suggestions[key] !== undefined) {
+        toApply[key] = suggestions[key];
+      }
+    }
+    if (Object.keys(toApply).length > 0) {
+      onFill(toApply);
+      setApplied(true);
+    }
+  };
+
+  const toggleKey = (key: string) => {
+    setSelectedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const labelForKey = (key: string) => {
+    return fields.find((f) => f.key === key)?.label ?? key;
+  };
+
+  const hasExistingValue = (key: string) => {
+    const val = currentValues[key];
+    return val !== undefined && val !== "";
+  };
+
+  return (
+    <>
+      {/* Floating button */}
+      <Button
+        size="icon"
+        className={cn(
+          "fixed bottom-6 right-6 z-50 rounded-full size-12 shadow-lg transition-transform",
+          open && "scale-0"
+        )}
+        onClick={() => setOpen(true)}
+      >
+        <Sparkles className="size-5" />
+      </Button>
+
+      {/* Panel */}
+      {open && (
+        <div className="fixed bottom-6 right-6 z-50 w-[400px] max-h-[520px] flex flex-col rounded-lg border bg-background shadow-xl">
+          {/* Header */}
+          <div className="flex items-center justify-between px-4 py-3 border-b">
+            <div className="flex items-center gap-2">
+              <Sparkles className="size-4 text-primary" />
+              <span className="text-sm font-medium">AI 填充助手</span>
+            </div>
+            <Button variant="ghost" size="icon-xs" onClick={() => setOpen(false)}>
+              <X className="size-4" />
+            </Button>
+          </div>
+
+          {/* Messages */}
+          <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3 min-h-0" style={{ maxHeight: 300 }}>
+            {messages.length === 0 && (
+              <div className="text-xs text-muted-foreground text-center py-8">
+                描述你想要的内容，AI 将为你生成表单填充建议
+              </div>
+            )}
+            {messages.map((msg, i) => (
+              <div
+                key={i}
+                className={cn(
+                  "text-sm rounded-lg px-3 py-2 max-w-[90%] whitespace-pre-wrap break-words",
+                  msg.role === "user"
+                    ? "bg-primary text-primary-foreground ml-auto"
+                    : "bg-muted"
+                )}
+              >
+                {msg.content || (
+                  <span className="inline-flex items-center gap-1 text-muted-foreground">
+                    <Loader2 className="size-3 animate-spin" /> 思考中...
+                  </span>
+                )}
+              </div>
+            ))}
+            <div ref={messagesEndRef} />
+          </div>
+
+          {/* Suggestions */}
+          {suggestions && !applied && (
+            <div className="border-t px-4 py-3 space-y-2">
+              <div className="text-xs font-medium text-muted-foreground">
+                填充建议（点击选择要应用的字段）
+              </div>
+              <div className="space-y-1 max-h-32 overflow-y-auto">
+                {Object.entries(suggestions).map(([key, value]) => (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => toggleKey(key)}
+                    className={cn(
+                      "w-full text-left px-2 py-1.5 rounded text-xs flex items-start gap-2 transition-colors",
+                      selectedKeys.has(key)
+                        ? "bg-primary/10 border border-primary/30"
+                        : "bg-muted/50 border border-transparent"
+                    )}
+                  >
+                    <Check
+                      className={cn(
+                        "size-3.5 mt-0.5 shrink-0",
+                        selectedKeys.has(key) ? "text-primary" : "text-muted-foreground/30"
+                      )}
+                    />
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-1">
+                        <span className="font-medium">{labelForKey(key)}</span>
+                        {hasExistingValue(key) && (
+                          <span className="text-amber-500 text-[10px]">覆盖</span>
+                        )}
+                      </div>
+                      <div className="text-muted-foreground truncate">{value}</div>
+                    </div>
+                  </button>
+                ))}
+              </div>
+              <Button
+                size="sm"
+                className="w-full"
+                onClick={handleApply}
+                disabled={selectedKeys.size === 0}
+              >
+                <Undo2 className="size-3.5" />
+                应用选中字段（{selectedKeys.size}）
+              </Button>
+            </div>
+          )}
+
+          {applied && (
+            <div className="border-t px-4 py-2 text-xs text-green-600 text-center">
+              已填充 {selectedKeys.size} 个字段
+            </div>
+          )}
+
+          {/* Input */}
+          <div className="border-t px-3 py-2">
+            <div className="flex items-end gap-2">
+              <Textarea
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    handleSend();
+                  }
+                }}
+                placeholder="描述你想要的内容..."
+                className="min-h-[36px] max-h-[80px] resize-none text-sm"
+                rows={1}
+                disabled={loading}
+              />
+              <Button
+                size="icon"
+                className="shrink-0 size-9"
+                onClick={handleSend}
+                disabled={loading || !input.trim()}
+              >
+                {loading ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Send className="size-4" />
+                )}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/forms/dynamic-form.tsx
+++ b/src/components/forms/dynamic-form.tsx
@@ -416,7 +416,13 @@ export function DynamicForm({
           ])
         )}
         onFill={(values) => {
-          setFormData((prev) => ({ ...prev, ...values }));
+          setFormData((prev) => {
+            const updated = { ...prev };
+            for (const [k, v] of Object.entries(values)) {
+              updated[k] = v;
+            }
+            return updated;
+          });
           // Clear errors for filled fields
           setErrors((prev) => {
             const next = { ...prev };

--- a/src/components/forms/dynamic-form.tsx
+++ b/src/components/forms/dynamic-form.tsx
@@ -400,6 +400,7 @@ export function DynamicForm({
 
       {/* AI Fill Assistant */}
       <AiFillAssistant
+        templateId={templateId}
         templateName={templateId}
         fields={sorted.map((ph) => ({
           key: ph.key,

--- a/src/components/forms/dynamic-form.tsx
+++ b/src/components/forms/dynamic-form.tsx
@@ -406,6 +406,7 @@ export function DynamicForm({
           label: ph.label,
           type: ph.inputType,
           description: ph.description ?? undefined,
+          options: ph.choiceConfig?.options,
         }))}
         currentValues={Object.fromEntries(
           Object.entries(formData).map(([k, v]) => [

--- a/src/components/forms/dynamic-form.tsx
+++ b/src/components/forms/dynamic-form.tsx
@@ -13,6 +13,7 @@ import { cn } from "@/lib/utils";
 import { DataPickerDialog } from "./data-picker-dialog";
 import { DynamicTableField } from "./dynamic-table-field";
 import { ChoicePickerField } from "./choice-picker-field";
+import { AiFillAssistant } from "./ai-fill-assistant";
 
 interface Placeholder {
   id: string;
@@ -395,6 +396,34 @@ export function DynamicForm({
         placeholderId={activePickerPlaceholder?.id ?? ""}
         fields={tableFields}
         onSelect={handlePickerSelect}
+      />
+
+      {/* AI Fill Assistant */}
+      <AiFillAssistant
+        templateName={templateId}
+        fields={sorted.map((ph) => ({
+          key: ph.key,
+          label: ph.label,
+          type: ph.inputType,
+          description: ph.description ?? undefined,
+        }))}
+        currentValues={Object.fromEntries(
+          Object.entries(formData).map(([k, v]) => [
+            k,
+            typeof v === "string" ? v : JSON.stringify(v),
+          ])
+        )}
+        onFill={(values) => {
+          setFormData((prev) => ({ ...prev, ...values }));
+          // Clear errors for filled fields
+          setErrors((prev) => {
+            const next = { ...prev };
+            for (const key of Object.keys(values)) {
+              delete next[key];
+            }
+            return next;
+          });
+        }}
       />
     </div>
   );

--- a/src/components/templates/fill-assist-prompt-editor.tsx
+++ b/src/components/templates/fill-assist-prompt-editor.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Save, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+interface FillAssistPromptEditorProps {
+  templateId: string;
+  initialValue: string | null;
+}
+
+export function FillAssistPromptEditor({
+  templateId,
+  initialValue,
+}: FillAssistPromptEditorProps) {
+  const [prompt, setPrompt] = useState(initialValue ?? "");
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/templates/${templateId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ fillAssistPrompt: prompt || null }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        toast.error(data?.error?.message || "保存失败");
+        return;
+      }
+      setDirty(false);
+      toast.success("AI 填充提示词已保存");
+    } catch {
+      toast.error("保存失败");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <Label className="text-sm font-medium">AI 填充提示词</Label>
+      <p className="text-xs text-muted-foreground">
+        配置后，用户填表时 AI 助手将遵循此指令来生成填充建议。留空则使用默认行为。
+      </p>
+      <Textarea
+        value={prompt}
+        onChange={(e) => {
+          setPrompt(e.target.value);
+          setDirty(true);
+        }}
+        placeholder="例如：请使用正式公文用语填写，金额字段使用大写中文数字..."
+        rows={4}
+        className="text-sm"
+      />
+      {dirty && (
+        <Button size="sm" onClick={handleSave} disabled={saving}>
+          {saving ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Save className="h-3.5 w-3.5" />
+          )}
+          保存提示词
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/lib/services/template.service.ts
+++ b/src/lib/services/template.service.ts
@@ -249,6 +249,7 @@ export async function updateTemplate(
     fieldMapping?: Record<string, string | null>;
     categoryId?: string | null;
     tagIds?: string[];
+    fillAssistPrompt?: string | null;
   }
 ): Promise<ServiceResult<TemplateListItem>> {
   try {
@@ -261,6 +262,7 @@ export async function updateTemplate(
       updateData.fieldMapping = data.fieldMapping;
     }
     if (data.categoryId !== undefined) updateData.categoryId = data.categoryId;
+    if (data.fillAssistPrompt !== undefined) updateData.fillAssistPrompt = data.fillAssistPrompt;
 
     const template = await db.template.update({
       where: { id },

--- a/src/validators/template.ts
+++ b/src/validators/template.ts
@@ -19,6 +19,7 @@ export const updateTemplateSchema = z.object({
   fieldMapping: fieldMappingSchema,
   categoryId: z.string().nullable().optional(),
   tagIds: z.array(z.string()).optional(),
+  fillAssistPrompt: z.string().max(2000).nullable().optional(),
 });
 
 export const templateQuerySchema = z.object({


### PR DESCRIPTION
## Summary
- 填表页面新增浮动 AI 助手，支持大模型辅助内容填充
- 集成 agent2 工具能力（查询数据表、搜索记录、获取时间等）
- 下拉选项字段（CHOICE_SINGLE/CHOICE_MULTI）严格约束为可选值
- 支持模板级别配置 AI 填充 system prompt，管理员可在模板详情页自定义

## Test plan
- [ ] 填表页面右上角 AI 助手按钮可正常打开/关闭
- [ ] 发送消息后 AI 流式返回响应，JSON 填充建议可选择性应用
- [ ] 下拉选项字段仅建议已有选项值
- [ ] 模板详情页管理员可见 "AI 填充助手配置" 卡片
- [ ] 配置模板专属提示词后，AI 填充行为遵循自定义指令
- [ ] 文档生成功能正常（Python 服务需启动）

🤖 Generated with [Claude Code](https://claude.com/claude-code)