### PR TITLE
[Feature] 关联字段搜索选择器

### DIFF
--- a/src/components/data/cell-editors/relation-cell-editor.tsx
+++ b/src/components/data/cell-editors/relation-cell-editor.tsx
@@ -5,8 +5,8 @@ import { Input } from "@/components/ui/input";
 import type { RelationTargetOption } from "@/components/data/relation-target-picker";
 
 interface RelationCellEditorProps {
-  value: string | null;
-  onCommit: (value: string | null) => void;
+  value: string | { id: string; display?: string } | null;
+  onCommit: (value: string | { id: string; display: string } | null) => void;
   onCancel: () => void;
   relationTableId?: string;
   displayField?: string;
@@ -77,9 +77,10 @@ export function RelationCellEditor({
     return String(value);
   }, [value]);
 
-  function handleSelect(id: string) {
+  function handleSelect(id: string, label: string) {
     committedRef.current = true;
-    onCommit(id);
+    // Return {id, display} so local state matches server-resolved format
+    onCommit({ id, display: label });
   }
 
   function handleClear() {
@@ -168,7 +169,7 @@ export function RelationCellEditor({
                   }`}
                   onMouseDown={(e) => {
                     e.preventDefault();
-                    handleSelect(option.id);
+                    handleSelect(option.id, option.label);
                   }}
                 >
                   {option.label}

--- a/src/components/data/cell-editors/relation-cell-editor.tsx
+++ b/src/components/data/cell-editors/relation-cell-editor.tsx
@@ -1,35 +1,183 @@
 "use client";
 
-import { useRef, useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Input } from "@/components/ui/input";
+import type { RelationTargetOption } from "@/components/data/relation-target-picker";
 
 interface RelationCellEditorProps {
   value: string | null;
   onCommit: (value: string | null) => void;
   onCancel: () => void;
+  relationTableId?: string;
+  displayField?: string;
 }
 
-export function RelationCellEditor({ value, onCommit, onCancel }: RelationCellEditorProps) {
-  const [draft, setDraft] = useState(value ?? "");
+export function RelationCellEditor({
+  value,
+  onCommit,
+  onCancel,
+  relationTableId,
+  displayField,
+}: RelationCellEditorProps) {
+  const [search, setSearch] = useState("");
+  const [options, setOptions] = useState<RelationTargetOption[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isOpen, setIsOpen] = useState(true);
+  const committedRef = useRef(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Fetch options from API
+  useEffect(() => {
+    if (!relationTableId) return;
+
+    const controller = new AbortController();
+    async function fetchOptions() {
+      setIsLoading(true);
+      try {
+        const params = new URLSearchParams();
+        if (search) params.set("search", search);
+        if (displayField) params.set("displayField", displayField);
+
+        const res = await fetch(
+          `/api/data-tables/${relationTableId}/relation-options?${params}`,
+          { signal: controller.signal }
+        );
+        if (!res.ok) return;
+        const data = (await res.json()) as RelationTargetOption[];
+        setOptions(Array.isArray(data) ? data : []);
+      } catch {
+        // abort is fine
+      } finally {
+        if (!controller.signal.aborted) setIsLoading(false);
+      }
+    }
+    fetchOptions();
+    return () => controller.abort();
+  }, [relationTableId, displayField, search]);
+
+  const optionMap = useMemo(
+    () => new Map(options.map((o) => [o.id, o])),
+    [options]
+  );
+
+  const currentLabel = useMemo(() => {
+    if (!value) return null;
+    // value may already be "{ id, display }" object from resolved data
+    if (typeof value === "object") return (value as { display?: string }).display;
+    return optionMap.get(value)?.label ?? value;
+  }, [value, optionMap]);
+
+  // Parse initial value to get the raw record ID
+  const rawId = useMemo(() => {
+    if (!value) return null;
+    if (typeof value === "object" && "id" in (value as object)) {
+      return (value as { id: string }).id;
+    }
+    return String(value);
+  }, [value]);
+
+  function handleSelect(id: string) {
+    committedRef.current = true;
+    onCommit(id);
+  }
+
+  function handleClear() {
+    committedRef.current = true;
+    onCommit(null);
+  }
+
+  function handleBlur(e: React.FocusEvent) {
+    // Don't commit if clicking inside the dropdown
+    if (containerRef.current?.contains(e.relatedTarget as Node)) return;
+    if (committedRef.current) return;
+    committedRef.current = true;
+    onCancel();
+  }
 
   useEffect(() => {
     inputRef.current?.focus();
-    inputRef.current?.select();
   }, []);
 
+  // Fallback: plain text input when no relationTableId configured
+  if (!relationTableId) {
+    return (
+      <Input
+        value={rawId ?? ""}
+        onChange={(e) => {}}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") { e.preventDefault(); onCancel(); }
+        }}
+        onBlur={() => onCancel()}
+        className="h-8 text-sm border-primary"
+        placeholder="未配置关联表"
+        readOnly
+      />
+    );
+  }
+
+  const filteredOptions = search
+    ? options.filter((o) =>
+        o.label.toLowerCase().includes(search.toLowerCase())
+      )
+    : options;
+
   return (
-    <Input
-      ref={inputRef}
-      value={draft}
-      onChange={(e) => setDraft(e.target.value)}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") { e.preventDefault(); onCommit(draft || null); }
-        if (e.key === "Escape") { e.preventDefault(); onCancel(); }
-      }}
-      onBlur={() => onCommit(draft || null)}
-      className="h-8 text-sm border-primary"
-      placeholder="输入关联记录 ID..."
-    />
+    <div ref={containerRef} className="relative" onBlur={handleBlur}>
+      <Input
+        ref={inputRef}
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            e.preventDefault();
+            committedRef.current = true;
+            onCancel();
+          }
+          if (e.key === "Backspace" && !search && rawId) {
+            handleClear();
+          }
+        }}
+        className="h-8 text-sm border-primary pr-6"
+        placeholder={rawId ? currentLabel ?? rawId : "搜索关联记录..."}
+      />
+      {rawId && !search && (
+        <span className="absolute left-2 top-1/2 -translate-y-1/2 text-xs bg-muted px-1 rounded max-w-[calc(100%-2rem)] truncate pointer-events-none">
+          {currentLabel ?? rawId}
+        </span>
+      )}
+
+      {isOpen && (
+        <div className="absolute top-full left-0 mt-0.5 w-64 bg-background border rounded-md shadow-lg z-50">
+          <div className="max-h-48 overflow-auto">
+            {isLoading ? (
+              <div className="p-3 text-center text-sm text-muted-foreground">
+                加载中...
+              </div>
+            ) : filteredOptions.length === 0 ? (
+              <div className="p-3 text-center text-sm text-muted-foreground">
+                {search ? "无匹配结果" : "暂无记录"}
+              </div>
+            ) : (
+              filteredOptions.map((option) => (
+                <button
+                  key={option.id}
+                  type="button"
+                  className={`w-full text-left px-3 py-1.5 text-sm hover:bg-muted truncate ${
+                    option.id === rawId ? "bg-muted font-medium" : ""
+                  }`}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    handleSelect(option.id);
+                  }}
+                >
+                  {option.label}
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -1287,7 +1287,15 @@ export function GridView({
           return (
             <RelationCellEditor
               value={relId}
-              onCommit={(v) => void commitEdit(v)}
+              onCommit={async (v) => {
+                // Extract raw ID for API
+                const apiValue = v && typeof v === "object" ? v.id : v;
+                await commitEdit(apiValue);
+                // Override local state with resolved {id, display} object
+                if (v && typeof v === "object") {
+                  onUpdateRecordField(record.id, field.key, v);
+                }
+              }}
               onCancel={cancelEdit}
               relationTableId={field.relationTo}
               displayField={field.displayField}

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -1281,14 +1281,19 @@ export function GridView({
             />
           );
         }
-        case FieldType.RELATION:
+        case FieldType.RELATION: {
+          const relValue = originalValue as { id?: string; display?: string } | string | null;
+          const relId = relValue && typeof relValue === "object" ? relValue.id ?? null : typeof relValue === "string" ? relValue : null;
           return (
             <RelationCellEditor
-              value={String(originalValue ?? "")}
+              value={relId}
               onCommit={(v) => void commitEdit(v)}
               onCancel={cancelEdit}
+              relationTableId={field.relationTo}
+              displayField={field.displayField}
             />
           );
+        }
         case FieldType.RELATION_SUBTABLE:
           // Not editable inline
           return null;


### PR DESCRIPTION
## Summary

- 重写 RelationCellEditor，从手动输入记录 ID 改为搜索下拉选择器
- 调用 `/api/data-tables/{id}/relation-options` API 动态加载关联记录
- 支持实时搜索过滤、显示记录名称而非 ID
- Backspace 可清除已选关联记录
- 无 `relationTableId` 配置时优雅降级为只读提示

## Test plan

- [x] 关联字段编辑器弹出搜索下拉面板
- [x] 输入关键字可搜索关联表记录
- [x] 选中后显示记录名称而非 ID
- [x] 类型检查通过
- [ ] 多选关联（RELATION_SUBTABLE）后续支持

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)