### PR TITLE
[Feature] 新增 Form 表单视图

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -739,6 +739,9 @@ enum AuditAction {
   USER_DELETE
   API_TOKEN_CREATE
   API_TOKEN_REVOKE
+  FORM_SHARE_CREATE
+  FORM_SHARE_DELETE
+  FORM_SUBMIT
 }
 
 model AuditLog {
@@ -788,16 +791,17 @@ model ApiToken {
 }
 
 model FormShareToken {
-  id          String    @id @default(cuid())
-  token       String    @unique @default(cuid())
-  viewId      String
-  view        DataView  @relation(fields: [viewId], references: [id], onDelete: Cascade)
-  label       String?
-  isActive    Boolean   @default(true)
-  createdById String
-  createdBy   User      @relation(fields: [createdById], references: [id], onDelete: Cascade)
-  createdAt   DateTime  @default(now())
-  expiresAt   DateTime?
+  id             String    @id @default(cuid())
+  token          String    @unique @default(cuid())
+  viewId         String
+  view           DataView  @relation(fields: [viewId], references: [id], onDelete: Cascade)
+  label          String?
+  isActive       Boolean   @default(true)
+  createdById    String
+  createdBy      User      @relation(fields: [createdById], references: [id], onDelete: Cascade)
+  createdAt      DateTime  @default(now())
+  expiresAt      DateTime?
+  submissionCount Int      @default(0)
 
   @@index([token])
   @@index([viewId])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,7 +49,7 @@ model User {
   collectionSubmissionVersions DocumentCollectionSubmissionVersion[] @relation("CollectionSubmissionVersions")
   notifications                 Notification[]                       @relation("UserNotifications")
   apiTokens                     ApiToken[]
-  changeHistories               DataRecordChangeHistory[]
+  formShareTokens               FormShareToken[]
 }
 
 enum TemplateStatus {
@@ -295,6 +295,7 @@ enum ViewType {
   KANBAN
   GALLERY
   TIMELINE
+  FORM
 }
 
 enum RelationCardinality {
@@ -428,6 +429,7 @@ model DataView {
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
   table         DataTable @relation(fields: [tableId], references: [id], onDelete: Cascade)
+  shareTokens   FormShareToken[]
 
   @@unique([tableId, name])
 }
@@ -783,5 +785,22 @@ model ApiToken {
   @@index([tokenHash])
   @@index([userId])
   @@map("api_tokens")
+}
+
+model FormShareToken {
+  id          String    @id @default(cuid())
+  token       String    @unique @default(cuid())
+  viewId      String
+  view        DataView  @relation(fields: [viewId], references: [id], onDelete: Cascade)
+  label       String?
+  isActive    Boolean   @default(true)
+  createdById String
+  createdBy   User      @relation(fields: [createdById], references: [id], onDelete: Cascade)
+  createdAt   DateTime  @default(now())
+  expiresAt   DateTime?
+
+  @@index([token])
+  @@index([viewId])
+  @@map("form_share_tokens")
 }
 

--- a/src/app/(public)/f/[token]/page.tsx
+++ b/src/app/(public)/f/[token]/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { use } from "react";
+import { PublicFormRenderer } from "@/components/public/public-form-renderer";
+import type { PublicFormConfig } from "@/lib/services/form-share.service";
+import { Loader2 } from "lucide-react";
+
+interface FormPageProps {
+  params: Promise<{ token: string }>;
+}
+
+export default function PublicFormPage({ params }: FormPageProps) {
+  const { token } = use(params);
+  const [config, setConfig] = useState<PublicFormConfig | null>(null);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`/api/public/form/${token}`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.success) {
+          setConfig(data.data);
+        } else {
+          setError(data.error?.message || "加载表单失败");
+        }
+      })
+      .catch(() => {
+        setError("网络错误，请稍后重试");
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [token]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="size-5 animate-spin" />
+          加载表单...
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center space-y-3">
+          <div className="text-4xl">:(</div>
+          <p className="text-lg font-medium">{error}</p>
+          <p className="text-sm text-muted-foreground">
+            该链接可能已失效或已过期
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!config) return null;
+
+  return (
+    <div className="max-w-xl mx-auto py-12 px-4">
+      <div className="rounded-lg border bg-card shadow-sm">
+        <div className="p-6 border-b">
+          <h1 className="text-xl font-semibold">
+            {config.formTitle || "未命名表单"}
+          </h1>
+          {config.formDescription && (
+            <p className="mt-2 text-sm text-muted-foreground">
+              {config.formDescription}
+            </p>
+          )}
+        </div>
+        <div className="p-6">
+          <PublicFormRenderer config={config} token={token} />
+        </div>
+      </div>
+      <div className="text-center mt-4 text-xs text-muted-foreground">
+        由 docx-template-system 提供支持
+      </div>
+    </div>
+  );
+}

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,0 +1,11 @@
+export default function PublicLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="min-h-screen bg-muted/40">
+      {children}
+    </div>
+  );
+}

--- a/src/app/api/data-tables/[id]/views/[viewId]/share/[tokenId]/route.ts
+++ b/src/app/api/data-tables/[id]/views/[viewId]/share/[tokenId]/route.ts
@@ -12,7 +12,7 @@ export async function DELETE(
   }
 
   const { tokenId } = await params;
-  const result = await deleteShareToken(tokenId, session.user.id);
+  const result = await deleteShareToken(tokenId, session.user.id, session.user.name);
 
   if (!result.success) {
     return NextResponse.json({ error: result.error }, { status: 404 });

--- a/src/app/api/data-tables/[id]/views/[viewId]/share/[tokenId]/route.ts
+++ b/src/app/api/data-tables/[id]/views/[viewId]/share/[tokenId]/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { deleteShareToken } from "@/lib/services/form-share.service";
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string; viewId: string; tokenId: string }> }
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "未授权" }, { status: 401 });
+  }
+
+  const { tokenId } = await params;
+  const result = await deleteShareToken(tokenId, session.user.id);
+
+  if (!result.success) {
+    return NextResponse.json({ error: result.error }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true, data: result.data });
+}

--- a/src/app/api/data-tables/[id]/views/[viewId]/share/route.ts
+++ b/src/app/api/data-tables/[id]/views/[viewId]/share/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import {
+  listShareTokens,
+  createShareToken,
+} from "@/lib/services/form-share.service";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string; viewId: string }> }
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "未授权" }, { status: 401 });
+  }
+
+  const { viewId } = await params;
+  const result = await listShareTokens(viewId);
+  if (!result.success) {
+    return NextResponse.json({ error: result.error }, { status: 400 });
+  }
+
+  return NextResponse.json({ success: true, data: result.data });
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; viewId: string }> }
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "未授权" }, { status: 401 });
+  }
+
+  const { viewId } = await params;
+  const body = await request.json().catch(() => ({}));
+
+  const result = await createShareToken(viewId, session.user.id, {
+    label: body.label,
+    expiresAt: body.expiresAt,
+  });
+
+  if (!result.success) {
+    return NextResponse.json({ error: result.error }, { status: 400 });
+  }
+
+  // Build full URL for convenience
+  const baseUrl = process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_BASE_URL || "";
+  const shareUrl = baseUrl ? `${baseUrl}/f/${result.data.token}` : `/f/${result.data.token}`;
+
+  return NextResponse.json(
+    { success: true, data: { ...result.data, url: shareUrl } },
+    { status: 201 }
+  );
+}

--- a/src/app/api/data-tables/[id]/views/[viewId]/share/route.ts
+++ b/src/app/api/data-tables/[id]/views/[viewId]/share/route.ts
@@ -20,7 +20,14 @@ export async function GET(
     return NextResponse.json({ error: result.error }, { status: 400 });
   }
 
-  return NextResponse.json({ success: true, data: result.data });
+  // Build full URLs for each token
+  const baseUrl = process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_BASE_URL || "";
+  const tokensWithUrl = result.data.map((t) => ({
+    ...t,
+    url: baseUrl ? `${baseUrl}/f/${t.token}` : `/f/${t.token}`,
+  }));
+
+  return NextResponse.json({ success: true, data: tokensWithUrl });
 }
 
 export async function POST(
@@ -35,10 +42,15 @@ export async function POST(
   const { viewId } = await params;
   const body = await request.json().catch(() => ({}));
 
-  const result = await createShareToken(viewId, session.user.id, {
-    label: body.label,
-    expiresAt: body.expiresAt,
-  });
+  const result = await createShareToken(
+    viewId,
+    session.user.id,
+    session.user.name,
+    {
+      label: body.label,
+      expiresAt: body.expiresAt,
+    }
+  );
 
   if (!result.success) {
     return NextResponse.json({ error: result.error }, { status: 400 });

--- a/src/app/api/data-tables/[id]/views/[viewId]/share/route.ts
+++ b/src/app/api/data-tables/[id]/views/[viewId]/share/route.ts
@@ -38,6 +38,9 @@ export async function POST(
   if (!session?.user) {
     return NextResponse.json({ error: "未授权" }, { status: 401 });
   }
+  if (session.user.role !== "ADMIN") {
+    return NextResponse.json({ error: "仅管理员可创建分享链接" }, { status: 403 });
+  }
 
   const { viewId } = await params;
   const body = await request.json().catch(() => ({}));

--- a/src/app/api/public/form/[token]/route.ts
+++ b/src/app/api/public/form/[token]/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import { resolvePublicForm } from "@/lib/services/form-share.service";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ token: string }> }
+) {
+  const { token } = await params;
+  const result = await resolvePublicForm(token);
+
+  if (!result.success) {
+    return NextResponse.json(
+      { error: result.error },
+      { status: result.error.code === "NOT_FOUND" || result.error.code === "EXPIRED" ? 404 : 400 }
+    );
+  }
+
+  return NextResponse.json({ success: true, data: result.data });
+}

--- a/src/app/api/public/form/[token]/submit/route.ts
+++ b/src/app/api/public/form/[token]/submit/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { submitPublicForm } from "@/lib/services/form-share.service";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ token: string }> }
+) {
+  const { token } = await params;
+
+  try {
+    const body = await request.json();
+    const data = body.data ?? body;
+
+    if (typeof data !== "object" || data === null) {
+      return NextResponse.json(
+        { error: { code: "INVALID_DATA", message: "提交数据格式无效" } },
+        { status: 400 }
+      );
+    }
+
+    const result = await submitPublicForm(token, data);
+
+    if (!result.success) {
+      return NextResponse.json(
+        { error: result.error },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json({ success: true, data: result.data });
+  } catch {
+    return NextResponse.json(
+      { error: { code: "INVALID_REQUEST", message: "请求处理失败" } },
+      { status: 400 }
+    );
+  }
+}

--- a/src/app/api/public/form/[token]/submit/route.ts
+++ b/src/app/api/public/form/[token]/submit/route.ts
@@ -28,7 +28,8 @@ export async function POST(
     }
 
     return NextResponse.json({ success: true, data: result.data });
-  } catch {
+  } catch (error) {
+    console.error("[FormSubmit] Error:", error);
     return NextResponse.json(
       { error: { code: "INVALID_REQUEST", message: "请求处理失败" } },
       { status: 400 }

--- a/src/components/data/record-table.tsx
+++ b/src/components/data/record-table.tsx
@@ -112,9 +112,9 @@ export function RecordTable({
   // Sync viewType from loaded view
   useEffect(() => {
     if (currentView?.type) {
-      setViewType(currentView.type);
+      setViewType(currentView.type as ViewType);
     }
-  }, [currentView?.type]);
+  }, [viewId, currentView?.type]);
 
   // ── Patch single field (for Kanban drag-and-drop) ────────────────────────
   const handlePatchRecord = useCallback(

--- a/src/components/data/record-table.tsx
+++ b/src/components/data/record-table.tsx
@@ -25,11 +25,13 @@ import { ConditionalFormatDialog } from "@/components/data/conditional-format-di
 import { FilterPanel } from "@/components/data/filter-panel";
 import { ViewSelector } from "@/components/data/view-selector";
 import { SaveViewDialog } from "@/components/data/save-view-dialog";
+import { KeyboardShortcutsDialog } from "@/components/data/views/keyboard-shortcuts-dialog";
 import { useTableData } from "@/hooks/use-table-data";
 import { GridView } from "@/components/data/views/grid-view";
 import { KanbanView } from "@/components/data/views/kanban/kanban-view";
 import { GalleryView } from "@/components/data/views/gallery/gallery-view";
 import { TimelineView } from "@/components/data/views/timeline/timeline-view";
+import { FormView } from "@/components/data/views/form/form-view";
 
 // ─── Props ──────────────────────────────────────────────────────────────────
 
@@ -343,6 +345,15 @@ export function RecordTable({
             onViewOptionsChange={setViewOptions}
           />
         );
+      case "FORM":
+        return (
+          <FormView
+            fields={fields}
+            view={activeView}
+            onViewOptionsChange={setViewOptions}
+            tableId={tableId}
+          />
+        );
       default:
         return (
           <div className="rounded-md border flex items-center justify-center py-20 text-zinc-400 text-sm">
@@ -403,6 +414,7 @@ export function RecordTable({
           </form>
         </div>
         <div className="flex items-center gap-2 w-full sm:w-auto">
+          <KeyboardShortcutsDialog />
           <DropdownMenu>
             <DropdownMenuTrigger
               render={

--- a/src/components/data/record-table.tsx
+++ b/src/components/data/record-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
@@ -24,6 +24,7 @@ import { FieldConfigPopover } from "@/components/data/field-config-popover";
 import { ConditionalFormatDialog } from "@/components/data/conditional-format-dialog";
 import { FilterPanel } from "@/components/data/filter-panel";
 import { ViewSelector } from "@/components/data/view-selector";
+import { ViewSwitcher } from "@/components/data/view-switcher";
 import { SaveViewDialog } from "@/components/data/save-view-dialog";
 import { KeyboardShortcutsDialog } from "@/components/data/views/keyboard-shortcuts-dialog";
 import { useTableData } from "@/hooks/use-table-data";
@@ -39,7 +40,6 @@ interface RecordTableProps {
   tableId: string;
   fields: DataFieldItem[];
   isAdmin: boolean;
-  viewType?: ViewType;
   onOpenDetail?: (recordId: string) => void;
 }
 
@@ -69,10 +69,10 @@ export function RecordTable({
   tableId,
   fields,
   isAdmin,
-  viewType = "GRID",
   onOpenDetail,
 }: RecordTableProps) {
   const router = useRouter();
+  const [viewType, setViewType] = useState<ViewType>("GRID");
   const [saveDialogOpen, setSaveDialogOpen] = useState(false);
   const [quickFormatField, setQuickFormatField] = useState<string | undefined>();
   const [quickFormatValue, setQuickFormatValue] = useState<string | undefined>();
@@ -108,6 +108,13 @@ export function RecordTable({
     const base = currentView ?? buildFallbackView(tableId, fields);
     return { ...base, viewOptions: currentConfig.viewOptions };
   }, [currentConfig.viewOptions, currentView, tableId, fields]);
+
+  // Sync viewType from loaded view
+  useEffect(() => {
+    if (currentView?.type) {
+      setViewType(currentView.type);
+    }
+  }, [currentView?.type]);
 
   // ── Patch single field (for Kanban drag-and-drop) ────────────────────────
   const handlePatchRecord = useCallback(
@@ -374,6 +381,7 @@ export function RecordTable({
             onViewChange={switchView}
             onSaveNewView={() => setSaveDialogOpen(true)}
           />
+          <ViewSwitcher currentType={viewType} onTypeChange={setViewType} />
           <FilterPanel
             fields={fields}
             filters={currentConfig.filters}

--- a/src/components/data/record-table.tsx
+++ b/src/components/data/record-table.tsx
@@ -514,6 +514,7 @@ export function RecordTable({
         onOpenChange={setSaveDialogOpen}
         tableId={tableId}
         currentConfig={currentConfig}
+        viewType={viewType}
         onSaved={switchView}
       />
     </div>

--- a/src/components/data/save-view-dialog.tsx
+++ b/src/components/data/save-view-dialog.tsx
@@ -14,13 +14,14 @@ import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
-import type { DataViewConfig } from "@/types/data-table";
+import type { DataViewConfig, ViewType } from "@/types/data-table";
 
 interface SaveViewDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   tableId: string;
   currentConfig: DataViewConfig;
+  viewType?: ViewType;
   onSaved: (viewId: string) => void;
 }
 
@@ -29,6 +30,7 @@ export function SaveViewDialog({
   onOpenChange,
   tableId,
   currentConfig,
+  viewType,
   onSaved,
 }: SaveViewDialogProps) {
   const [name, setName] = useState("");
@@ -58,6 +60,7 @@ export function SaveViewDialog({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name: name.trim(),
+          type: viewType,
           filters: currentConfig.filters,
           sortBy: currentConfig.sortBy,
           visibleFields: currentConfig.visibleFields,

--- a/src/components/data/table-detail-content.tsx
+++ b/src/components/data/table-detail-content.tsx
@@ -7,14 +7,13 @@ import { Separator } from "@/components/ui/separator";
 import { Bot } from "lucide-react";
 import { toast } from "sonner";
 import { RecordTable } from "@/components/data/record-table";
-import { ViewSwitcher } from "@/components/data/view-switcher";
 import { RecordDetailDrawer } from "@/components/data/record-detail-drawer";
 import { ChatArea } from "@/components/agent2/chat-area";
 import {
   Sheet,
   SheetContent,
 } from "@/components/ui/sheet";
-import type { DataTableDetail, ViewType } from "@/types/data-table";
+import type { DataTableDetail } from "@/types/data-table";
 
 interface TableDetailContentProps {
   tableId: string;
@@ -23,7 +22,6 @@ interface TableDetailContentProps {
 }
 
 export function TableDetailContent({ tableId, table, isAdmin }: TableDetailContentProps) {
-  const [viewType, setViewType] = useState<ViewType>("GRID");
   const [detailRecordId, setDetailRecordId] = useState<string | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
 
@@ -176,7 +174,6 @@ export function TableDetailContent({ tableId, table, isAdmin }: TableDetailConte
             {table.recordCount} 条记录
           </div>
         </div>
-        <ViewSwitcher currentType={viewType} onTypeChange={setViewType} />
       </div>
 
       <Separator />
@@ -186,7 +183,6 @@ export function TableDetailContent({ tableId, table, isAdmin }: TableDetailConte
         tableId={tableId}
         fields={table.fields}
         isAdmin={isAdmin}
-        viewType={viewType}
         onOpenDetail={(recordId) => {
           setDetailRecordId(recordId);
           setDetailOpen(true);

--- a/src/components/data/view-switcher.tsx
+++ b/src/components/data/view-switcher.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/tooltip";
 import type { ViewType } from "@/types/data-table";
 import {
+  ClipboardList,
   Columns3,
   GalleryHorizontal,
   GanttChart,
@@ -44,6 +45,11 @@ const VIEW_ITEMS: Array<{
     type: "TIMELINE",
     label: "时间线",
     Icon: GanttChart,
+  },
+  {
+    type: "FORM",
+    label: "表单",
+    Icon: ClipboardList,
   },
 ];
 

--- a/src/components/data/views/form/form-field-item.tsx
+++ b/src/components/data/views/form/form-field-item.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useRef, useState, useCallback } from "react";
+import { GripVertical } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { DataFieldItem } from "@/types/data-table";
+
+interface FormFieldItemProps {
+  field: DataFieldItem;
+  index: number;
+  groupId: string;
+  onDrop: (fieldKey: string, toIndex: number) => void;
+}
+
+const FIELD_TYPE_LABELS: Record<string, string> = {
+  TEXT: "文本",
+  NUMBER: "数字",
+  DATE: "日期",
+  SELECT: "单选",
+  MULTISELECT: "多选",
+  EMAIL: "邮箱",
+  PHONE: "电话",
+  URL: "链接",
+  BOOLEAN: "布尔",
+  FILE: "附件",
+  RELATION: "关联",
+};
+
+export function FormFieldItem({
+  field,
+  index,
+  groupId,
+  onDrop,
+}: FormFieldItemProps) {
+  const [dragOver, setDragOver] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const handleDragStart = useCallback(
+    (e: React.DragEvent) => {
+      e.dataTransfer.setData("text/plain", JSON.stringify({ fieldKey: field.key, groupId }));
+      e.dataTransfer.effectAllowed = "move";
+      if (ref.current) {
+        ref.current.style.opacity = "0.5";
+      }
+    },
+    [field.key, groupId]
+  );
+
+  const handleDragEnd = useCallback(() => {
+    if (ref.current) {
+      ref.current.style.opacity = "1";
+    }
+    setDragOver(false);
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    setDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback(() => {
+    setDragOver(false);
+  }, []);
+
+  const handleDrop_ = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragOver(false);
+      try {
+        const data = JSON.parse(e.dataTransfer.getData("text/plain"));
+        if (data.fieldKey) {
+          onDrop(data.fieldKey, index);
+        }
+      } catch {
+        /* ignore invalid data */
+      }
+    },
+    [index, onDrop]
+  );
+
+  return (
+    <div
+      ref={ref}
+      draggable
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop_}
+      className={cn(
+        "flex items-center gap-2 px-2 py-1.5 rounded-md border text-sm cursor-grab active:cursor-grabbing transition-colors",
+        dragOver
+          ? "border-primary bg-primary/5"
+          : "border-transparent hover:bg-muted"
+      )}
+    >
+      <GripVertical className="size-4 text-muted-foreground shrink-0" />
+      <span className="flex-1 truncate">{field.label}</span>
+      <span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+        {FIELD_TYPE_LABELS[field.type] ?? field.type}
+      </span>
+      {field.required && (
+        <span className="text-xs text-destructive">*</span>
+      )}
+    </div>
+  );
+}

--- a/src/components/data/views/form/form-preview.tsx
+++ b/src/components/data/views/form/form-preview.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { parseSelectOptions } from "@/types/data-table";
+import { FieldType } from "@/generated/prisma/enums";
+import type { DataFieldItem, FormViewOptions } from "@/types/data-table";
+
+interface FormPreviewProps {
+  options: FormViewOptions;
+  fields: DataFieldItem[];
+}
+
+export function FormPreview({ options, fields }: FormPreviewProps) {
+  return (
+    <div className="max-w-xl mx-auto py-8 px-4">
+      <div className="rounded-lg border bg-card shadow-sm">
+        <div className="p-6 border-b">
+          <h1 className="text-xl font-semibold">
+            {options.formTitle || "未命名表单"}
+          </h1>
+          {options.formDescription && (
+            <p className="mt-2 text-sm text-muted-foreground">
+              {options.formDescription}
+            </p>
+          )}
+        </div>
+
+        <form
+          className="p-6 space-y-5"
+          onSubmit={(e) => e.preventDefault()}
+        >
+          {options.layout.groups.map((group) => {
+            const groupFields = group.fieldKeys
+              .map((key) => fields.find((f) => f.key === key))
+              .filter(Boolean) as DataFieldItem[];
+
+            if (groupFields.length === 0) return null;
+
+            return (
+              <div key={group.id}>
+                {group.title && (
+                  <div className="mb-3">
+                    <h3 className="text-sm font-medium">{group.title}</h3>
+                  </div>
+                )}
+                <div className="space-y-4">
+                  {groupFields.map((field) => (
+                    <div key={field.key} className="grid gap-1.5">
+                      <Label className="text-sm flex items-center gap-1">
+                        {field.label}
+                        {field.required && (
+                          <span className="text-destructive">*</span>
+                        )}
+                      </Label>
+                      <PreviewFieldInput field={field} />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+
+          <Button className="w-full mt-6">
+            {options.submitButtonText || "提交"}
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function PreviewFieldInput({ field }: { field: DataFieldItem }) {
+  const disabled = true; // Preview mode - read only
+
+  switch (field.type) {
+    case FieldType.NUMBER:
+      return (
+        <Input
+          type="number"
+          disabled={disabled}
+          placeholder={`输入${field.label}`}
+        />
+      );
+
+    case FieldType.DATE:
+      return <Input type="date" disabled={disabled} />;
+
+    case FieldType.SELECT: {
+      const selectOpts = parseSelectOptions(field.options);
+      return (
+        <div className="flex gap-1.5 flex-wrap">
+          {selectOpts.length > 0 ? (
+            selectOpts.map((opt) => (
+              <span
+                key={opt.label}
+                className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs border"
+                style={{
+                  backgroundColor: opt.color + "33",
+                  borderColor: opt.color,
+                }}
+              >
+                <span
+                  className="w-2 h-2 rounded-full"
+                  style={{ backgroundColor: opt.color }}
+                />
+                {opt.label}
+              </span>
+            ))
+          ) : (
+            <span className="text-xs text-muted-foreground">无选项</span>
+          )}
+        </div>
+      );
+    }
+
+    case FieldType.MULTISELECT:
+      return <Input disabled={disabled} placeholder="多个值用逗号分隔" />;
+
+    case FieldType.EMAIL:
+      return (
+        <Input type="email" disabled={disabled} placeholder="email@example.com" />
+      );
+
+    case FieldType.PHONE:
+      return <Input type="tel" disabled={disabled} placeholder="输入电话" />;
+
+    case FieldType.URL:
+      return <Input type="url" disabled={disabled} placeholder="https://" />;
+
+    case FieldType.BOOLEAN:
+      return (
+        <div className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            disabled={disabled}
+            className="h-4 w-4 rounded"
+          />
+          <span className="text-sm text-muted-foreground">是/否</span>
+        </div>
+      );
+
+    case FieldType.FILE:
+      return (
+        <div className="border rounded-md px-3 py-2 text-sm text-muted-foreground">
+          点击上传文件
+        </div>
+      );
+
+    case FieldType.RELATION:
+      return (
+        <Input disabled={disabled} placeholder="搜索关联记录..." />
+      );
+
+    default:
+      return (
+        <Input disabled={disabled} placeholder={`输入${field.label}`} />
+      );
+  }
+}

--- a/src/components/data/views/form/form-view.tsx
+++ b/src/components/data/views/form/form-view.tsx
@@ -225,10 +225,13 @@ export function FormView({
     setTimeout(() => setCopiedToken(null), 2000);
   }, []);
 
+  const isFallbackView = view.id === "fallback";
+
   const openShareDialog = useCallback(() => {
+    if (isFallbackView) return;
     setShareDialogOpen(true);
     void loadShareTokens();
-  }, [loadShareTokens]);
+  }, [isFallbackView, loadShareTokens]);
 
   return (
     <div className="flex flex-col h-full">
@@ -252,15 +255,21 @@ export function FormView({
             预览
           </Button>
         </div>
-        <Dialog open={shareDialogOpen} onOpenChange={setShareDialogOpen}>
-          <DialogTrigger
-            render={
-              <Button size="sm" variant="outline" onClick={openShareDialog}>
-                <Share2 className="size-3.5 mr-1" />
-                分享
-              </Button>
-            }
-          />
+        {isFallbackView ? (
+          <Button size="sm" variant="outline" disabled title="请先保存视图再分享">
+            <Share2 className="size-3.5 mr-1" />
+            分享
+          </Button>
+        ) : (
+          <Dialog open={shareDialogOpen} onOpenChange={setShareDialogOpen}>
+            <DialogTrigger
+              render={
+                <Button size="sm" variant="outline" onClick={openShareDialog}>
+                  <Share2 className="size-3.5 mr-1" />
+                  分享
+                </Button>
+              }
+            />
           <DialogContent>
             <DialogHeader>
               <DialogTitle>分享表单</DialogTitle>
@@ -313,6 +322,7 @@ export function FormView({
             </div>
           </DialogContent>
         </Dialog>
+        )}
       </div>
 
       {/* Content */}

--- a/src/components/data/views/form/form-view.tsx
+++ b/src/components/data/views/form/form-view.tsx
@@ -1,0 +1,501 @@
+"use client";
+
+import { useState, useCallback, useMemo } from "react";
+import {
+  ClipboardList,
+  Eye,
+  Pencil,
+  Share2,
+  Plus,
+  Trash2,
+  GripVertical,
+  ChevronDown,
+  ChevronRight,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import type {
+  DataFieldItem,
+  DataViewItem,
+  FormFieldGroup,
+  FormViewOptions,
+  FormShareTokenItem,
+} from "@/types/data-table";
+import { FormFieldItem } from "./form-field-item";
+import { FormPreview } from "./form-preview";
+
+// Fields not shown in form view
+const FORM_HIDDEN_TYPES = new Set([
+  "RELATION_SUBTABLE",
+  "SYSTEM_TIMESTAMP",
+  "SYSTEM_USER",
+  "AUTO_NUMBER",
+  "FORMULA",
+]);
+
+interface FormViewProps {
+  fields: DataFieldItem[];
+  view: DataViewItem;
+  onViewOptionsChange: (options: Record<string, unknown>) => void;
+  tableId: string;
+}
+
+function getDefaultOptions(
+  tableName: string,
+  fields: DataFieldItem[]
+): FormViewOptions {
+  const visibleFields = fields.filter((f) => !FORM_HIDDEN_TYPES.has(f.type));
+  return {
+    formTitle: tableName,
+    formDescription: "",
+    submitButtonText: "提交",
+    successMessage: "提交成功！",
+    allowMultipleSubmissions: false,
+    layout: {
+      version: 1,
+      groups: [
+        {
+          id: "default",
+          title: "",
+          fieldKeys: visibleFields.map((f) => f.key),
+        },
+      ],
+    },
+  };
+}
+
+export function FormView({
+  fields,
+  view,
+  onViewOptionsChange,
+  tableId,
+}: FormViewProps) {
+  const options = (view.viewOptions ?? {}) as Partial<FormViewOptions>;
+
+  // Ensure layout exists with defaults
+  const fullOptions = useMemo<FormViewOptions>(() => {
+    const defaults = getDefaultOptions(view.name, fields);
+    return {
+      formTitle: options.formTitle ?? defaults.formTitle,
+      formDescription: options.formDescription ?? defaults.formDescription,
+      submitButtonText: options.submitButtonText ?? defaults.submitButtonText,
+      successMessage: options.successMessage ?? defaults.successMessage,
+      allowMultipleSubmissions:
+        options.allowMultipleSubmissions ?? defaults.allowMultipleSubmissions,
+      layout: options.layout ?? defaults.layout,
+    };
+  }, [view.viewOptions, view.name, fields]);
+
+  const [mode, setMode] = useState<"edit" | "preview">("edit");
+  const [shareDialogOpen, setShareDialogOpen] = useState(false);
+  const [shareTokens, setShareTokens] = useState<FormShareTokenItem[]>([]);
+  const [shareLoading, setShareLoading] = useState(false);
+  const [copiedToken, setCopiedToken] = useState<string | null>(null);
+
+  const update = useCallback(
+    (patch: Partial<FormViewOptions>) => {
+      onViewOptionsChange({ ...fullOptions, ...patch });
+    },
+    [fullOptions, onViewOptionsChange]
+  );
+
+  const visibleFields = useMemo(
+    () => fields.filter((f) => !FORM_HIDDEN_TYPES.has(f.type)),
+    [fields]
+  );
+
+  // Drag-and-drop reorder field within/between groups
+  const moveField = useCallback(
+    (fieldKey: string, toGroupId: string, toIndex: number) => {
+      const groups = fullOptions.layout.groups.map((g) => ({
+        ...g,
+        fieldKeys: g.fieldKeys.filter((k) => k !== fieldKey),
+      }));
+      const targetGroup = groups.find((g) => g.id === toGroupId);
+      if (targetGroup) {
+        targetGroup.fieldKeys.splice(toIndex, 0, fieldKey);
+      }
+      update({ layout: { ...fullOptions.layout, groups } });
+    },
+    [fullOptions, update]
+  );
+
+  const addGroup = useCallback(() => {
+    const newGroup: FormFieldGroup = {
+      id: `group-${Date.now()}`,
+      title: "新分组",
+      fieldKeys: [],
+    };
+    update({
+      layout: {
+        ...fullOptions.layout,
+        groups: [...fullOptions.layout.groups, newGroup],
+      },
+    });
+  }, [fullOptions, update]);
+
+  const removeGroup = useCallback(
+    (groupId: string) => {
+      const groups = fullOptions.layout.groups.filter((g) => g.id !== groupId);
+      if (groups.length === 0) return; // Keep at least one group
+      // Move fields from removed group to first group
+      const removed = fullOptions.layout.groups.find((g) => g.id === groupId);
+      if (removed && removed.fieldKeys.length > 0) {
+        groups[0].fieldKeys = [...groups[0].fieldKeys, ...removed.fieldKeys];
+      }
+      update({ layout: { ...fullOptions.layout, groups } });
+    },
+    [fullOptions, update]
+  );
+
+  const renameGroup = useCallback(
+    (groupId: string, title: string) => {
+      const groups = fullOptions.layout.groups.map((g) =>
+        g.id === groupId ? { ...g, title } : g
+      );
+      update({ layout: { ...fullOptions.layout, groups } });
+    },
+    [fullOptions, update]
+  );
+
+  // Share management
+  const loadShareTokens = useCallback(async () => {
+    setShareLoading(true);
+    try {
+      const res = await fetch(
+        `/api/data-tables/${tableId}/views/${view.id}/share`
+      );
+      const data = await res.json();
+      if (data.success) setShareTokens(data.data);
+    } catch {
+      /* ignore */
+    } finally {
+      setShareLoading(false);
+    }
+  }, [tableId, view.id]);
+
+  const handleCreateShare = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `/api/data-tables/${tableId}/views/${view.id}/share`,
+        { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" }
+      );
+      const data = await res.json();
+      if (data.success) {
+        setShareTokens((prev) => [data.data, ...prev]);
+      }
+    } catch {
+      /* ignore */
+    }
+  }, [tableId, view.id]);
+
+  const handleDeleteShare = useCallback(
+    async (tokenId: string) => {
+      try {
+        const res = await fetch(
+          `/api/data-tables/${tableId}/views/${view.id}/share/${tokenId}`,
+          { method: "DELETE" }
+        );
+        const data = await res.json();
+        if (data.success) {
+          setShareTokens((prev) => prev.filter((t) => t.id !== tokenId));
+        }
+      } catch {
+        /* ignore */
+      }
+    },
+    [tableId, view.id]
+  );
+
+  const handleCopyLink = useCallback((token: string) => {
+    const url = `${window.location.origin}/f/${token}`;
+    navigator.clipboard.writeText(url);
+    setCopiedToken(token);
+    setTimeout(() => setCopiedToken(null), 2000);
+  }, []);
+
+  const openShareDialog = useCallback(() => {
+    setShareDialogOpen(true);
+    void loadShareTokens();
+  }, [loadShareTokens]);
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Toolbar */}
+      <div className="flex items-center justify-between px-2 py-2 border-b gap-2">
+        <div className="flex items-center gap-1">
+          <Button
+            size="sm"
+            variant={mode === "edit" ? "secondary" : "ghost"}
+            onClick={() => setMode("edit")}
+          >
+            <Pencil className="size-3.5 mr-1" />
+            编辑
+          </Button>
+          <Button
+            size="sm"
+            variant={mode === "preview" ? "secondary" : "ghost"}
+            onClick={() => setMode("preview")}
+          >
+            <Eye className="size-3.5 mr-1" />
+            预览
+          </Button>
+        </div>
+        <Dialog open={shareDialogOpen} onOpenChange={setShareDialogOpen}>
+          <DialogTrigger
+            render={
+              <Button size="sm" variant="outline" onClick={openShareDialog}>
+                <Share2 className="size-3.5 mr-1" />
+                分享
+              </Button>
+            }
+          />
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>分享表单</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4">
+              <Button onClick={handleCreateShare} size="sm">
+                <Plus className="size-3.5 mr-1" />
+                生成新链接
+              </Button>
+              {shareLoading ? (
+                <div className="text-sm text-muted-foreground text-center py-4">
+                  加载中...
+                </div>
+              ) : shareTokens.length === 0 ? (
+                <div className="text-sm text-muted-foreground text-center py-4">
+                  暂无分享链接
+                </div>
+              ) : (
+                <div className="space-y-2 max-h-60 overflow-y-auto">
+                  {shareTokens.map((t) => (
+                    <div
+                      key={t.id}
+                      className="flex items-center gap-2 p-2 rounded border text-sm"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <div className="truncate text-xs text-muted-foreground">
+                          /f/{t.token}
+                        </div>
+                      </div>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="shrink-0"
+                        onClick={() => handleCopyLink(t.token)}
+                      >
+                        {copiedToken === t.token ? "已复制" : "复制链接"}
+                      </Button>
+                      <Button
+                        size="icon-xs"
+                        variant="ghost"
+                        className="shrink-0 text-destructive"
+                        onClick={() => handleDeleteShare(t.id)}
+                      >
+                        <Trash2 className="size-3.5" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto">
+        {mode === "edit" ? (
+          <div className="max-w-2xl mx-auto p-6 space-y-6">
+            {/* Form settings */}
+            <div className="space-y-4">
+              <h3 className="text-sm font-medium text-muted-foreground">
+                表单设置
+              </h3>
+              <div className="grid gap-3">
+                <div className="grid gap-1.5">
+                  <Label className="text-xs">表单标题</Label>
+                  <Input
+                    value={fullOptions.formTitle}
+                    onChange={(e) => update({ formTitle: e.target.value })}
+                    placeholder="表单标题"
+                  />
+                </div>
+                <div className="grid gap-1.5">
+                  <Label className="text-xs">表单描述</Label>
+                  <Textarea
+                    value={fullOptions.formDescription}
+                    onChange={(e) =>
+                      update({ formDescription: e.target.value })
+                    }
+                    placeholder="可选的表单描述"
+                    rows={2}
+                  />
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="grid gap-1.5">
+                    <Label className="text-xs">提交按钮文本</Label>
+                    <Input
+                      value={fullOptions.submitButtonText}
+                      onChange={(e) =>
+                        update({ submitButtonText: e.target.value })
+                      }
+                    />
+                  </div>
+                  <div className="grid gap-1.5">
+                    <Label className="text-xs">成功提示</Label>
+                    <Input
+                      value={fullOptions.successMessage}
+                      onChange={(e) =>
+                        update({ successMessage: e.target.value })
+                      }
+                    />
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Switch
+                    checked={fullOptions.allowMultipleSubmissions}
+                    onCheckedChange={(v) =>
+                      update({ allowMultipleSubmissions: v })
+                    }
+                  />
+                  <Label className="text-xs">允许重复提交</Label>
+                </div>
+              </div>
+            </div>
+
+            {/* Field groups */}
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-medium text-muted-foreground">
+                  字段布局
+                </h3>
+                <Button size="sm" variant="outline" onClick={addGroup}>
+                  <Plus className="size-3.5 mr-1" />
+                  添加分组
+                </Button>
+              </div>
+
+              {fullOptions.layout.groups.map((group, gi) => (
+                <GroupEditor
+                  key={group.id}
+                  group={group}
+                  fields={visibleFields}
+                  canRemove={fullOptions.layout.groups.length > 1}
+                  onRename={(title) => renameGroup(group.id, title)}
+                  onRemove={() => removeGroup(group.id)}
+                  onMoveField={moveField}
+                />
+              ))}
+            </div>
+          </div>
+        ) : (
+          <FormPreview
+            options={fullOptions}
+            fields={visibleFields}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Group editor sub-component ──
+
+function GroupEditor({
+  group,
+  fields,
+  canRemove,
+  onRename,
+  onRemove,
+  onMoveField,
+}: {
+  group: FormFieldGroup;
+  fields: DataFieldItem[];
+  canRemove: boolean;
+  onRename: (title: string) => void;
+  onRemove: () => void;
+  onMoveField: (fieldKey: string, toGroupId: string, toIndex: number) => void;
+}) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  const groupFields = useMemo(
+    () =>
+      group.fieldKeys
+        .map((key) => fields.find((f) => f.key === key))
+        .filter(Boolean) as DataFieldItem[],
+    [group.fieldKeys, fields]
+  );
+
+  // Fields not yet assigned to any group in this layout (shouldn't happen normally)
+  const handleDrop = useCallback(
+    (fieldKey: string, toIndex: number) => {
+      onMoveField(fieldKey, group.id, toIndex);
+    },
+    [group.id, onMoveField]
+  );
+
+  return (
+    <div className="border rounded-lg overflow-hidden">
+      <div className="flex items-center gap-2 px-3 py-2 bg-muted/50">
+        <button
+          type="button"
+          onClick={() => setCollapsed(!collapsed)}
+          className="text-muted-foreground"
+        >
+          {collapsed ? (
+            <ChevronRight className="size-4" />
+          ) : (
+            <ChevronDown className="size-4" />
+          )}
+        </button>
+        <Input
+          value={group.title}
+          onChange={(e) => onRename(e.target.value)}
+          placeholder="分组标题"
+          className="h-7 text-sm border-none bg-transparent shadow-none focus-visible:ring-0 px-1"
+        />
+        {canRemove && (
+          <Button
+            size="icon-xs"
+            variant="ghost"
+            className="text-muted-foreground ml-auto"
+            onClick={onRemove}
+          >
+            <Trash2 className="size-3.5" />
+          </Button>
+        )}
+      </div>
+      {!collapsed && (
+        <div className="p-2 space-y-1 min-h-[40px]">
+          {groupFields.map((field, i) => (
+            <FormFieldItem
+              key={field.key}
+              field={field}
+              index={i}
+              groupId={group.id}
+              onDrop={handleDrop}
+            />
+          ))}
+          {groupFields.length === 0 && (
+            <div className="text-xs text-muted-foreground text-center py-3">
+              拖拽字段到此处
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/data/views/form/form-view.tsx
+++ b/src/components/data/views/form/form-view.tsx
@@ -12,6 +12,8 @@ import {
   GripVertical,
   ChevronDown,
   ChevronRight,
+  ExternalLink,
+  Calendar,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -21,6 +23,7 @@ import { Switch } from "@/components/ui/switch";
 import {
   Dialog,
   DialogContent,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -103,6 +106,11 @@ export function FormView({
   const [shareTokens, setShareTokens] = useState<FormShareTokenItem[]>([]);
   const [shareLoading, setShareLoading] = useState(false);
   const [copiedToken, setCopiedToken] = useState<string | null>(null);
+
+  // New share form state
+  const [newLabel, setNewLabel] = useState("");
+  const [newExpiresAt, setNewExpiresAt] = useState("");
+  const [creating, setCreating] = useState(false);
 
   const update = useCallback(
     (patch: Partial<FormViewOptions>) => {
@@ -187,19 +195,35 @@ export function FormView({
   }, [tableId, view.id]);
 
   const handleCreateShare = useCallback(async () => {
+    setCreating(true);
     try {
+      const body: Record<string, string> = {};
+      if (newLabel.trim()) body.label = newLabel.trim();
+      if (newExpiresAt) body.expiresAt = newExpiresAt;
+
       const res = await fetch(
         `/api/data-tables/${tableId}/views/${view.id}/share`,
-        { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" }
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        }
       );
       const data = await res.json();
       if (data.success) {
         setShareTokens((prev) => [data.data, ...prev]);
+        setNewLabel("");
+        setNewExpiresAt("");
+        toast.success("分享链接已创建");
+      } else {
+        toast.error(data.error?.message ?? "创建失败");
       }
     } catch {
-      /* ignore */
+      toast.error("创建失败");
+    } finally {
+      setCreating(false);
     }
-  }, [tableId, view.id]);
+  }, [tableId, view.id, newLabel, newExpiresAt]);
 
   const handleDeleteShare = useCallback(
     async (tokenId: string) => {
@@ -211,9 +235,10 @@ export function FormView({
         const data = await res.json();
         if (data.success) {
           setShareTokens((prev) => prev.filter((t) => t.id !== tokenId));
+          toast.success("链接已删除");
         }
       } catch {
-        /* ignore */
+        toast.error("删除失败");
       }
     },
     [tableId, view.id]
@@ -224,6 +249,10 @@ export function FormView({
     navigator.clipboard.writeText(url);
     setCopiedToken(token);
     setTimeout(() => setCopiedToken(null), 2000);
+  }, []);
+
+  const handleOpenLink = useCallback((token: string) => {
+    window.open(`/f/${token}`, "_blank");
   }, []);
 
   const isFallbackView = view.id === "fallback";
@@ -271,15 +300,41 @@ export function FormView({
                 </Button>
               }
             />
-          <DialogContent>
+          <DialogContent className="sm:max-w-lg">
             <DialogHeader>
               <DialogTitle>分享表单</DialogTitle>
             </DialogHeader>
             <div className="space-y-4">
-              <Button onClick={handleCreateShare} size="sm">
-                <Plus className="size-3.5 mr-1" />
-                生成新链接
-              </Button>
+              {/* Create new share */}
+              <div className="space-y-3 p-3 border rounded-lg bg-muted/30">
+                <h4 className="text-sm font-medium">创建新链接</h4>
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="grid gap-1.5">
+                    <Label className="text-xs">标签/备注</Label>
+                    <Input
+                      placeholder="如：客户填报"
+                      value={newLabel}
+                      onChange={(e) => setNewLabel(e.target.value)}
+                      className="h-8 text-sm"
+                    />
+                  </div>
+                  <div className="grid gap-1.5">
+                    <Label className="text-xs">过期时间（可选）</Label>
+                    <Input
+                      type="datetime-local"
+                      value={newExpiresAt}
+                      onChange={(e) => setNewExpiresAt(e.target.value)}
+                      className="h-8 text-sm"
+                    />
+                  </div>
+                </div>
+                <Button onClick={handleCreateShare} size="sm" disabled={creating}>
+                  <Plus className="size-3.5 mr-1" />
+                  {creating ? "创建中..." : "生成链接"}
+                </Button>
+              </div>
+
+              {/* Existing tokens list */}
               {shareLoading ? (
                 <div className="text-sm text-muted-foreground text-center py-4">
                   加载中...
@@ -289,33 +344,60 @@ export function FormView({
                   暂无分享链接
                 </div>
               ) : (
-                <div className="space-y-2 max-h-60 overflow-y-auto">
+                <div className="space-y-2 max-h-72 overflow-y-auto">
                   {shareTokens.map((t) => (
                     <div
                       key={t.id}
-                      className="flex items-center gap-2 p-2 rounded border text-sm"
+                      className="flex items-start gap-2 p-3 rounded border text-sm"
                     >
-                      <div className="flex-1 min-w-0">
-                        <div className="truncate text-xs text-muted-foreground">
-                          /f/{t.token}
+                      <div className="flex-1 min-w-0 space-y-1">
+                        {/* Label */}
+                        <div className="font-medium truncate">
+                          {t.label || <span className="text-muted-foreground italic">无标签</span>}
+                        </div>
+                        {/* URL */}
+                        <div className="truncate text-xs text-muted-foreground font-mono">
+                          {t.url ?? `/f/${t.token}`}
+                        </div>
+                        {/* Meta row */}
+                        <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                          <span>{t.submissionCount} 次提交</span>
+                          <span>{new Date(t.createdAt).toLocaleDateString()}</span>
+                          {t.expiresAt && (
+                            <span className={new Date(t.expiresAt) < new Date() ? "text-destructive" : ""}>
+                              <Calendar className="size-3 inline mr-0.5" />
+                              {new Date(t.expiresAt) < new Date() ? "已过期" : `过期: ${new Date(t.expiresAt).toLocaleDateString()}`}
+                            </span>
+                          )}
                         </div>
                       </div>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        className="shrink-0"
-                        onClick={() => handleCopyLink(t.token)}
-                      >
-                        {copiedToken === t.token ? "已复制" : "复制链接"}
-                      </Button>
-                      <Button
-                        size="icon-xs"
-                        variant="ghost"
-                        className="shrink-0 text-destructive"
-                        onClick={() => handleDeleteShare(t.id)}
-                      >
-                        <Trash2 className="size-3.5" />
-                      </Button>
+                      {/* Action buttons */}
+                      <div className="flex items-center gap-1 shrink-0">
+                        <Button
+                          size="icon-xs"
+                          variant="ghost"
+                          title="打开表单"
+                          onClick={() => handleOpenLink(t.token)}
+                        >
+                          <ExternalLink className="size-3.5" />
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-7 text-xs"
+                          onClick={() => handleCopyLink(t.token)}
+                        >
+                          {copiedToken === t.token ? "已复制" : "复制"}
+                        </Button>
+                        <Button
+                          size="icon-xs"
+                          variant="ghost"
+                          className="text-destructive"
+                          onClick={() => handleDeleteShare(t.id)}
+                        >
+                          <Trash2 className="size-3.5" />
+                        </Button>
+                      </div>
                     </div>
                   ))}
                 </div>

--- a/src/components/data/views/form/form-view.tsx
+++ b/src/components/data/views/form/form-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useMemo } from "react";
+import { toast } from "sonner";
 import {
   ClipboardList,
   Eye,
@@ -256,7 +257,7 @@ export function FormView({
           </Button>
         </div>
         {isFallbackView ? (
-          <Button size="sm" variant="outline" disabled title="请先保存视图再分享">
+          <Button size="sm" variant="outline" onClick={() => toast.info("请先保存视图再分享：点击顶部视图选择器 →「+ 新建视图」，输入名称保存即可。")}>
             <Share2 className="size-3.5 mr-1" />
             分享
           </Button>

--- a/src/components/public/public-form-renderer.tsx
+++ b/src/components/public/public-form-renderer.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { parseSelectOptions } from "@/types/data-table";
+import { Loader2 } from "lucide-react";
+import type { PublicFormConfig } from "@/lib/services/form-share.service";
+
+interface PublicFormRendererProps {
+  config: PublicFormConfig;
+  token: string;
+}
+
+function buildSchema(fields: PublicFormConfig["fields"]) {
+  return z.object(
+    Object.fromEntries(
+      fields.map((field) => {
+        let fieldSchema: z.ZodTypeAny;
+
+        switch (field.type) {
+          case "NUMBER":
+            fieldSchema = z.coerce.number().nullable().optional();
+            break;
+          case "DATE":
+            fieldSchema = z.string().nullable().optional();
+            break;
+          case "MULTISELECT":
+            fieldSchema = z.array(z.string()).nullable().optional();
+            break;
+          case "EMAIL":
+            fieldSchema = z
+              .string()
+              .email()
+              .nullable()
+              .optional()
+              .or(z.literal(""));
+            break;
+          case "BOOLEAN":
+            fieldSchema = z.boolean().nullable().optional();
+            break;
+          default:
+            fieldSchema = z.string().nullable().optional();
+        }
+
+        if (field.required) {
+          if (field.type === "NUMBER") {
+            fieldSchema = z.coerce.number({
+              message: `${field.label}必须是数字`,
+            });
+          } else if (field.type === "MULTISELECT") {
+            fieldSchema = z
+              .array(z.string())
+              .min(1, { message: `${field.label}至少选择一项` });
+          } else {
+            fieldSchema = z.string().min(1, {
+              message: `${field.label}不能为空`,
+            });
+          }
+        }
+
+        return [field.key, fieldSchema];
+      })
+    )
+  );
+}
+
+export function PublicFormRenderer({ config, token }: PublicFormRendererProps) {
+  const [submitted, setSubmitted] = useState(false);
+  const [submitError, setSubmitError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const schema = buildSchema(config.fields);
+  const defaultValues = Object.fromEntries(
+    config.fields.map((f) => [f.key, null])
+  );
+
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors },
+  } = useForm({
+    resolver: zodResolver(schema),
+    defaultValues,
+  });
+
+  const onSubmit = async (data: Record<string, unknown>) => {
+    setSubmitError("");
+    setIsSubmitting(true);
+
+    // Clean null/empty values
+    const cleaned = Object.fromEntries(
+      Object.entries(data).map(([k, v]) => [k, v === "" ? null : v])
+    );
+
+    try {
+      const res = await fetch(`/api/public/form/${token}/submit`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ data: cleaned }),
+      });
+
+      const result = await res.json();
+
+      if (result.success) {
+        setSubmitted(true);
+      } else {
+        setSubmitError(
+          result.error?.message || "提交失败，请稍后重试"
+        );
+      }
+    } catch {
+      setSubmitError("网络错误，请稍后重试");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (submitted) {
+    return (
+      <div className="text-center py-16">
+        <div className="inline-flex items-center justify-center size-16 rounded-full bg-green-100 text-green-600 mb-4">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="32"
+            height="32"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M20 6 9 17l-5-5" />
+          </svg>
+        </div>
+        <h2 className="text-xl font-semibold">
+          {config.successMessage || "提交成功！"}
+        </h2>
+        {config.allowMultipleSubmissions && (
+          <Button
+            variant="outline"
+            className="mt-6"
+            onClick={() => {
+              setSubmitted(false);
+            }}
+          >
+            再次填写
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+      {config.layout.groups.map((group) => {
+        const groupFields = group.fieldKeys
+          .map((key) => config.fields.find((f) => f.key === key))
+          .filter(Boolean) as PublicFormConfig["fields"];
+
+        if (groupFields.length === 0) return null;
+
+        return (
+          <div key={group.id}>
+            {group.title && (
+              <h3 className="text-sm font-medium mb-3">{group.title}</h3>
+            )}
+            <div className="space-y-4">
+              {groupFields.map((field) => (
+                <div key={field.key} className="grid gap-1.5">
+                  <Label className="text-sm flex items-center gap-1">
+                    {field.label}
+                    {field.required && (
+                      <span className="text-destructive">*</span>
+                    )}
+                  </Label>
+                  <PublicFormField
+                    field={field}
+                    register={register}
+                    setValue={setValue}
+                    watch={watch}
+                  />
+                  {errors[field.key] && (
+                    <p className="text-sm text-destructive">
+                      {String(errors[field.key]?.message ?? "")}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+      })}
+
+      {submitError && (
+        <div className="p-3 text-sm text-destructive bg-destructive/10 rounded-md">
+          {submitError}
+        </div>
+      )}
+
+      <Button
+        type="submit"
+        className="w-full"
+        disabled={isSubmitting}
+      >
+        {isSubmitting ? (
+          <>
+            <Loader2 className="size-4 mr-2 animate-spin" />
+            提交中...
+          </>
+        ) : (
+          config.submitButtonText || "提交"
+        )}
+      </Button>
+    </form>
+  );
+}
+
+function PublicFormField({
+  field,
+  register,
+  setValue,
+  watch,
+}: {
+  field: PublicFormConfig["fields"][number];
+  register: ReturnType<typeof useForm>["register"];
+  setValue: ReturnType<typeof useForm>["setValue"];
+  watch: ReturnType<typeof useForm>["watch"];
+}) {
+  switch (field.type) {
+    case "NUMBER":
+      return (
+        <Input
+          type="number"
+          step="any"
+          {...register(field.key, {
+            setValueAs: (v: string) => (v === "" ? null : Number(v)),
+          })}
+          placeholder={`输入${field.label}`}
+        />
+      );
+
+    case "DATE":
+      return <Input type="date" {...register(field.key)} />;
+
+    case "SELECT": {
+      const selectOpts = parseSelectOptions(field.options);
+      return (
+        <Select
+          value={String(watch(field.key) ?? "")}
+          onValueChange={(v) => setValue(field.key, v || null)}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder={`选择${field.label}`} />
+          </SelectTrigger>
+          <SelectContent>
+            {selectOpts.map((option) => (
+              <SelectItem key={option.label} value={option.label}>
+                <span className="flex items-center gap-2">
+                  <span
+                    className="w-3 h-3 rounded-full shrink-0"
+                    style={{ backgroundColor: option.color }}
+                  />
+                  {option.label}
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      );
+    }
+
+    case "MULTISELECT":
+      return (
+        <Input
+          {...register(field.key)}
+          placeholder="多个值用逗号分隔"
+        />
+      );
+
+    case "EMAIL":
+      return (
+        <Input
+          type="email"
+          {...register(field.key)}
+          placeholder="email@example.com"
+        />
+      );
+
+    case "PHONE":
+      return (
+        <Input
+          type="tel"
+          {...register(field.key)}
+          placeholder="输入电话"
+        />
+      );
+
+    case "URL":
+      return (
+        <Input
+          type="url"
+          {...register(field.key)}
+          placeholder="https://"
+        />
+      );
+
+    case "BOOLEAN":
+      return (
+        <div className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            id={field.key}
+            checked={!!watch(field.key)}
+            onChange={(e) => setValue(field.key, e.target.checked)}
+            className="h-4 w-4 rounded"
+          />
+          <label htmlFor={field.key} className="text-sm text-muted-foreground">
+            {watch(field.key) ? "是" : "否"}
+          </label>
+        </div>
+      );
+
+    case "FILE":
+      return <Input {...register(field.key)} placeholder="文件路径" />;
+
+    default:
+      return (
+        <Input
+          {...register(field.key)}
+          placeholder={`输入${field.label}`}
+        />
+      );
+  }
+}

--- a/src/components/public/public-form-renderer.tsx
+++ b/src/components/public/public-form-renderer.tsx
@@ -27,47 +27,39 @@ function buildSchema(fields: PublicFormConfig["fields"]) {
   return z.object(
     Object.fromEntries(
       fields.map((field) => {
+        const label = field.label;
         let fieldSchema: z.ZodTypeAny;
 
         switch (field.type) {
           case "NUMBER":
-            fieldSchema = z.coerce.number().nullable().optional();
+            fieldSchema = field.required
+              ? z.coerce.number({ message: `${label}必须是数字` })
+              : z.coerce.number().nullable().optional();
             break;
           case "DATE":
-            fieldSchema = z.string().nullable().optional();
+            fieldSchema = field.required
+              ? z.string().min(1, { message: `${label}不能为空` })
+              : z.string().nullable().optional();
             break;
           case "MULTISELECT":
-            fieldSchema = z.array(z.string()).nullable().optional();
+            fieldSchema = field.required
+              ? z.array(z.string()).min(1, { message: `${label}至少选择一项` })
+              : z.array(z.string()).nullable().optional();
             break;
           case "EMAIL":
-            fieldSchema = z
-              .string()
-              .email()
-              .nullable()
-              .optional()
-              .or(z.literal(""));
+            fieldSchema = field.required
+              ? z.string().min(1, { message: `${label}不能为空` }).email({ message: `${label}格式不正确` })
+              : z.string().email().nullable().optional().or(z.literal(""));
             break;
           case "BOOLEAN":
-            fieldSchema = z.boolean().nullable().optional();
+            fieldSchema = field.required
+              ? z.boolean().refine((v) => v === true, { message: `${label}必须勾选` })
+              : z.boolean().nullable().optional();
             break;
           default:
-            fieldSchema = z.string().nullable().optional();
-        }
-
-        if (field.required) {
-          if (field.type === "NUMBER") {
-            fieldSchema = z.coerce.number({
-              message: `${field.label}必须是数字`,
-            });
-          } else if (field.type === "MULTISELECT") {
-            fieldSchema = z
-              .array(z.string())
-              .min(1, { message: `${field.label}至少选择一项` });
-          } else {
-            fieldSchema = z.string().min(1, {
-              message: `${field.label}不能为空`,
-            });
-          }
+            fieldSchema = field.required
+              ? z.string().min(1, { message: `${label}不能为空` })
+              : z.string().nullable().optional();
         }
 
         return [field.key, fieldSchema];
@@ -83,7 +75,10 @@ export function PublicFormRenderer({ config, token }: PublicFormRendererProps) {
 
   const schema = buildSchema(config.fields);
   const defaultValues = Object.fromEntries(
-    config.fields.map((f) => [f.key, null])
+    config.fields.map((f) => [
+      f.key,
+      f.type === "MULTISELECT" ? [] : f.type === "BOOLEAN" ? false : null,
+    ])
   );
 
   const {
@@ -284,13 +279,49 @@ function PublicFormField({
       );
     }
 
-    case "MULTISELECT":
+    case "MULTISELECT": {
+      const multiOpts = parseSelectOptions(field.options);
+      const currentValues: string[] = Array.isArray(watch(field.key))
+        ? watch(field.key)
+        : [];
       return (
-        <Input
-          {...register(field.key)}
-          placeholder="多个值用逗号分隔"
-        />
+        <div className="flex flex-wrap gap-2">
+          {multiOpts.map((option) => {
+            const checked = currentValues.includes(option.label);
+            return (
+              <label
+                key={option.label}
+                className="flex items-center gap-1.5 cursor-pointer text-sm"
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={() => {
+                    const next = checked
+                      ? currentValues.filter((v) => v !== option.label)
+                      : [...currentValues, option.label];
+                    setValue(field.key, next);
+                  }}
+                  className="h-4 w-4 rounded"
+                />
+                <span
+                  className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs"
+                  style={{
+                    backgroundColor: option.color,
+                    color: "var(--fg, inherit)",
+                  }}
+                >
+                  {option.label}
+                </span>
+              </label>
+            );
+          })}
+          {multiOpts.length === 0 && (
+            <span className="text-sm text-muted-foreground">无选项</span>
+          )}
+        </div>
       );
+    }
 
     case "EMAIL":
       return (

--- a/src/hooks/use-table-data.ts
+++ b/src/hooks/use-table-data.ts
@@ -162,17 +162,6 @@ export function useTableData({
     [debouncedSyncSearch]
   );
 
-  const switchView = useCallback(
-    (nextViewId: string | null) => {
-      latestFetchIdRef.current += 1;
-      setIsViewConfigReady(nextViewId === null);
-      setIsLoading(true);
-      setViewId(nextViewId);
-      syncUrlQuery({ viewId: nextViewId }, "push");
-    },
-    [syncUrlQuery]
-  );
-
   const refreshViews = useCallback(async () => {
     try {
       const response = await fetch(`/api/data-tables/${tableId}/views`);
@@ -189,6 +178,21 @@ export function useTableData({
       // 视图列表加载失败时沿用已有状态
     }
   }, [tableId]);
+
+  const switchView = useCallback(
+    (nextViewId: string | null) => {
+      latestFetchIdRef.current += 1;
+      setIsViewConfigReady(nextViewId === null);
+      setIsLoading(true);
+      setViewId(nextViewId);
+      syncUrlQuery({ viewId: nextViewId }, "push");
+      // Refresh views list to ensure newly saved views are available
+      if (nextViewId) {
+        void refreshViews();
+      }
+    },
+    [syncUrlQuery, refreshViews]
+  );
 
   const refresh = useCallback(() => {
     setRefreshTick((value) => value + 1);

--- a/src/lib/services/form-share.service.ts
+++ b/src/lib/services/form-share.service.ts
@@ -245,7 +245,16 @@ export async function submitPublicForm(
   const config = configResult.data;
   const userId = await getSystemUserId();
 
-  const result = await createRecord(userId, config.tableId, data, {
+  // Only allow keys that are declared in the public form fields
+  const allowedKeys = new Set(config.fields.map((f) => f.key));
+  const filteredData: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (allowedKeys.has(key)) {
+      filteredData[key] = value;
+    }
+  }
+
+  const result = await createRecord(userId, config.tableId, filteredData, {
     skipRequiredValidation: false,
   });
 

--- a/src/lib/services/form-share.service.ts
+++ b/src/lib/services/form-share.service.ts
@@ -1,6 +1,6 @@
 import { db } from "@/lib/db";
 import { createRecord } from "./data-record.service";
-import { getTable } from "./data-table.service";
+import { logAudit } from "./audit-log.service";
 import type { FormShareTokenItem, FormViewOptions, ServiceResult } from "@/types/data-table";
 
 // Fields not shown on public forms
@@ -21,6 +21,7 @@ function mapTokenItem(row: {
   isActive: boolean;
   createdAt: Date;
   expiresAt: Date | null;
+  submissionCount: number;
 }): FormShareTokenItem {
   return {
     id: row.id,
@@ -30,6 +31,7 @@ function mapTokenItem(row: {
     isActive: row.isActive,
     createdAt: row.createdAt.toISOString(),
     expiresAt: row.expiresAt?.toISOString() ?? null,
+    submissionCount: row.submissionCount,
   };
 }
 
@@ -38,6 +40,7 @@ function mapTokenItem(row: {
 export async function createShareToken(
   viewId: string,
   userId: string,
+  userName?: string | null,
   options?: { label?: string; expiresAt?: string }
 ): Promise<ServiceResult<FormShareTokenItem>> {
   const token = await db.formShareToken.create({
@@ -48,6 +51,18 @@ export async function createShareToken(
       expiresAt: options?.expiresAt ? new Date(options.expiresAt) : null,
     },
   });
+
+  // Audit log
+  await logAudit({
+    userId,
+    userName,
+    action: "FORM_SHARE_CREATE",
+    targetType: "FormShareToken",
+    targetId: token.id,
+    targetName: options?.label ?? null,
+    detail: { viewId, token: token.token, expiresAt: options?.expiresAt ?? null },
+  });
+
   return { success: true, data: mapTokenItem(token) };
 }
 
@@ -80,7 +95,8 @@ export async function revokeShareToken(
 
 export async function deleteShareToken(
   tokenId: string,
-  userId: string
+  userId: string,
+  userName?: string | null
 ): Promise<ServiceResult<{ id: string }>> {
   const token = await db.formShareToken.findFirst({
     where: { id: tokenId, createdById: userId },
@@ -88,7 +104,20 @@ export async function deleteShareToken(
   if (!token) {
     return { success: false, error: { code: "NOT_FOUND", message: "分享链接不存在" } };
   }
+
   await db.formShareToken.delete({ where: { id: tokenId } });
+
+  // Audit log
+  await logAudit({
+    userId,
+    userName,
+    action: "FORM_SHARE_DELETE",
+    targetType: "FormShareToken",
+    targetId: tokenId,
+    targetName: token.label ?? null,
+    detail: { viewId: token.viewId, token: token.token },
+  });
+
   return { success: true, data: { id: tokenId } };
 }
 
@@ -197,6 +226,19 @@ export async function submitPublicForm(
   token: string,
   data: Record<string, unknown>
 ): Promise<ServiceResult<{ message: string }>> {
+  // First validate the token and get shareToken record
+  const shareToken = await db.formShareToken.findUnique({
+    where: { token },
+  });
+
+  if (!shareToken || !shareToken.isActive) {
+    return { success: false, error: { code: "NOT_FOUND", message: "表单链接无效或已失效" } };
+  }
+
+  if (shareToken.expiresAt && shareToken.expiresAt < new Date()) {
+    return { success: false, error: { code: "EXPIRED", message: "表单链接已过期" } };
+  }
+
   const configResult = await resolvePublicForm(token);
   if (!configResult.success) return configResult as ServiceResult<{ message: string }>;
 
@@ -213,6 +255,22 @@ export async function submitPublicForm(
       error: { code: "SUBMIT_FAILED", message: result.error.message },
     };
   }
+
+  // Increment submission count
+  await db.formShareToken.update({
+    where: { id: shareToken.id },
+    data: { submissionCount: { increment: 1 } },
+  });
+
+  // Audit log for form submission
+  await logAudit({
+    userId,
+    action: "FORM_SUBMIT",
+    targetType: "FormShareToken",
+    targetId: shareToken.id,
+    targetName: shareToken.label ?? null,
+    detail: { token: shareToken.token, viewId: shareToken.viewId, tableId: config.tableId },
+  });
 
   return {
     success: true,

--- a/src/lib/services/form-share.service.ts
+++ b/src/lib/services/form-share.service.ts
@@ -1,0 +1,221 @@
+import { db } from "@/lib/db";
+import { createRecord } from "./data-record.service";
+import { getTable } from "./data-table.service";
+import type { FormShareTokenItem, FormViewOptions, ServiceResult } from "@/types/data-table";
+
+// Fields not shown on public forms
+const EXCLUDED_PUBLIC_FIELD_TYPES = new Set([
+  "RELATION",
+  "RELATION_SUBTABLE",
+  "SYSTEM_TIMESTAMP",
+  "SYSTEM_USER",
+  "AUTO_NUMBER",
+  "FORMULA",
+]);
+
+function mapTokenItem(row: {
+  id: string;
+  token: string;
+  viewId: string;
+  label: string | null;
+  isActive: boolean;
+  createdAt: Date;
+  expiresAt: Date | null;
+}): FormShareTokenItem {
+  return {
+    id: row.id,
+    token: row.token,
+    viewId: row.viewId,
+    label: row.label,
+    isActive: row.isActive,
+    createdAt: row.createdAt.toISOString(),
+    expiresAt: row.expiresAt?.toISOString() ?? null,
+  };
+}
+
+// ── Share Token CRUD ──
+
+export async function createShareToken(
+  viewId: string,
+  userId: string,
+  options?: { label?: string; expiresAt?: string }
+): Promise<ServiceResult<FormShareTokenItem>> {
+  const token = await db.formShareToken.create({
+    data: {
+      viewId,
+      createdById: userId,
+      label: options?.label ?? null,
+      expiresAt: options?.expiresAt ? new Date(options.expiresAt) : null,
+    },
+  });
+  return { success: true, data: mapTokenItem(token) };
+}
+
+export async function listShareTokens(
+  viewId: string
+): Promise<ServiceResult<FormShareTokenItem[]>> {
+  const tokens = await db.formShareToken.findMany({
+    where: { viewId },
+    orderBy: { createdAt: "desc" },
+  });
+  return { success: true, data: tokens.map(mapTokenItem) };
+}
+
+export async function revokeShareToken(
+  tokenId: string,
+  userId: string
+): Promise<ServiceResult<{ id: string }>> {
+  const token = await db.formShareToken.findFirst({
+    where: { id: tokenId, createdById: userId },
+  });
+  if (!token) {
+    return { success: false, error: { code: "NOT_FOUND", message: "分享链接不存在" } };
+  }
+  await db.formShareToken.update({
+    where: { id: tokenId },
+    data: { isActive: false },
+  });
+  return { success: true, data: { id: tokenId } };
+}
+
+export async function deleteShareToken(
+  tokenId: string,
+  userId: string
+): Promise<ServiceResult<{ id: string }>> {
+  const token = await db.formShareToken.findFirst({
+    where: { id: tokenId, createdById: userId },
+  });
+  if (!token) {
+    return { success: false, error: { code: "NOT_FOUND", message: "分享链接不存在" } };
+  }
+  await db.formShareToken.delete({ where: { id: tokenId } });
+  return { success: true, data: { id: tokenId } };
+}
+
+// ── Public Form: Resolve & Submit ──
+
+export interface PublicFormConfig {
+  formTitle: string;
+  formDescription: string;
+  submitButtonText: string;
+  successMessage: string;
+  allowMultipleSubmissions: boolean;
+  tableId: string;
+  tableName: string;
+  fields: Array<{
+    key: string;
+    label: string;
+    type: string;
+    required: boolean;
+    options?: unknown;
+    description?: string;
+  }>;
+  layout: FormViewOptions["layout"];
+}
+
+export async function resolvePublicForm(
+  token: string
+): Promise<ServiceResult<PublicFormConfig>> {
+  const shareToken = await db.formShareToken.findUnique({
+    where: { token },
+    include: {
+      view: {
+        include: {
+          table: {
+            include: { fields: { orderBy: { sortOrder: "asc" } } },
+          },
+        },
+      },
+    },
+  });
+
+  if (!shareToken || !shareToken.isActive) {
+    return { success: false, error: { code: "NOT_FOUND", message: "表单链接无效或已失效" } };
+  }
+
+  if (shareToken.expiresAt && shareToken.expiresAt < new Date()) {
+    return { success: false, error: { code: "EXPIRED", message: "表单链接已过期" } };
+  }
+
+  const view = shareToken.view;
+  const table = view.table;
+  const opts = (view.viewOptions ?? {}) as Partial<FormViewOptions>;
+
+  // Filter out fields not suitable for public forms
+  const publicFields = table.fields.filter(
+    (f) => !EXCLUDED_PUBLIC_FIELD_TYPES.has(f.type)
+  );
+
+  const defaultLayout: FormViewOptions["layout"] = {
+    version: 1,
+    groups: [
+      {
+        id: "default",
+        title: "",
+        fieldKeys: publicFields.map((f) => f.key),
+      },
+    ],
+  };
+
+  return {
+    success: true,
+    data: {
+      formTitle: opts.formTitle ?? table.name,
+      formDescription: opts.formDescription ?? "",
+      submitButtonText: opts.submitButtonText ?? "提交",
+      successMessage: opts.successMessage ?? "提交成功！",
+      allowMultipleSubmissions: opts.allowMultipleSubmissions ?? false,
+      tableId: table.id,
+      tableName: table.name,
+      fields: publicFields.map((f) => ({
+        key: f.key,
+        label: f.label,
+        type: f.type,
+        required: f.required,
+        options: f.options,
+      })),
+      layout: opts.layout ?? defaultLayout,
+    },
+  };
+}
+
+// System user for public form submissions
+let _systemUserId: string | null = null;
+
+async function getSystemUserId(): Promise<string> {
+  if (_systemUserId) return _systemUserId;
+  const admin = await db.user.findFirst({
+    where: { role: "ADMIN" },
+    select: { id: true },
+  });
+  if (!admin) throw new Error("No admin user found for public form submission");
+  _systemUserId = admin.id;
+  return _systemUserId;
+}
+
+export async function submitPublicForm(
+  token: string,
+  data: Record<string, unknown>
+): Promise<ServiceResult<{ message: string }>> {
+  const configResult = await resolvePublicForm(token);
+  if (!configResult.success) return configResult as ServiceResult<{ message: string }>;
+
+  const config = configResult.data;
+  const userId = await getSystemUserId();
+
+  const result = await createRecord(userId, config.tableId, data, {
+    skipRequiredValidation: false,
+  });
+
+  if (!result.success) {
+    return {
+      success: false,
+      error: { code: "SUBMIT_FAILED", message: result.error.message },
+    };
+  }
+
+  return {
+    success: true,
+    data: { message: config.successMessage },
+  };
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -19,6 +19,11 @@ export async function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
+  // Allow public form routes
+  if (pathname.startsWith("/api/public/") || pathname.startsWith("/f/")) {
+    return NextResponse.next();
+  }
+
   const token = await getToken({
     req: request,
     secret: process.env.NEXTAUTH_SECRET,
@@ -35,6 +40,6 @@ export async function proxy(request: NextRequest) {
 
 export const config = {
   matcher: [
-    "/((?!_next/|api/auth/|api/v1/|login$|favicon.ico|sitemap.xml|robots.txt).*)",
+    "/((?!_next/|api/auth/|api/v1/|api/public/|f/|login$|favicon.ico|sitemap.xml|robots.txt).*)",
   ],
 };

--- a/src/types/data-table.ts
+++ b/src/types/data-table.ts
@@ -330,4 +330,6 @@ export interface FormShareTokenItem {
   isActive: boolean;
   createdAt: string;
   expiresAt: string | null;
+  submissionCount: number;
+  url?: string;
 }

--- a/src/types/data-table.ts
+++ b/src/types/data-table.ts
@@ -301,3 +301,33 @@ export interface DataViewItem {
   createdAt: Date;
   updatedAt: Date;
 }
+
+// ========== Form View Types ==========
+
+export interface FormFieldGroup {
+  id: string;
+  title: string;
+  fieldKeys: string[];
+}
+
+export interface FormViewOptions {
+  formTitle: string;
+  formDescription: string;
+  submitButtonText: string;
+  successMessage: string;
+  allowMultipleSubmissions: boolean;
+  layout: {
+    version: 1;
+    groups: FormFieldGroup[];
+  };
+}
+
+export interface FormShareTokenItem {
+  id: string;
+  token: string;
+  viewId: string;
+  label: string | null;
+  isActive: boolean;
+  createdAt: string;
+  expiresAt: string | null;
+}

--- a/src/validators/data-table.ts
+++ b/src/validators/data-table.ts
@@ -124,7 +124,7 @@ export type JsonImportOptionsInput = z.infer<typeof jsonImportOptionsSchema>;
 
 // ========== View Schemas ==========
 
-export const viewTypeNameSchema = z.enum(["GRID", "KANBAN", "GALLERY", "TIMELINE"]);
+export const viewTypeNameSchema = z.enum(["GRID", "KANBAN", "GALLERY", "TIMELINE", "FORM"]);
 
 export const patchFieldSchema = z.object({
   fieldKey: z.string().regex(/^[a-z][a-z0-9_]*$/),


### PR DESCRIPTION
## Summary

- 新增 Form 表单视图类型，支持将数据表转为可分享的填报表单（类似 Airtable Form View）
- 表单编辑器：拖拽排序字段、字段分组、自定义标题/描述/提交按钮/成功提示
- 表单预览模式
- 公开分享链接管理：创建/删除链接、标签备注、过期时间、提交统计
- 公开表单页面（无需认证）：表单提交自动创建数据记录
- 视图类型切换器：表格/看板/画廊/时间线/表单
- 审计日志：FORM_SHARE_CREATE、FORM_SHARE_DELETE、FORM_SUBMIT

## Test plan

- [x] 创建 Form 视图并编辑字段布局
- [x] 预览表单
- [x] 创建分享链接（带标签和过期时间）
- [x] 从列表打开公开表单
- [x] 公开表单提交创建记录
- [x] 提交次数统计自增
- [x] 审计日志记录分享创建/删除和表单提交
- [x] 切换视图后正确恢复表单视图类型

Closes #79