### PR TITLE
[Feature] 数据表查找替换 & Ctrl+F 快捷键

### DIFF
--- a/src/components/data/views/find-replace-bar.tsx
+++ b/src/components/data/views/find-replace-bar.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useState, useCallback, useEffect, useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { X, ChevronUp, ChevronDown, Replace } from "lucide-react";
+
+interface FindResult {
+  rowIndex: number;
+  colIndex: number;
+}
+
+interface FindReplaceBarProps {
+  open: boolean;
+  onClose: () => void;
+  records: { id: string; data: Record<string, unknown> }[];
+  fieldKeys: string[];
+  isGroupRow?: (rowIndex: number) => boolean;
+  onNavigateTo: (rowIndex: number, colIndex: number) => void;
+  onReplace: (recordId: string, fieldKey: string, oldValue: string, newValue: string) => void;
+}
+
+export function FindReplaceBar({
+  open,
+  onClose,
+  records,
+  fieldKeys,
+  isGroupRow,
+  onNavigateTo,
+  onReplace,
+}: FindReplaceBarProps) {
+  const [findText, setFindText] = useState("");
+  const [replaceText, setReplaceText] = useState("");
+  const [showReplace, setShowReplace] = useState(false);
+  const [results, setResults] = useState<FindResult[]>([]);
+  const [currentIdx, setCurrentIdx] = useState(-1);
+  const findInputRef = useRef<HTMLInputElement>(null);
+
+  // Perform search
+  const doSearch = useCallback(
+    (query: string) => {
+      if (!query) {
+        setResults([]);
+        setCurrentIdx(-1);
+        return;
+      }
+      const lower = query.toLowerCase();
+      const found: FindResult[] = [];
+      for (let r = 0; r < records.length; r++) {
+        if (isGroupRow?.(r)) continue;
+        const record = records[r];
+        if (!record?.data) continue;
+        for (let c = 0; c < fieldKeys.length; c++) {
+          const val = String(record.data[fieldKeys[c]] ?? "");
+          if (val.toLowerCase().includes(lower)) {
+            found.push({ rowIndex: r, colIndex: c });
+          }
+        }
+      }
+      setResults(found);
+      setCurrentIdx(found.length > 0 ? 0 : -1);
+    },
+    [records, fieldKeys, isGroupRow]
+  );
+
+  // Search on text change
+  useEffect(() => {
+    doSearch(findText);
+  }, [findText, doSearch]);
+
+  // Navigate to current result
+  useEffect(() => {
+    if (currentIdx >= 0 && currentIdx < results.length) {
+      const r = results[currentIdx];
+      onNavigateTo(r.rowIndex, r.colIndex);
+    }
+  }, [currentIdx, results, onNavigateTo]);
+
+  // Focus input on open
+  useEffect(() => {
+    if (open) {
+      setTimeout(() => findInputRef.current?.focus(), 50);
+    } else {
+      setFindText("");
+      setReplaceText("");
+      setShowReplace(false);
+      setResults([]);
+      setCurrentIdx(-1);
+    }
+  }, [open]);
+
+  const goNext = useCallback(() => {
+    if (results.length === 0) return;
+    setCurrentIdx((prev) => (prev + 1) % results.length);
+  }, [results]);
+
+  const goPrev = useCallback(() => {
+    if (results.length === 0) return;
+    setCurrentIdx((prev) => (prev - 1 + results.length) % results.length);
+  }, [results]);
+
+  const handleReplaceCurrent = useCallback(() => {
+    if (currentIdx < 0 || currentIdx >= results.length) return;
+    const r = results[currentIdx];
+    const record = records[r.rowIndex];
+    if (!record) return;
+    const fieldKey = fieldKeys[r.colIndex];
+    const oldVal = String(record.data[fieldKey] ?? "");
+    const newVal = oldVal.replace(new RegExp(escapeRegex(findText), "gi"), replaceText);
+    onReplace(record.id, fieldKey, oldVal, newVal);
+    // Re-search after replace
+    setTimeout(() => doSearch(findText), 100);
+  }, [currentIdx, results, records, fieldKeys, findText, replaceText, onReplace, doSearch]);
+
+  const handleReplaceAll = useCallback(() => {
+    for (const r of results) {
+      const record = records[r.rowIndex];
+      if (!record) continue;
+      const fieldKey = fieldKeys[r.colIndex];
+      const oldVal = String(record.data[fieldKey] ?? "");
+      const newVal = oldVal.replace(new RegExp(escapeRegex(findText), "gi"), replaceText);
+      if (oldVal !== newVal) {
+        onReplace(record.id, fieldKey, oldVal, newVal);
+      }
+    }
+    setTimeout(() => doSearch(findText), 100);
+  }, [results, records, fieldKeys, findText, replaceText, onReplace, doSearch]);
+
+  // Keyboard shortcut: Enter = next, Shift+Enter = prev, Escape = close
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        if (e.shiftKey) goPrev();
+        else goNext();
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    },
+    [goNext, goPrev, onClose]
+  );
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="absolute top-0 right-0 z-50 bg-background border rounded-bl-lg shadow-lg p-2 flex flex-col gap-2 min-w-[360px]"
+      onKeyDown={handleKeyDown}
+    >
+      <div className="flex items-center gap-1">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6 shrink-0"
+          onClick={() => setShowReplace(!showReplace)}
+          title="替换"
+        >
+          <Replace className="h-3 w-3" />
+        </Button>
+        <Input
+          ref={findInputRef}
+          value={findText}
+          onChange={(e) => setFindText(e.target.value)}
+          placeholder="查找..."
+          className="h-7 text-sm flex-1"
+        />
+        <span className="text-xs text-muted-foreground whitespace-nowrap min-w-[60px] text-center">
+          {results.length > 0 ? `${currentIdx + 1}/${results.length}` : findText ? "0/0" : ""}
+        </span>
+        <Button variant="ghost" size="icon" className="h-6 w-6 shrink-0" onClick={goPrev} disabled={results.length === 0}>
+          <ChevronUp className="h-3 w-3" />
+        </Button>
+        <Button variant="ghost" size="icon" className="h-6 w-6 shrink-0" onClick={goNext} disabled={results.length === 0}>
+          <ChevronDown className="h-3 w-3" />
+        </Button>
+        <Button variant="ghost" size="icon" className="h-6 w-6 shrink-0" onClick={onClose}>
+          <X className="h-3 w-3" />
+        </Button>
+      </div>
+      {showReplace && (
+        <div className="flex items-center gap-1">
+          <div className="w-6 shrink-0" />
+          <Input
+            value={replaceText}
+            onChange={(e) => setReplaceText(e.target.value)}
+            placeholder="替换为..."
+            className="h-7 text-sm flex-1"
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs px-2"
+            onClick={handleReplaceCurrent}
+            disabled={currentIdx < 0}
+          >
+            替换
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs px-2"
+            onClick={handleReplaceAll}
+            disabled={results.length === 0}
+          >
+            全部
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/components/data/views/find-replace-bar.tsx
+++ b/src/components/data/views/find-replace-bar.tsx
@@ -6,26 +6,29 @@ import { Input } from "@/components/ui/input";
 import { X, ChevronUp, ChevronDown, Replace } from "lucide-react";
 
 interface FindResult {
-  rowIndex: number;
+  /** Index in flatRecords (the full array including group rows) */
+  flatRowIndex: number;
+  /** Index in orderedVisibleFields */
   colIndex: number;
+  recordId: string;
+  fieldKey: string;
 }
 
 interface FindReplaceBarProps {
   open: boolean;
   onClose: () => void;
-  records: { id: string; data: Record<string, unknown> }[];
+  /** Full flatRecords array — each entry is null for group rows, or { id, data } for data rows */
+  rows: Array<{ id: string; data: Record<string, unknown> } | null>;
   fieldKeys: string[];
-  isGroupRow?: (rowIndex: number) => boolean;
-  onNavigateTo: (rowIndex: number, colIndex: number) => void;
-  onReplace: (recordId: string, fieldKey: string, oldValue: string, newValue: string) => void;
+  onNavigateTo: (flatRowIndex: number, colIndex: number) => void;
+  onReplace: (recordId: string, fieldKey: string, newValue: string) => void;
 }
 
 export function FindReplaceBar({
   open,
   onClose,
-  records,
+  rows,
   fieldKeys,
-  isGroupRow,
   onNavigateTo,
   onReplace,
 }: FindReplaceBarProps) {
@@ -36,7 +39,7 @@ export function FindReplaceBar({
   const [currentIdx, setCurrentIdx] = useState(-1);
   const findInputRef = useRef<HTMLInputElement>(null);
 
-  // Perform search
+  // Perform search — rows[] is indexed identically to flatRecords
   const doSearch = useCallback(
     (query: string) => {
       if (!query) {
@@ -46,21 +49,20 @@ export function FindReplaceBar({
       }
       const lower = query.toLowerCase();
       const found: FindResult[] = [];
-      for (let r = 0; r < records.length; r++) {
-        if (isGroupRow?.(r)) continue;
-        const record = records[r];
-        if (!record?.data) continue;
+      for (let r = 0; r < rows.length; r++) {
+        const row = rows[r];
+        if (!row?.data) continue; // skip group rows / nulls
         for (let c = 0; c < fieldKeys.length; c++) {
-          const val = String(record.data[fieldKeys[c]] ?? "");
+          const val = String(row.data[fieldKeys[c]] ?? "");
           if (val.toLowerCase().includes(lower)) {
-            found.push({ rowIndex: r, colIndex: c });
+            found.push({ flatRowIndex: r, colIndex: c, recordId: row.id, fieldKey: fieldKeys[c] });
           }
         }
       }
       setResults(found);
       setCurrentIdx(found.length > 0 ? 0 : -1);
     },
-    [records, fieldKeys, isGroupRow]
+    [rows, fieldKeys]
   );
 
   // Search on text change
@@ -72,11 +74,11 @@ export function FindReplaceBar({
   useEffect(() => {
     if (currentIdx >= 0 && currentIdx < results.length) {
       const r = results[currentIdx];
-      onNavigateTo(r.rowIndex, r.colIndex);
+      onNavigateTo(r.flatRowIndex, r.colIndex);
     }
   }, [currentIdx, results, onNavigateTo]);
 
-  // Focus input on open
+  // Focus input on open / reset on close
   useEffect(() => {
     if (open) {
       setTimeout(() => findInputRef.current?.focus(), 50);
@@ -102,31 +104,28 @@ export function FindReplaceBar({
   const handleReplaceCurrent = useCallback(() => {
     if (currentIdx < 0 || currentIdx >= results.length) return;
     const r = results[currentIdx];
-    const record = records[r.rowIndex];
-    if (!record) return;
-    const fieldKey = fieldKeys[r.colIndex];
-    const oldVal = String(record.data[fieldKey] ?? "");
+    const row = rows[r.flatRowIndex];
+    if (!row) return;
+    const oldVal = String(row.data[r.fieldKey] ?? "");
     const newVal = oldVal.replace(new RegExp(escapeRegex(findText), "gi"), replaceText);
-    onReplace(record.id, fieldKey, oldVal, newVal);
-    // Re-search after replace
+    onReplace(r.recordId, r.fieldKey, newVal);
     setTimeout(() => doSearch(findText), 100);
-  }, [currentIdx, results, records, fieldKeys, findText, replaceText, onReplace, doSearch]);
+  }, [currentIdx, results, rows, findText, replaceText, onReplace, doSearch]);
 
   const handleReplaceAll = useCallback(() => {
     for (const r of results) {
-      const record = records[r.rowIndex];
-      if (!record) continue;
-      const fieldKey = fieldKeys[r.colIndex];
-      const oldVal = String(record.data[fieldKey] ?? "");
+      const row = rows[r.flatRowIndex];
+      if (!row) continue;
+      const oldVal = String(row.data[r.fieldKey] ?? "");
       const newVal = oldVal.replace(new RegExp(escapeRegex(findText), "gi"), replaceText);
       if (oldVal !== newVal) {
-        onReplace(record.id, fieldKey, oldVal, newVal);
+        onReplace(r.recordId, r.fieldKey, newVal);
       }
     }
     setTimeout(() => doSearch(findText), 100);
-  }, [results, records, fieldKeys, findText, replaceText, onReplace, doSearch]);
+  }, [results, rows, findText, replaceText, onReplace, doSearch]);
 
-  // Keyboard shortcut: Enter = next, Shift+Enter = prev, Escape = close
+  // Keyboard: Enter = next, Shift+Enter = prev, Escape = close
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === "Enter") {

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -1628,24 +1628,10 @@ export function GridView({
         <FindReplaceBar
           open={findBarOpen}
           onClose={() => setFindBarOpen(false)}
-          records={flatRecords.map(e => e.type === "record" && e.record ? { id: e.record.id, data: e.record.data } : null).filter(Boolean) as { id: string; data: Record<string, unknown> }[]}
+          rows={flatRecords.map(e => e.type === "record" && e.record ? { id: e.record.id, data: e.record.data } : null)}
           fieldKeys={orderedVisibleFields.map(f => f.key)}
-          isGroupRow={(rowIndex) => groupRowIndices.has(rowIndex)}
-          onNavigateTo={(rowIndex, colIndex) => {
-            // Find the flatRecords index for this filtered row index
-            let dataRowIdx = -1;
-            for (let i = 0; i < flatRecords.length; i++) {
-              if (flatRecords[i].type !== "record") continue;
-              dataRowIdx++;
-              if (dataRowIdx === rowIndex) {
-                setActiveCell({ rowIndex: i, colIndex });
-                return;
-              }
-            }
-          }}
-          onReplace={(recordId, fieldKey, _oldValue, newValue) => {
-            handleCommit(recordId, fieldKey, newValue);
-          }}
+          onNavigateTo={(flatRowIndex, colIndex) => setActiveCell({ rowIndex: flatRowIndex, colIndex })}
+          onReplace={(recordId, fieldKey, newValue) => handleCommit(recordId, fieldKey, newValue)}
         />
         <table
           className="w-full caption-bottom text-sm outline-none select-none"

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -6,6 +6,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { ChevronDown, ChevronRight, Expand, GripVertical, Loader2, Plus, Redo2, Trash2, Undo2 } from "lucide-react";
 import { BatchActionBar } from "@/components/data/batch-action-bar";
 import { BatchEditDialog } from "@/components/data/batch-edit-dialog";
+import { FindReplaceBar } from "@/components/data/views/find-replace-bar";
 import { DragDropProvider } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { FieldType } from "@/generated/prisma/enums";
@@ -382,6 +383,7 @@ export function GridView({
 
   // ── Batch selection state ────────────────────────────────────────────────
   const [batchEditOpen, setBatchEditOpen] = useState(false);
+  const [findBarOpen, setFindBarOpen] = useState(false);
 
   // ── Collapsed groups state ──────────────────────────────────────────────
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
@@ -1025,6 +1027,7 @@ export function GridView({
       if (entry?.type !== "record" || !entry.record) return;
       void handleDuplicateRow(entry.record);
     },
+    onFindBar: () => setFindBarOpen(true),
   });
 
   // Wrapper that syncs both ref and state
@@ -1621,7 +1624,20 @@ export function GridView({
           <Redo2 className="h-3.5 w-3.5" />
         </Button>
       </div>
-      <div className="flex-1 min-h-0 overflow-auto" ref={scrollRef}>
+      <div className="flex-1 min-h-0 overflow-auto relative" ref={scrollRef}>
+        <FindReplaceBar
+          open={findBarOpen}
+          onClose={() => setFindBarOpen(false)}
+          records={flatRecords.filter(e => e.type === "record").map(e => ({ id: e.record!.id, data: e.record!.data }))}
+          fieldKeys={orderedVisibleFields.map(f => f.key)}
+          isGroupRow={(rowIndex) => groupRowIndices.has(rowIndex)}
+          onNavigateTo={(rowIndex, colIndex) => {
+            setActiveCell({ rowIndex, colIndex });
+          }}
+          onReplace={(recordId, fieldKey, _oldValue, newValue) => {
+            handleCommit(recordId, fieldKey, newValue);
+          }}
+        />
         <table
           className="w-full caption-bottom text-sm outline-none select-none"
           style={{ tableLayout: "fixed" }}

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -1628,11 +1628,20 @@ export function GridView({
         <FindReplaceBar
           open={findBarOpen}
           onClose={() => setFindBarOpen(false)}
-          records={flatRecords.filter(e => e.type === "record").map(e => ({ id: e.record!.id, data: e.record!.data }))}
+          records={flatRecords.map(e => e.type === "record" && e.record ? { id: e.record.id, data: e.record.data } : null).filter(Boolean) as { id: string; data: Record<string, unknown> }[]}
           fieldKeys={orderedVisibleFields.map(f => f.key)}
           isGroupRow={(rowIndex) => groupRowIndices.has(rowIndex)}
           onNavigateTo={(rowIndex, colIndex) => {
-            setActiveCell({ rowIndex, colIndex });
+            // Find the flatRecords index for this filtered row index
+            let dataRowIdx = -1;
+            for (let i = 0; i < flatRecords.length; i++) {
+              if (flatRecords[i].type !== "record") continue;
+              dataRowIdx++;
+              if (dataRowIdx === rowIndex) {
+                setActiveCell({ rowIndex: i, colIndex });
+                return;
+              }
+            }
           }}
           onReplace={(recordId, fieldKey, _oldValue, newValue) => {
             handleCommit(recordId, fieldKey, newValue);

--- a/src/hooks/use-keyboard-nav.ts
+++ b/src/hooks/use-keyboard-nav.ts
@@ -36,6 +36,7 @@ interface UseKeyboardNavOptions {
   onCutCell?: () => string | null;
   onDuplicateRow?: () => void;
   onInsertNowDate?: () => void;
+  onFindBar?: () => void;
 }
 
 export function useKeyboardNav({
@@ -60,6 +61,7 @@ export function useKeyboardNav({
   onCutCell,
   onDuplicateRow,
   onInsertNowDate,
+  onFindBar,
 }: UseKeyboardNavOptions) {
   const activeCellRef = useRef<ActiveCell | null>(null);
   const selectionRangeRef = useRef<CellRange | null>(null);
@@ -292,6 +294,13 @@ export function useKeyboardNav({
             e.preventDefault();
           }
           break;
+        case "f":
+        case "g":
+          if (ctrl) {
+            onFindBar?.();
+            e.preventDefault();
+          }
+          break;
         default:
           if ((e.ctrlKey || e.metaKey) && e.key === "c") {
             const range = selectionRangeRef.current;
@@ -340,7 +349,7 @@ export function useKeyboardNav({
       editingCell, rowCount, colCount, onMoveTo, onStartEdit, onCancelEdit,
       onClearCell, onCopyCell, onPasteCell, onCopyRange, onPasteRange,
       onSelectionChange, skipGroupRow, onUndo, onRedo, onEditNavigate,
-      onExpandRecord, onInsertRowBelow, onCutCell, onDuplicateRow, onInsertNowDate, setSelectionRange,
+      onExpandRecord, onInsertRowBelow, onCutCell, onDuplicateRow, onInsertNowDate, onFindBar, setSelectionRange,
     ]
   );
 


### PR DESCRIPTION
## Summary
- Ctrl+F / Ctrl+G 打开浮动查找栏（表格右上角）
- 实时搜索当前表所有字段，显示匹配数量和当前位置
- Enter 下一个 / Shift+Enter 上一个匹配项
- 点击替换图标展开替换输入框，支持单个替换和全部替换
- Esc 关闭查找栏

## Test plan
- [ ] 在数据表中按 Ctrl+F，查找栏弹出
- [ ] 输入关键词后自动搜索并高亮跳转到第一个匹配
- [ ] Enter/Shift+Enter 切换匹配项
- [ ] 展开替换栏，替换当前匹配和全部替换功能正常
- [ ] Esc 关闭查找栏不影响其他操作

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)