### PR TITLE
[Feature] Select 字段颜色标签

### DIFF
--- a/src/components/data/cell-editors/multiselect-cell-editor.tsx
+++ b/src/components/data/cell-editors/multiselect-cell-editor.tsx
@@ -2,12 +2,12 @@
 
 import { useRef, useEffect, useState } from "react";
 import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
 import { X } from "lucide-react";
+import type { SelectOption } from "@/types/data-table";
 
 interface MultiselectCellEditorProps {
   value: string[];
-  options: string[];
+  options: SelectOption[];
   onCommit: (value: string[]) => void;
   onCancel: () => void;
 }
@@ -22,16 +22,22 @@ export function MultiselectCellEditor({
   const [inputValue, setInputValue] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
 
+  const colorMap = new Map(options.map((o) => [o.label, o.color]));
+
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
 
-  const availableOptions = options.filter((o) => !selected.includes(o));
+  const availableOptions = options.filter((o) => !selected.includes(o.label));
 
   return (
     <div className="relative flex flex-wrap gap-1 p-1 border border-primary rounded bg-background min-w-[200px]">
       {selected.map((item) => (
-        <Badge key={item} variant="secondary" className="text-xs gap-0.5">
+        <span
+          key={item}
+          className="inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium gap-0.5"
+          style={{ backgroundColor: colorMap.get(item) ?? "#f3f4f6" }}
+        >
           {item}
           <button
             type="button"
@@ -40,7 +46,7 @@ export function MultiselectCellEditor({
           >
             <X className="h-3 w-3" />
           </button>
-        </Badge>
+        </span>
       ))}
       <Input
         ref={inputRef}
@@ -49,8 +55,11 @@ export function MultiselectCellEditor({
         onKeyDown={(e) => {
           if (e.key === "Enter") {
             e.preventDefault();
-            if (inputValue && availableOptions.includes(inputValue)) {
-              setSelected([...selected, inputValue]);
+            const match = availableOptions.find(
+              (o) => o.label.toLowerCase() === inputValue.toLowerCase()
+            );
+            if (inputValue && match) {
+              setSelected([...selected, match.label]);
               setInputValue("");
             }
           }
@@ -63,24 +72,27 @@ export function MultiselectCellEditor({
         placeholder={selected.length === 0 ? "输入选项..." : ""}
         className="h-6 text-xs border-0 p-0 flex-1 min-w-[80px] focus-visible:ring-0"
       />
-      {/* Autocomplete dropdown */}
-      {inputValue && availableOptions.filter((o) => o.toLowerCase().includes(inputValue.toLowerCase())).length > 0 && (
+      {inputValue && availableOptions.filter((o) => o.label.toLowerCase().includes(inputValue.toLowerCase())).length > 0 && (
         <div className="absolute top-full left-0 mt-1 bg-background border rounded shadow-md z-50 max-h-32 overflow-auto">
           {availableOptions
-            .filter((o) => o.toLowerCase().includes(inputValue.toLowerCase()))
+            .filter((o) => o.label.toLowerCase().includes(inputValue.toLowerCase()))
             .map((option) => (
               <button
-                key={option}
+                key={option.label}
                 type="button"
-                className="block w-full text-left px-2 py-1 text-xs hover:bg-muted"
+                className="flex items-center gap-2 w-full text-left px-2 py-1 text-xs hover:bg-muted"
                 onMouseDown={(e) => {
-                  e.preventDefault(); // prevent blur
-                  setSelected([...selected, option]);
+                  e.preventDefault();
+                  setSelected([...selected, option.label]);
                   setInputValue("");
                   inputRef.current?.focus();
                 }}
               >
-                {option}
+                <span
+                  className="w-3 h-3 rounded-full flex-shrink-0"
+                  style={{ backgroundColor: option.color }}
+                />
+                {option.label}
               </button>
             ))}
         </div>

--- a/src/components/data/cell-editors/multiselect-cell-editor.tsx
+++ b/src/components/data/cell-editors/multiselect-cell-editor.tsx
@@ -4,6 +4,7 @@ import { useRef, useEffect, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { X } from "lucide-react";
 import type { SelectOption } from "@/types/data-table";
+import { SELECT_COLORS } from "@/types/data-table";
 
 interface MultiselectCellEditorProps {
   value: string[];
@@ -22,7 +23,10 @@ export function MultiselectCellEditor({
   const [inputValue, setInputValue] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const colorMap = new Map(options.map((o) => [o.label, o.color]));
+  const colorMap = new Map(options.map((o) => {
+    const preset = SELECT_COLORS.find(c => c.bg === o.color);
+    return [o.label, { bg: o.color, fg: preset?.fg ?? "#374151" }];
+  }));
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -32,11 +36,13 @@ export function MultiselectCellEditor({
 
   return (
     <div className="relative flex flex-wrap gap-1 p-1 border border-primary rounded bg-background min-w-[200px]">
-      {selected.map((item) => (
+      {selected.map((item) => {
+        const c = colorMap.get(item) ?? { bg: "#f3f4f6", fg: "#374151" };
+        return (
         <span
           key={item}
           className="inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium gap-0.5"
-          style={{ backgroundColor: colorMap.get(item) ?? "#f3f4f6" }}
+          style={{ backgroundColor: c.bg, color: c.fg }}
         >
           {item}
           <button
@@ -47,7 +53,8 @@ export function MultiselectCellEditor({
             <X className="h-3 w-3" />
           </button>
         </span>
-      ))}
+        );
+      })}
       <Input
         ref={inputRef}
         value={inputValue}

--- a/src/components/data/cell-editors/select-cell-editor.tsx
+++ b/src/components/data/cell-editors/select-cell-editor.tsx
@@ -8,10 +8,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import type { SelectOption } from "@/types/data-table";
 
 interface SelectCellEditorProps {
   value: string;
-  options: string[];
+  options: SelectOption[];
   onCommit: (value: string) => void;
   onCancel: () => void;
 }
@@ -20,7 +21,6 @@ export function SelectCellEditor({ value, options, onCommit, onCancel }: SelectC
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    // Auto-open on mount
     const trigger = containerRef.current?.querySelector("[data-radix-collection-item]");
     if (trigger) (trigger as HTMLElement).click();
   }, []);
@@ -42,8 +42,14 @@ export function SelectCellEditor({ value, options, onCommit, onCancel }: SelectC
         </SelectTrigger>
         <SelectContent>
           {options.map((option) => (
-            <SelectItem key={option} value={option}>
-              {option}
+            <SelectItem key={option.label} value={option.label}>
+              <span className="flex items-center gap-2">
+                <span
+                  className="w-3 h-3 rounded-full flex-shrink-0"
+                  style={{ backgroundColor: option.color }}
+                />
+                {option.label}
+              </span>
             </SelectItem>
           ))}
         </SelectContent>

--- a/src/components/data/column-header.tsx
+++ b/src/components/data/column-header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { parseSelectOptions } from "@/types/data-table";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -339,9 +340,9 @@ export function ColumnHeader({
                   <SelectValue placeholder="选择值" />
                 </SelectTrigger>
                 <SelectContent>
-                  {(field.options as string[]).map((opt) => (
-                    <SelectItem key={opt} value={opt}>
-                      {opt}
+                  {parseSelectOptions(field.options).map((opt) => (
+                    <SelectItem key={opt.label} value={opt.label}>
+                      {opt.label}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/src/components/data/create-field-dialog.tsx
+++ b/src/components/data/create-field-dialog.tsx
@@ -199,10 +199,10 @@ export function CreateFieldDialog({
                         className="w-5 h-5 rounded-full border flex-shrink-0"
                         style={{ backgroundColor: opt.color }}
                         onClick={() => {
-                          const currentIdx = SELECT_COLORS.findIndex((c) => c.hex === opt.color);
+                          const currentIdx = SELECT_COLORS.findIndex((c) => c.bg === opt.color);
                           const nextIdx = (currentIdx + 1) % SELECT_COLORS.length;
                           const updated = [...selectOptions];
-                          updated[i] = { ...updated[i], color: SELECT_COLORS[nextIdx].hex };
+                          updated[i] = { ...updated[i], color: SELECT_COLORS[nextIdx].bg };
                           setSelectOptions(updated);
                         }}
                       />
@@ -237,7 +237,7 @@ export function CreateFieldDialog({
                     onClick={() =>
                       setSelectOptions([
                         ...selectOptions,
-                        { label: "", color: SELECT_COLORS[selectOptions.length % SELECT_COLORS.length].hex },
+                        { label: "", color: SELECT_COLORS[selectOptions.length % SELECT_COLORS.length].bg },
                       ])
                     }
                   >

--- a/src/components/data/create-field-dialog.tsx
+++ b/src/components/data/create-field-dialog.tsx
@@ -22,6 +22,8 @@ import {
 import { Checkbox } from "@/components/ui/checkbox";
 import { generateFieldKey } from "@/lib/utils";
 import type { FieldType } from "@/generated/prisma/enums";
+import type { SelectOption } from "@/types/data-table";
+import { SELECT_COLORS } from "@/types/data-table";
 
 const FIELD_TYPES: { value: FieldType; label: string }[] = [
   { value: "TEXT", label: "文本" },
@@ -40,7 +42,7 @@ export interface CreateFieldFormData {
   label: string;
   type: FieldType;
   required: boolean;
-  options: string[];
+  options: SelectOption[];
   defaultValue: string;
 }
 
@@ -63,7 +65,7 @@ export function CreateFieldDialog({
   const [label, setLabel] = useState("");
   const [type, setType] = useState<FieldType>("TEXT");
   const [required, setRequired] = useState(false);
-  const [optionsInput, setOptionsInput] = useState("");
+  const [selectOptions, setSelectOptions] = useState<SelectOption[]>([]);
   const [defaultValue, setDefaultValue] = useState("");
   const [keyError, setKeyError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -75,7 +77,7 @@ export function CreateFieldDialog({
       setKey(generateFieldKey(columnLabel, existingKeys));
       setType("TEXT");
       setRequired(false);
-      setOptionsInput("");
+      setSelectOptions([]);
       setDefaultValue("");
       setKeyError("");
     }
@@ -102,10 +104,7 @@ export function CreateFieldDialog({
     }
 
     const options = ["SELECT", "MULTISELECT"].includes(type)
-      ? optionsInput
-          .split("\n")
-          .map((s) => s.trim())
-          .filter(Boolean)
+      ? selectOptions.filter((o) => o.label.trim())
       : [];
 
     setIsLoading(true);
@@ -191,16 +190,60 @@ export function CreateFieldDialog({
 
             {needsOptions && (
               <div className="grid gap-2">
-                <Label htmlFor="field-options">选项列表</Label>
-                <textarea
-                  id="field-options"
-                  className="flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none focus:border-ring focus:ring-2 focus:ring-ring/20 disabled:cursor-not-allowed disabled:opacity-50"
-                  placeholder="每行一个选项"
-                  value={optionsInput}
-                  onChange={(e) => setOptionsInput(e.target.value)}
-                  disabled={isLoading}
-                  rows={3}
-                />
+                <Label>选项列表</Label>
+                <div className="space-y-2">
+                  {selectOptions.map((opt, i) => (
+                    <div key={i} className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        className="w-5 h-5 rounded-full border flex-shrink-0"
+                        style={{ backgroundColor: opt.color }}
+                        onClick={() => {
+                          const currentIdx = SELECT_COLORS.findIndex((c) => c.hex === opt.color);
+                          const nextIdx = (currentIdx + 1) % SELECT_COLORS.length;
+                          const updated = [...selectOptions];
+                          updated[i] = { ...updated[i], color: SELECT_COLORS[nextIdx].hex };
+                          setSelectOptions(updated);
+                        }}
+                      />
+                      <Input
+                        value={opt.label}
+                        onChange={(e) => {
+                          const updated = [...selectOptions];
+                          updated[i] = { ...updated[i], label: e.target.value };
+                          setSelectOptions(updated);
+                        }}
+                        className="h-8 text-sm flex-1"
+                        placeholder={`选项 ${i + 1}`}
+                        disabled={isLoading}
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+                        onClick={() => setSelectOptions(selectOptions.filter((_, idx) => idx !== i))}
+                        disabled={isLoading}
+                      >
+                        ×
+                      </Button>
+                    </div>
+                  ))}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={isLoading}
+                    onClick={() =>
+                      setSelectOptions([
+                        ...selectOptions,
+                        { label: "", color: SELECT_COLORS[selectOptions.length % SELECT_COLORS.length].hex },
+                      ])
+                    }
+                  >
+                    + 添加选项
+                  </Button>
+                </div>
               </div>
             )}
 

--- a/src/components/data/dynamic-record-form.tsx
+++ b/src/components/data/dynamic-record-form.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/select";
 import type { DataFieldItem, DataRecordItem } from "@/types/data-table";
 import type { RelationSubtableValueItem } from "@/types/data-table";
+import { parseSelectOptions } from "@/types/data-table";
 import { FieldType } from "@/generated/prisma/enums";
 import { RelationSubtableEditor } from "./relation-subtable-editor";
 import { RelationSelect } from "./relation-select";
@@ -272,7 +273,8 @@ export function DynamicRecordForm({
           />
         );
 
-      case FieldType.SELECT:
+      case FieldType.SELECT: {
+        const selectOpts = parseSelectOptions(field.options);
         return (
           <Select
             value={watch(field.key) ?? ""}
@@ -282,14 +284,21 @@ export function DynamicRecordForm({
               <SelectValue placeholder={`选择${field.label}`} />
             </SelectTrigger>
             <SelectContent>
-              {Array.isArray(field.options) && field.options.map((option) => (
-                <SelectItem key={option} value={option}>
-                  {option}
+              {selectOpts.map((option) => (
+                <SelectItem key={option.label} value={option.label}>
+                  <span className="flex items-center gap-2">
+                    <span
+                      className="w-3 h-3 rounded-full flex-shrink-0"
+                      style={{ backgroundColor: option.color }}
+                    />
+                    {option.label}
+                  </span>
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
         );
+      }
 
       case FieldType.MULTISELECT:
         // Simplified: comma-separated input for now

--- a/src/components/data/field-config-form.tsx
+++ b/src/components/data/field-config-form.tsx
@@ -458,10 +458,10 @@ export function FieldConfigForm({
                         style={{ backgroundColor: opt.color }}
                         title="点击更换颜色"
                         onClick={() => {
-                          const currentIdx = SELECT_COLORS.findIndex((c) => c.hex === opt.color);
+                          const currentIdx = SELECT_COLORS.findIndex((c) => c.bg === opt.color);
                           const nextIdx = (currentIdx + 1) % SELECT_COLORS.length;
                           const updated = [...selectOptions];
-                          updated[i] = { ...updated[i], color: SELECT_COLORS[nextIdx].hex };
+                          updated[i] = { ...updated[i], color: SELECT_COLORS[nextIdx].bg };
                           setSelectOptions(updated);
                         }}
                       >
@@ -501,7 +501,7 @@ export function FieldConfigForm({
                         ...selectOptions,
                         {
                           label: "",
-                          color: SELECT_COLORS[selectOptions.length % SELECT_COLORS.length].hex,
+                          color: SELECT_COLORS[selectOptions.length % SELECT_COLORS.length].bg,
                         },
                       ])
                     }

--- a/src/components/data/field-config-form.tsx
+++ b/src/components/data/field-config-form.tsx
@@ -26,7 +26,9 @@ import type {
   DataFieldItem,
   RelationCardinality,
   RelationSchemaField,
+  SelectOption,
 } from "@/types/data-table";
+import { parseSelectOptions, SELECT_COLORS } from "@/types/data-table";
 import { parseFieldOptions } from "@/types/data-table";
 import type { DataFieldInput } from "@/validators/data-table";
 
@@ -150,8 +152,8 @@ export function FieldConfigForm({
   const [fieldType, setFieldType] = useState<FieldType>(() => field?.type ?? FieldType.TEXT);
   const [required, setRequired] = useState(() => field?.required ?? false);
   const [defaultValue, setDefaultValue] = useState(() => field?.defaultValue ?? "");
-  const [optionsText, setOptionsText] = useState(() =>
-    Array.isArray(field?.options) ? field.options.join("\n") : ""
+  const [selectOptions, setSelectOptions] = useState<SelectOption[]>(() =>
+    parseSelectOptions(field?.options)
   );
   const [selectedTableId, setSelectedTableId] = useState(() => field?.relationTo ?? "");
   const [selectedDisplayField, setSelectedDisplayField] = useState(() => field?.displayField ?? "");
@@ -341,10 +343,7 @@ export function FieldConfigForm({
 
     let fieldOptions: DataFieldInput["options"] = undefined;
     if (fieldType === FieldType.SELECT || fieldType === FieldType.MULTISELECT) {
-      fieldOptions = optionsText
-        .split("\n")
-        .map((item) => item.trim())
-        .filter(Boolean);
+      fieldOptions = selectOptions.filter((o) => o.label.trim());
     } else if (fieldType === FieldType.FORMULA) {
       fieldOptions = { formula: formulaExpression.trim() };
     } else if (fieldType === FieldType.SYSTEM_TIMESTAMP || fieldType === FieldType.SYSTEM_USER) {
@@ -449,15 +448,67 @@ export function FieldConfigForm({
 
             {(fieldType === FieldType.SELECT || fieldType === FieldType.MULTISELECT) && (
               <div className="grid gap-2">
-                <Label htmlFor="options">选项列表</Label>
-                <Textarea
-                  id="options"
-                  placeholder="每行一个选项，例如：&#10;进行中&#10;已完成&#10;已取消"
-                  value={optionsText}
-                  onChange={(event) => setOptionsText(event.target.value)}
-                  rows={4}
-                />
-                <p className="text-xs text-zinc-500">每行一个选项值</p>
+                <Label>选项列表</Label>
+                <div className="space-y-2">
+                  {selectOptions.map((opt, i) => (
+                    <div key={i} className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        className="w-6 h-6 rounded-full border flex-shrink-0 relative group"
+                        style={{ backgroundColor: opt.color }}
+                        title="点击更换颜色"
+                        onClick={() => {
+                          const currentIdx = SELECT_COLORS.findIndex((c) => c.hex === opt.color);
+                          const nextIdx = (currentIdx + 1) % SELECT_COLORS.length;
+                          const updated = [...selectOptions];
+                          updated[i] = { ...updated[i], color: SELECT_COLORS[nextIdx].hex };
+                          setSelectOptions(updated);
+                        }}
+                      >
+                        <span className="absolute inset-0 flex items-center justify-center text-xs opacity-0 group-hover:opacity-100 transition-opacity">
+                          ↻
+                        </span>
+                      </button>
+                      <Input
+                        value={opt.label}
+                        onChange={(e) => {
+                          const updated = [...selectOptions];
+                          updated[i] = { ...updated[i], label: e.target.value };
+                          setSelectOptions(updated);
+                        }}
+                        className="h-8 text-sm flex-1"
+                        placeholder={`选项 ${i + 1}`}
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+                        onClick={() =>
+                          setSelectOptions(selectOptions.filter((_, idx) => idx !== i))
+                        }
+                      >
+                        ×
+                      </Button>
+                    </div>
+                  ))}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      setSelectOptions([
+                        ...selectOptions,
+                        {
+                          label: "",
+                          color: SELECT_COLORS[selectOptions.length % SELECT_COLORS.length].hex,
+                        },
+                      ])
+                    }
+                  >
+                    + 添加选项
+                  </Button>
+                </div>
               </div>
             )}
 

--- a/src/components/data/field-config-list.tsx
+++ b/src/components/data/field-config-list.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { FieldConfigForm } from "./field-config-form";
 import type { DataFieldItem, DataTableListItem } from "@/types/data-table";
+import { parseSelectOptions } from "@/types/data-table";
 import type { DataFieldInput } from "@/validators/data-table";
 import { FieldType } from "@/generated/prisma/enums";
 
@@ -310,10 +311,20 @@ export function FieldConfigList({
                   <TableCell className="max-w-[200px]">
                     {field.type === FieldType.SELECT ||
                     field.type === FieldType.MULTISELECT ? (
-                      <span className="text-sm text-zinc-500">
-                        {Array.isArray(field.options) && field.options.slice(0, 3).join(", ")}
-                        {Array.isArray(field.options) && field.options.length > 3 && "..."}
-                      </span>
+                      <div className="flex flex-wrap gap-1">
+                        {parseSelectOptions(field.options).slice(0, 4).map((opt, i) => (
+                          <span
+                            key={i}
+                              className="inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium"
+                            style={{ backgroundColor: opt.color }}
+                          >
+                            {opt.label}
+                          </span>
+                        ))}
+                        {parseSelectOptions(field.options).length > 4 && (
+                          <span className="text-xs text-zinc-400">+{parseSelectOptions(field.options).length - 4}</span>
+                        )}
+                      </div>
                     ) : field.type === FieldType.RELATION_SUBTABLE ? (
                       <div className="space-y-1 text-sm text-zinc-500">
                         <div>

--- a/src/components/data/field-config-list.tsx
+++ b/src/components/data/field-config-list.tsx
@@ -14,7 +14,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { FieldConfigForm } from "./field-config-form";
 import type { DataFieldItem, DataTableListItem } from "@/types/data-table";
-import { parseSelectOptions } from "@/types/data-table";
+import { parseSelectOptions, SELECT_COLORS } from "@/types/data-table";
 import type { DataFieldInput } from "@/validators/data-table";
 import { FieldType } from "@/generated/prisma/enums";
 
@@ -312,15 +312,18 @@ export function FieldConfigList({
                     {field.type === FieldType.SELECT ||
                     field.type === FieldType.MULTISELECT ? (
                       <div className="flex flex-wrap gap-1">
-                        {parseSelectOptions(field.options).slice(0, 4).map((opt, i) => (
+                        {parseSelectOptions(field.options).slice(0, 4).map((opt, i) => {
+                          const preset = SELECT_COLORS.find(c => c.bg === opt.color);
+                          return (
                           <span
                             key={i}
                               className="inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium"
-                            style={{ backgroundColor: opt.color }}
+                            style={{ backgroundColor: opt.color, color: preset?.fg ?? "#374151" }}
                           >
                             {opt.label}
                           </span>
-                        ))}
+                          );
+                        })}
                         {parseSelectOptions(field.options).length > 4 && (
                           <span className="text-xs text-zinc-400">+{parseSelectOptions(field.options).length - 4}</span>
                         )}

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -19,6 +19,7 @@ import type {
   FilterGroup,
   SortConfig,
 } from "@/types/data-table";
+import { parseSelectOptions } from "@/types/data-table";
 import { ColumnHeader } from "@/components/data/column-header";
 import { formatCellValue } from "@/lib/format-cell";
 import { useInlineEdit } from "@/hooks/use-inline-edit";
@@ -1263,7 +1264,7 @@ export function GridView({
           return (
             <SelectCellEditor
               value={String(originalValue ?? "")}
-              options={Array.isArray(field.options) ? field.options : []}
+              options={parseSelectOptions(field.options)}
               onCommit={(v) => void commitEdit(v)}
               onCancel={cancelEdit}
             />
@@ -1275,7 +1276,7 @@ export function GridView({
           return (
             <MultiselectCellEditor
               value={arrValue}
-              options={Array.isArray(field.options) ? field.options : []}
+              options={parseSelectOptions(field.options)}
               onCommit={(v) => void commitEdit(v)}
               onCancel={cancelEdit}
             />

--- a/src/components/forms/ai-fill-assistant.tsx
+++ b/src/components/forms/ai-fill-assistant.tsx
@@ -1,10 +1,17 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from "react";
-import { Sparkles, X, Send, Loader2, Check, Undo2 } from "lucide-react";
+import { Sparkles, X, Send, Loader2, Check, Undo2, ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
+
+interface ModelItem {
+  id: string;
+  name: string;
+  providerId: string;
+  modelId: string;
+}
 
 interface FieldInfo {
   key: string;
@@ -68,9 +75,60 @@ export function AiFillAssistant({
   const [suggestions, setSuggestions] = useState<Record<string, FillValue> | null>(null);
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
   const [applied, setApplied] = useState(false);
+  const [models, setModels] = useState<ModelItem[]>([]);
+  const [selectedModel, setSelectedModel] = useState<string>("");
+  const [modelName, setModelName] = useState("默认模型");
+  const [modelMenuOpen, setModelMenuOpen] = useState(false);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const modelMenuRef = useRef<HTMLDivElement>(null);
+
+  // Fetch available models on mount
+  useEffect(() => {
+    let active = true;
+    fetch("/api/agent2/models")
+      .then((res) => res.json())
+      .then((data) => {
+        if (!active || !data?.success) return;
+        setModels(data.data);
+        // Try to load saved default model from settings
+        fetch("/api/agent2/settings")
+          .then((r) => r.json())
+          .then((settings) => {
+            if (!active) return;
+            const saved = settings.success ? settings.data.defaultModel : null;
+            if (saved) {
+              setSelectedModel(saved);
+              const found = data.data.find((m: ModelItem) => m.id === saved);
+              setModelName(found ? found.name : saved);
+            } else if (data.data.length > 0) {
+              // Default to first model (usually env-configured default)
+              setSelectedModel(data.data[0].id);
+              setModelName(data.data[0].name);
+            }
+          })
+          .catch(() => {
+            if (!active || data.data.length === 0) return;
+            setSelectedModel(data.data[0].id);
+            setModelName(data.data[0].name);
+          });
+      })
+      .catch(() => {});
+    return () => { active = false; };
+  }, []);
+
+  // Close model menu on outside click
+  useEffect(() => {
+    if (!modelMenuOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (modelMenuRef.current && !modelMenuRef.current.contains(e.target as Node)) {
+        setModelMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [modelMenuOpen]);
 
   // Scroll to bottom on new messages
   useEffect(() => {
@@ -102,6 +160,7 @@ export function AiFillAssistant({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           messages: newMessages.map((m) => ({ role: m.role, content: m.content })),
+          ...(selectedModel ? { model: selectedModel } : {}),
           templateId,
           context: {
             templateName,
@@ -159,7 +218,7 @@ export function AiFillAssistant({
       setLoading(false);
       abortRef.current = null;
     }
-  }, [input, loading, messages, templateName, fields, currentValues]);
+  }, [input, loading, messages, templateName, fields, currentValues, selectedModel]);
 
   const handleApply = () => {
     if (!suggestions) return;
@@ -216,9 +275,51 @@ export function AiFillAssistant({
               <Sparkles className="size-4 text-primary" />
               <span className="text-sm font-medium">AI 填充助手</span>
             </div>
-            <Button variant="ghost" size="icon-xs" onClick={() => setOpen(false)}>
-              <X className="size-4" />
-            </Button>
+            <div className="flex items-center gap-1">
+              {/* Model selector */}
+              {models.length > 0 && (
+                <div className="relative" ref={modelMenuRef}>
+                  <button
+                    type="button"
+                    onClick={() => setModelMenuOpen(!modelMenuOpen)}
+                    className="flex items-center gap-1 rounded-md px-1.5 py-1 text-xs text-muted-foreground hover:bg-muted transition-colors max-w-[160px]"
+                  >
+                    <span className="truncate">{modelName}</span>
+                    <ChevronDown className="size-3 shrink-0" />
+                  </button>
+                  {modelMenuOpen && (
+                    <div className="absolute right-0 top-full mt-1 z-50 min-w-[180px] max-h-60 overflow-y-auto rounded-md border bg-popover p-1 shadow-md">
+                      {models.map((m) => (
+                        <button
+                          key={m.id}
+                          type="button"
+                          className={cn(
+                            "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-accent transition-colors",
+                            m.id === selectedModel && "bg-accent"
+                          )}
+                          onClick={() => {
+                            setSelectedModel(m.id);
+                            setModelName(m.name);
+                            setModelMenuOpen(false);
+                          }}
+                        >
+                          <span className="size-4 shrink-0 flex items-center justify-center rounded bg-muted text-[9px] font-semibold text-muted-foreground uppercase">
+                            {m.providerId.slice(0, 2)}
+                          </span>
+                          <span className="flex-1 truncate text-left">{m.name}</span>
+                          {m.id === selectedModel && (
+                            <Check className="size-3 shrink-0 text-primary" />
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+              <Button variant="ghost" size="icon-xs" onClick={() => setOpen(false)}>
+                <X className="size-4" />
+              </Button>
+            </div>
           </div>
 
           {/* Messages */}

--- a/src/lib/format-cell.tsx
+++ b/src/lib/format-cell.tsx
@@ -5,23 +5,31 @@ import type { DataFieldItem, RelationSubtableValueItem, SelectOption } from "@/t
 import { parseSelectOptions, SELECT_COLORS } from "@/types/data-table";
 import { FileIcon } from "lucide-react";
 
+type ColorPair = { bg: string; fg: string };
+
 /** Build a color lookup map from field.options */
-function buildColorMap(field: DataFieldItem): Map<string, string> {
+function buildColorMap(field: DataFieldItem): Map<string, ColorPair> {
   const options = parseSelectOptions(field.options);
-  const map = new Map<string, string>();
+  const map = new Map<string, ColorPair>();
   for (const opt of options) {
-    map.set(opt.label, opt.color);
+    map.set(opt.label, { bg: opt.color, fg: findFg(opt.color) });
   }
   return map;
 }
 
-/** Get color for a select value, fallback to hash-based color */
-function getSelectColor(value: string, colorMap: Map<string, string>): string {
+/** Find matching foreground color for a given background hex */
+function findFg(bgHex: string): string {
+  const preset = SELECT_COLORS.find((c) => c.bg === bgHex);
+  return preset?.fg ?? "#374151";
+}
+
+/** Get color pair for a select value, with hash-based fallback */
+function getSelectColor(value: string, colorMap: Map<string, ColorPair>): ColorPair {
   if (colorMap.has(value)) return colorMap.get(value)!;
-  // Fallback: deterministic color based on string hash
   let hash = 0;
   for (let i = 0; i < value.length; i++) hash = value.charCodeAt(i) + ((hash << 5) - hash);
-  return SELECT_COLORS[Math.abs(hash) % SELECT_COLORS.length].hex;
+  const preset = SELECT_COLORS[Math.abs(hash) % SELECT_COLORS.length];
+  return { bg: preset.bg, fg: preset.fg };
 }
 
 function isEmptyCell(value: unknown): boolean {
@@ -87,11 +95,11 @@ export function formatCellValue(
       );
     case FieldType.SELECT: {
       const colorMap = buildColorMap(field);
-      const color = getSelectColor(String(value), colorMap);
+      const { bg, fg } = getSelectColor(String(value), colorMap);
       return (
         <span
           className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium max-w-full truncate"
-          style={{ backgroundColor: color }}
+          style={{ backgroundColor: bg, color: fg }}
         >
           {String(value)}
         </span>
@@ -103,12 +111,12 @@ export function formatCellValue(
         return (
           <div className="flex flex-wrap gap-1">
             {value.map((item, index) => {
-              const color = getSelectColor(String(item), colorMap);
+              const { bg, fg } = getSelectColor(String(item), colorMap);
               return (
                 <span
                   key={index}
                   className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
-                  style={{ backgroundColor: color }}
+                  style={{ backgroundColor: bg, color: fg }}
                 >
                   {String(item)}
                 </span>

--- a/src/lib/format-cell.tsx
+++ b/src/lib/format-cell.tsx
@@ -1,8 +1,28 @@
 import { Badge } from "@/components/ui/badge";
 import { FieldType } from "@/generated/prisma/enums";
 import type { ReactNode } from "react";
-import type { DataFieldItem, RelationSubtableValueItem } from "@/types/data-table";
+import type { DataFieldItem, RelationSubtableValueItem, SelectOption } from "@/types/data-table";
+import { parseSelectOptions, SELECT_COLORS } from "@/types/data-table";
 import { FileIcon } from "lucide-react";
+
+/** Build a color lookup map from field.options */
+function buildColorMap(field: DataFieldItem): Map<string, string> {
+  const options = parseSelectOptions(field.options);
+  const map = new Map<string, string>();
+  for (const opt of options) {
+    map.set(opt.label, opt.color);
+  }
+  return map;
+}
+
+/** Get color for a select value, fallback to hash-based color */
+function getSelectColor(value: string, colorMap: Map<string, string>): string {
+  if (colorMap.has(value)) return colorMap.get(value)!;
+  // Fallback: deterministic color based on string hash
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) hash = value.charCodeAt(i) + ((hash << 5) - hash);
+  return SELECT_COLORS[Math.abs(hash) % SELECT_COLORS.length].hex;
+}
 
 function isEmptyCell(value: unknown): boolean {
   return value === null || value === undefined || value === "";
@@ -65,21 +85,40 @@ export function formatCellValue(
           <span className="truncate">{getFileName(String(value))}</span>
         </a>
       );
-    case FieldType.SELECT:
-      return <Badge variant="secondary">{String(value)}</Badge>;
-    case FieldType.MULTISELECT:
+    case FieldType.SELECT: {
+      const colorMap = buildColorMap(field);
+      const color = getSelectColor(String(value), colorMap);
+      return (
+        <span
+          className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium max-w-full truncate"
+          style={{ backgroundColor: color }}
+        >
+          {String(value)}
+        </span>
+      );
+    }
+    case FieldType.MULTISELECT: {
       if (Array.isArray(value)) {
+        const colorMap = buildColorMap(field);
         return (
           <div className="flex flex-wrap gap-1">
-            {value.map((item, index) => (
-              <Badge key={index} variant="secondary" className="text-xs">
-                {String(item)}
-              </Badge>
-            ))}
+            {value.map((item, index) => {
+              const color = getSelectColor(String(item), colorMap);
+              return (
+                <span
+                  key={index}
+                  className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
+                  style={{ backgroundColor: color }}
+                >
+                  {String(item)}
+                </span>
+              );
+            })}
           </div>
         );
       }
       return String(value);
+    }
     case FieldType.EMAIL:
       return (
         <a href={`mailto:${value}`} className="text-blue-600 hover:underline">

--- a/src/types/data-table.ts
+++ b/src/types/data-table.ts
@@ -43,18 +43,18 @@ export interface SelectOption {
   color: string;
 }
 
-/** Preset color palette for select options */
+/** Preset color palette for select options (bg = background, fg = text) */
 export const SELECT_COLORS = [
-  { name: "蓝色", bg: "bg-blue-100", text: "text-blue-800", hex: "#dbeafe" },
-  { name: "绿色", bg: "bg-green-100", text: "text-green-800", hex: "#dcfce7" },
-  { name: "黄色", bg: "bg-yellow-100", text: "text-yellow-800", hex: "#fef9c3" },
-  { name: "红色", bg: "bg-red-100", text: "text-red-800", hex: "#fee2e2" },
-  { name: "紫色", bg: "bg-purple-100", text: "text-purple-800", hex: "#f3e8ff" },
-  { name: "粉色", bg: "bg-pink-100", text: "text-pink-800", hex: "#fce7f3" },
-  { name: "橙色", bg: "bg-orange-100", text: "text-orange-800", hex: "#ffedd5" },
-  { name: "青色", bg: "bg-cyan-100", text: "text-cyan-800", hex: "#cffafe" },
-  { name: "靛蓝", bg: "bg-indigo-100", text: "text-indigo-800", hex: "#e0e7ff" },
-  { name: "灰色", bg: "bg-gray-100", text: "text-gray-800", hex: "#f3f4f6" },
+  { name: "蓝色", bg: "#dbeafe", fg: "#1e40af" },
+  { name: "绿色", bg: "#dcfce7", fg: "#166534" },
+  { name: "黄色", bg: "#fef9c3", fg: "#854d0e" },
+  { name: "红色", bg: "#fee2e2", fg: "#991b1b" },
+  { name: "紫色", bg: "#f3e8ff", fg: "#6b21a8" },
+  { name: "粉色", bg: "#fce7f3", fg: "#9d174d" },
+  { name: "橙色", bg: "#ffedd5", fg: "#9a3412" },
+  { name: "青色", bg: "#cffafe", fg: "#155e75" },
+  { name: "靛蓝", bg: "#e0e7ff", fg: "#3730a3" },
+  { name: "灰色", bg: "#f3f4f6", fg: "#374151" },
 ] as const;
 
 /** Parse field.options into SelectOption[] with backward compatibility */
@@ -68,7 +68,7 @@ export function parseSelectOptions(raw: unknown): SelectOption[] {
   // Legacy format: string[] → auto-assign colors
   return (raw as string[]).map((label, i) => ({
     label,
-    color: SELECT_COLORS[i % SELECT_COLORS.length].hex,
+    color: SELECT_COLORS[i % SELECT_COLORS.length].bg,
   }));
 }
 

--- a/src/types/data-table.ts
+++ b/src/types/data-table.ts
@@ -37,6 +37,41 @@ export interface RelationSchemaConfig {
 
 // ========== Field Options (stored in DataField.options JSON) ==========
 
+/** A single option for SELECT / MULTISELECT fields */
+export interface SelectOption {
+  label: string;
+  color: string;
+}
+
+/** Preset color palette for select options */
+export const SELECT_COLORS = [
+  { name: "蓝色", bg: "bg-blue-100", text: "text-blue-800", hex: "#dbeafe" },
+  { name: "绿色", bg: "bg-green-100", text: "text-green-800", hex: "#dcfce7" },
+  { name: "黄色", bg: "bg-yellow-100", text: "text-yellow-800", hex: "#fef9c3" },
+  { name: "红色", bg: "bg-red-100", text: "text-red-800", hex: "#fee2e2" },
+  { name: "紫色", bg: "bg-purple-100", text: "text-purple-800", hex: "#f3e8ff" },
+  { name: "粉色", bg: "bg-pink-100", text: "text-pink-800", hex: "#fce7f3" },
+  { name: "橙色", bg: "bg-orange-100", text: "text-orange-800", hex: "#ffedd5" },
+  { name: "青色", bg: "bg-cyan-100", text: "text-cyan-800", hex: "#cffafe" },
+  { name: "靛蓝", bg: "bg-indigo-100", text: "text-indigo-800", hex: "#e0e7ff" },
+  { name: "灰色", bg: "bg-gray-100", text: "text-gray-800", hex: "#f3f4f6" },
+] as const;
+
+/** Parse field.options into SelectOption[] with backward compatibility */
+export function parseSelectOptions(raw: unknown): SelectOption[] {
+  if (!Array.isArray(raw)) return [];
+  if (raw.length === 0) return [];
+  // New format: { label, color }[]
+  if (typeof raw[0] === "object" && raw[0] !== null && "color" in raw[0]) {
+    return raw as SelectOption[];
+  }
+  // Legacy format: string[] → auto-assign colors
+  return (raw as string[]).map((label, i) => ({
+    label,
+    color: SELECT_COLORS[i % SELECT_COLORS.length].hex,
+  }));
+}
+
 export interface FieldOptions {
   /** AUTO_NUMBER: next auto-increment value */
   nextValue?: number;

--- a/src/validators/data-table.ts
+++ b/src/validators/data-table.ts
@@ -46,6 +46,7 @@ export const dataFieldItemSchema = z.object({
   required: z.boolean().default(false),
   options: z.union([
     z.array(z.string()),
+    z.array(z.object({ label: z.string(), color: z.string() })),
     z.object({ formula: z.string() }),
     z.object({ nextValue: z.number() }),
     z.object({ kind: z.enum(["created", "updated"]) }),


### PR DESCRIPTION
## Summary

- Select/MultiSelect 选项从纯文本改为带颜色的标签
- 新增 `SelectOption` 类型（label + color）和 10 色预设色板
- 字段配置页面从 Textarea 改为可交互的选项列表（点击色块切换颜色）
- 单元格中 SELECT/MULTISELECT 以对应颜色的圆角标签展示
- 编辑器下拉和筛选面板中显示颜色圆点
- `parseSelectOptions` 自动兼容旧版 `string[]` 格式，无需数据迁移

## Test plan

- [x] 字段配置中可为选项选择颜色
- [x] 单元格内选项以对应颜色 Badge 显示
- [x] 新建选项自动分配颜色
- [x] 多选字段每个标签颜色独立
- [x] 类型检查通过
- [ ] 旧数据向后兼容

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)