### PR TITLE
[Feature] 数据表导航增强：Ctrl+方向键跳转、Ctrl+; 填入日期

### DIFF
--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -993,6 +993,17 @@ export function GridView({
         onOpenDetail(entry.record.id);
       }
     },
+    onInsertNowDate: () => {
+      if (!stableActiveCell) return;
+      const entry = flatRecords[stableActiveCell.rowIndex];
+      if (entry?.type !== "record" || !entry.record) return;
+      const field = orderedVisibleFields[stableActiveCell.colIndex];
+      if (!field) return;
+      if (field.type === FieldType.DATE || field.type === FieldType.TEXT) {
+        const now = new Date().toISOString().slice(0, 10);
+        void handleCommitWithUndo(entry.record.id, field.key, now);
+      }
+    },
   });
 
   // Wrapper that syncs both ref and state

--- a/src/hooks/use-keyboard-nav.ts
+++ b/src/hooks/use-keyboard-nav.ts
@@ -32,6 +32,7 @@ interface UseKeyboardNavOptions {
   onRedo?: () => void;
   onEditNavigate?: (direction: "left" | "right" | "down") => void;
   onExpandRecord?: () => void;
+  onInsertNowDate?: () => void;
 }
 
 export function useKeyboardNav({
@@ -52,6 +53,7 @@ export function useKeyboardNav({
   onRedo,
   onEditNavigate,
   onExpandRecord,
+  onInsertNowDate,
 }: UseKeyboardNavOptions) {
   const activeCellRef = useRef<ActiveCell | null>(null);
   const selectionRangeRef = useRef<CellRange | null>(null);
@@ -123,42 +125,74 @@ export function useKeyboardNav({
       const maxRow = rowCount - 1;
       const maxCol = colCount - 1;
       const shift = e.shiftKey;
+      const ctrl = e.ctrlKey || e.metaKey;
+
+      // Helper: find edge row in a direction (skipping group rows)
+      const findEdgeRow = (fromRow: number, dir: 1 | -1): number => {
+        let row = fromRow;
+        while (true) {
+          const next = row + dir;
+          if (next < 0 || next > maxRow) break;
+          if (!isGroupRow?.(next)) row = next;
+          else break; // stop at group boundary
+          // For non-Ctrl: would stop here; for Ctrl: keep going
+        }
+        return row;
+      };
 
       switch (e.key) {
         case "ArrowUp": {
-          const next = skipGroupRow(active.rowIndex - 1, -1);
-          if (next >= 0) {
-            activeCellRef.current = { ...active, rowIndex: next };
-            if (shift) {
-              const range = selectionRangeRef.current ?? { startRow: active.rowIndex, startCol: active.colIndex, endRow: active.rowIndex, endCol: active.colIndex };
-              selectionRangeRef.current = { ...range, endRow: next };
-              onSelectionChange?.(selectionRangeRef.current);
-            } else {
-              setSelectionRange(null);
+          let next: number;
+          if (ctrl) {
+            // Jump to first data row
+            for (let r = 0; r <= maxRow; r++) {
+              if (!isGroupRow?.(r)) { next = r; break; }
             }
-            onMoveTo(activeCellRef.current);
+            next = next!;
+          } else {
+            next = skipGroupRow(active.rowIndex - 1, -1);
+            if (next < 0) { e.preventDefault(); break; }
           }
+          activeCellRef.current = { ...active, rowIndex: next! };
+          if (shift) {
+            const range = selectionRangeRef.current ?? { startRow: active.rowIndex, startCol: active.colIndex, endRow: active.rowIndex, endCol: active.colIndex };
+            selectionRangeRef.current = { ...range, endRow: next! };
+            onSelectionChange?.(selectionRangeRef.current);
+          } else {
+            setSelectionRange(null);
+          }
+          onMoveTo(activeCellRef.current);
           e.preventDefault();
           break;
         }
         case "ArrowDown": {
-          const next = skipGroupRow(active.rowIndex + 1, 1);
-          if (next <= maxRow) {
-            activeCellRef.current = { ...active, rowIndex: next };
-            if (shift) {
-              const range = selectionRangeRef.current ?? { startRow: active.rowIndex, startCol: active.colIndex, endRow: active.rowIndex, endCol: active.colIndex };
-              selectionRangeRef.current = { ...range, endRow: next };
-              onSelectionChange?.(selectionRangeRef.current);
-            } else {
-              setSelectionRange(null);
+          let next: number;
+          if (ctrl) {
+            // Jump to last data row
+            next = maxRow;
+            for (let r = maxRow; r >= 0; r--) {
+              if (!isGroupRow?.(r)) { next = r; break; }
             }
-            onMoveTo(activeCellRef.current);
+          } else {
+            next = skipGroupRow(active.rowIndex + 1, 1);
+            if (next > maxRow) { e.preventDefault(); break; }
           }
+          activeCellRef.current = { ...active, rowIndex: next };
+          if (shift) {
+            const range = selectionRangeRef.current ?? { startRow: active.rowIndex, startCol: active.colIndex, endRow: active.rowIndex, endCol: active.colIndex };
+            selectionRangeRef.current = { ...range, endRow: next };
+            onSelectionChange?.(selectionRangeRef.current);
+          } else {
+            setSelectionRange(null);
+          }
+          onMoveTo(activeCellRef.current);
           e.preventDefault();
           break;
         }
         case "ArrowRight":
-          if (active.colIndex < maxCol) {
+          if (ctrl) {
+            activeCellRef.current = { ...active, colIndex: maxCol };
+          } else if (active.colIndex < maxCol) {
             activeCellRef.current = { ...active, colIndex: active.colIndex + 1 };
           } else if (active.rowIndex < maxRow) {
             const next = skipGroupRow(active.rowIndex + 1, 1);
@@ -175,7 +209,9 @@ export function useKeyboardNav({
           e.preventDefault();
           break;
         case "ArrowLeft":
-          if (active.colIndex > 0) {
+          if (ctrl) {
+            activeCellRef.current = { ...active, colIndex: 0 };
+          } else if (active.colIndex > 0) {
             activeCellRef.current = { ...active, colIndex: active.colIndex - 1 };
           } else if (active.rowIndex > 0) {
             const next = skipGroupRow(active.rowIndex - 1, -1);
@@ -234,6 +270,12 @@ export function useKeyboardNav({
           onClearCell();
           e.preventDefault();
           break;
+        case ";":
+          if (ctrl) {
+            onInsertNowDate?.();
+            e.preventDefault();
+          }
+          break;
         default:
           if ((e.ctrlKey || e.metaKey) && e.key === "c") {
             const range = selectionRangeRef.current;
@@ -268,7 +310,7 @@ export function useKeyboardNav({
       editingCell, rowCount, colCount, onMoveTo, onStartEdit, onCancelEdit,
       onClearCell, onCopyCell, onPasteCell, onCopyRange, onPasteRange,
       onSelectionChange, skipGroupRow, onUndo, onRedo, onEditNavigate,
-      onExpandRecord, setSelectionRange,
+      onExpandRecord, onInsertNowDate, setSelectionRange,
     ]
   );
 


### PR DESCRIPTION
## Summary
- Ctrl+↑/↓: 跳转到表格第一条/最后一条记录（跳过分组行）
- Ctrl+←/→: 跳转到当前行最左/最右列
- Ctrl+Shift+方向键: 跳转并选中从当前位置到边缘的范围
- Ctrl+;: 在日期/文本字段自动填入当前日期 (YYYY-MM-DD 格式)

## Test plan
- [ ] 选中单元格后按 Ctrl+↓ 跳转到最后一条记录
- [ ] 选中单元格后按 Ctrl+→ 跳转到最右列
- [ ] Ctrl+Shift+↓ 跳转并选中范围
- [ ] 选中日期字段后按 Ctrl+; 填入当前日期
- [ ] 普通方向键行为不受影响

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)