### PR TITLE
[Feature] 公式编辑器增强

### DIFF
--- a/src/components/data/field-config-form.tsx
+++ b/src/components/data/field-config-form.tsx
@@ -228,6 +228,32 @@ export function FieldConfigForm({
     return () => { cancelled = true; };
   }, [open, fieldType, tableId]);
 
+  // Reset all state when field prop changes (edit vs create)
+  useEffect(() => {
+    const opts = parseFieldOptions(field?.options);
+    setKey(field?.key ?? "");
+    setLabel(field?.label ?? "");
+    setFieldType(field?.type ?? FieldType.TEXT);
+    setRequired(field?.required ?? false);
+    setDefaultValue(field?.defaultValue ?? "");
+    setSelectOptions(parseSelectOptions(field?.options));
+    setSelectedTableId(field?.relationTo ?? "");
+    setSelectedDisplayField(field?.displayField ?? "");
+    setRelationCardinality(field?.relationCardinality ?? "SINGLE");
+    setInverseRelationCardinality(
+      field?.inverseRelationCardinality ??
+        (field?.relationCardinality === "MULTIPLE" ? "MULTIPLE" : "SINGLE")
+    );
+    setRelationSchemaFields(buildRelationSchemaDraft(field?.relationSchema?.fields));
+    const relTable = field?.relationTo
+      ? availableTables.find((t) => t.id === field.relationTo)
+      : undefined;
+    setRelationFields(relTable?.fields ?? []);
+    setFormulaExpression(opts.formula ?? "");
+    setSystemFieldKind(opts.kind ?? "created");
+    setError("");
+  }, [field, availableTables]);
+
   const formulaPreview = useMemo(() => {
     const expr = formulaExpression.trim();
     if (!expr || formulaError || !sampleData) return undefined;

--- a/src/components/data/field-config-form.tsx
+++ b/src/components/data/field-config-form.tsx
@@ -31,11 +31,15 @@ import type {
 import { parseSelectOptions, SELECT_COLORS } from "@/types/data-table";
 import { parseFieldOptions } from "@/types/data-table";
 import type { DataFieldInput } from "@/validators/data-table";
+import { FormulaEditor } from "@/components/data/formula-editor";
+import { parseFormula, evaluateFormula, detectCircularRefs } from "@/lib/formula";
 
 interface FieldConfigFormProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   field?: DataFieldItem | null;
+  fields?: DataFieldItem[];
+  tableId?: string;
   availableTables: { id: string; name: string; fields: DataFieldItem[] }[];
   existingFieldKeys?: string[];
   onSubmit: (data: DataFieldInput) => void;
@@ -142,6 +146,8 @@ export function FieldConfigForm({
   open,
   onOpenChange,
   field,
+  fields: allFields = [],
+  tableId,
   availableTables,
   existingFieldKeys = [],
   onSubmit,
@@ -178,6 +184,59 @@ export function FieldConfigForm({
     const opts = parseFieldOptions(field?.options);
     return opts.formula ?? "";
   });
+
+  // Formula validation
+  const formulaError = useMemo(() => {
+    const expr = formulaExpression.trim();
+    if (!expr) return null;
+    try {
+      parseFormula(expr);
+    } catch (e) {
+      return e instanceof Error ? e.message : "公式语法错误";
+    }
+    // Circular reference check
+    if (allFields.length > 0 && field?.key) {
+      const formulaMap: Record<string, string> = {};
+      for (const f of allFields) {
+        if (f.type === "FORMULA") {
+          const opts = parseFieldOptions(f.options);
+          if (opts.formula) formulaMap[f.key] = opts.formula;
+        }
+      }
+      formulaMap[field.key] = expr;
+      const cycle = detectCircularRefs(formulaMap);
+      if (cycle) return cycle;
+    }
+    return null;
+  }, [formulaExpression, allFields, field?.key]);
+
+  // Live preview: fetch sample record once when form opens
+  const [sampleData, setSampleData] = useState<Record<string, unknown> | null>(null);
+
+  useEffect(() => {
+    if (!open || fieldType !== FieldType.FORMULA || !tableId) return;
+    let cancelled = false;
+    fetch(`/api/data-tables/${tableId}/records?pageSize=1`)
+      .then((res) => res.json())
+      .then((result) => {
+        if (cancelled) return;
+        if (result.records?.[0]?.data) {
+          setSampleData(result.records[0].data);
+        }
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [open, fieldType, tableId]);
+
+  const formulaPreview = useMemo(() => {
+    const expr = formulaExpression.trim();
+    if (!expr || formulaError || !sampleData) return undefined;
+    try {
+      return evaluateFormula(expr, sampleData);
+    } catch {
+      return undefined;
+    }
+  }, [formulaExpression, formulaError, sampleData]);
   const [systemFieldKind, setSystemFieldKind] = useState<"created" | "updated">(() => {
     const opts = parseFieldOptions(field?.options);
     return opts.kind ?? "created";
@@ -514,18 +573,14 @@ export function FieldConfigForm({
 
             {fieldType === FieldType.FORMULA && (
               <div className="grid gap-2">
-                <Label htmlFor="formula">公式表达式</Label>
-                <Textarea
-                  id="formula"
-                  placeholder="例如：price * quantity&#10;支持：+ - * / () 及函数 SUM, AVG, MIN, MAX, IF 等"
-                  value={formulaExpression}
-                  onChange={(event) => setFormulaExpression(event.target.value)}
-                  rows={4}
-                  className="font-mono text-sm"
+                <Label>公式表达式</Label>
+                <FormulaEditor
+                  initialValue={formulaExpression}
+                  fields={allFields}
+                  onChange={setFormulaExpression}
+                  error={formulaError}
+                  livePreview={formulaPreview}
                 />
-                <p className="text-xs text-zinc-500">
-                  使用其他字段标识作为变量，例如 <code className="bg-muted px-1 rounded">price * quantity</code>
-                </p>
               </div>
             )}
 

--- a/src/components/data/field-config-list.tsx
+++ b/src/components/data/field-config-list.tsx
@@ -386,6 +386,8 @@ export function FieldConfigList({
           if (!open) setEditingField(null);
         }}
         field={editingField}
+        fields={fields}
+        tableId={tableId}
         availableTables={tablesWithFields}
         existingFieldKeys={fields.map((f) => f.key)}
         onSubmit={editingField ? handleEditField : handleAddField}

--- a/src/components/data/formula-editor.tsx
+++ b/src/components/data/formula-editor.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useRef, useState, useCallback } from "react";
-import { Input } from "@/components/ui/input";
+import { useRef, useState, useCallback, useMemo } from "react";
+import { Textarea } from "@/components/ui/textarea";
 import type { DataFieldItem } from "@/types/data-table";
+import { ALL_FUNCTIONS, FUNCTION_CATALOG } from "@/lib/formula/function-catalog";
 
 interface FormulaEditorProps {
   initialValue: string;
@@ -20,52 +21,169 @@ export function FormulaEditor({
   livePreview,
 }: FormulaEditorProps) {
   const [draft, setDraft] = useState(initialValue);
-  const [showFieldPicker, setShowFieldPicker] = useState(false);
+  const [showPicker, setShowPicker] = useState(false);
   const [pickerFilter, setPickerFilter] = useState("");
-  const inputRef = useRef<HTMLInputElement>(null);
+  const [pickerMode, setPickerMode] = useState<"field" | "function">("field");
+  const [showRef, setShowRef] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  const editableFields = fields.filter(
-    (f) => f.type !== "FORMULA" && f.type !== "RELATION_SUBTABLE"
+  const editableFields = useMemo(
+    () => fields.filter((f) => f.type !== "FORMULA" && f.type !== "RELATION_SUBTABLE"),
+    [fields]
   );
 
-  const filteredFields = pickerFilter
-    ? editableFields.filter(
-        (f) =>
-          f.key.toLowerCase().includes(pickerFilter.toLowerCase()) ||
-          f.label.toLowerCase().includes(pickerFilter.toLowerCase())
-      )
-    : editableFields;
+  // Filtered items for the picker
+  const filteredFields = useMemo(() => {
+    if (!pickerFilter) return editableFields;
+    const q = pickerFilter.toLowerCase();
+    return editableFields.filter(
+      (f) => f.key.toLowerCase().includes(q) || f.label.toLowerCase().includes(q)
+    );
+  }, [editableFields, pickerFilter]);
+
+  const filteredFunctions = useMemo(() => {
+    if (!pickerFilter) return Array.from(ALL_FUNCTIONS.values());
+    const q = pickerFilter.toUpperCase();
+    return Array.from(ALL_FUNCTIONS.values()).filter((fn) =>
+      fn.name.startsWith(q)
+    );
+  }, [pickerFilter]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === "{") {
+      if (e.key === "{" ) {
         e.preventDefault();
-        setShowFieldPicker(true);
+        setPickerMode("field");
         setPickerFilter("");
+        setShowPicker(true);
       }
       if (e.key === "Escape") {
-        setShowFieldPicker(false);
+        setShowPicker(false);
       }
     },
     []
   );
 
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const value = e.target.value;
+      setDraft(value);
+      onChange(value);
+
+      // Detect function name being typed (uppercase letters before cursor)
+      const cursorPos = e.target.selectionStart ?? value.length;
+      const textBeforeCursor = value.slice(0, cursorPos);
+      const fnMatch = textBeforeCursor.match(/([A-Z][A-Z_]{1,})$/);
+      if (fnMatch) {
+        const matching = Array.from(ALL_FUNCTIONS.keys()).filter((name) =>
+          name.startsWith(fnMatch[1])
+        );
+        if (matching.length > 0 && fnMatch[1].length >= 2) {
+          setPickerMode("function");
+          setPickerFilter(fnMatch[1]);
+          setShowPicker(true);
+          return;
+        }
+      }
+
+      // If inside { }, switch to field mode
+      const lastOpenBrace = textBeforeCursor.lastIndexOf("{");
+      const lastCloseBrace = textBeforeCursor.lastIndexOf("}");
+      if (lastOpenBrace > lastCloseBrace) {
+        const innerText = textBeforeCursor.slice(lastOpenBrace + 1).trim();
+        setPickerMode("field");
+        setPickerFilter(innerText);
+        setShowPicker(true);
+      } else {
+        setShowPicker(false);
+      }
+    },
+    [onChange]
+  );
+
   const insertField = useCallback(
     (field: DataFieldItem) => {
-      const input = inputRef.current;
-      if (!input) return;
-      const cursorPos = input.selectionStart ?? draft.length;
-      const newDraft =
-        draft.slice(0, cursorPos) +
-        `{ ${field.key} }` +
-        draft.slice(cursorPos);
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+
+      const cursorPos = textarea.selectionStart ?? draft.length;
+      const textBeforeCursor = draft.slice(0, cursorPos);
+      const textAfterCursor = draft.slice(cursorPos);
+
+      // If inside { }, replace from the { to cursor
+      const lastOpenBrace = textBeforeCursor.lastIndexOf("{");
+      let newDraft: string;
+      let newPos: number;
+
+      if (lastOpenBrace >= 0) {
+        newDraft =
+          draft.slice(0, lastOpenBrace) +
+          `{ ${field.key} }` +
+          textAfterCursor;
+        newPos = lastOpenBrace + field.key.length + 4;
+      } else {
+        newDraft = draft.slice(0, cursorPos) + `{ ${field.key} }` + textAfterCursor;
+        newPos = cursorPos + field.key.length + 4;
+      }
+
       setDraft(newDraft);
       onChange(newDraft);
-      setShowFieldPicker(false);
-      const newPos = cursorPos + field.key.length + 4;
+      setShowPicker(false);
       setTimeout(() => {
-        input.setSelectionRange(newPos, newPos);
-        input.focus();
+        textarea.setSelectionRange(newPos, newPos);
+        textarea.focus();
+      }, 0);
+    },
+    [draft, onChange]
+  );
+
+  const insertFunction = useCallback(
+    (fn: { name: string }) => {
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+
+      const cursorPos = textarea.selectionStart ?? draft.length;
+      const textBeforeCursor = draft.slice(0, cursorPos);
+      const textAfterCursor = draft.slice(cursorPos);
+
+      // If typing a function name prefix, replace it
+      const fnMatch = textBeforeCursor.match(/([A-Z][A-Z_]{1,})$/);
+      let newDraft: string;
+      let newPos: number;
+
+      if (fnMatch) {
+        const start = cursorPos - fnMatch[1].length;
+        newDraft = draft.slice(0, start) + `${fn.name}()` + textAfterCursor;
+        newPos = start + fn.name.length + 1; // cursor between ()
+      } else {
+        newDraft = draft.slice(0, cursorPos) + `${fn.name}()` + textAfterCursor;
+        newPos = cursorPos + fn.name.length + 1;
+      }
+
+      setDraft(newDraft);
+      onChange(newDraft);
+      setShowPicker(false);
+      setTimeout(() => {
+        textarea.setSelectionRange(newPos, newPos);
+        textarea.focus();
+      }, 0);
+    },
+    [draft, onChange]
+  );
+
+  const insertFromRef = useCallback(
+    (fn: { name: string }) => {
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+      const cursorPos = textarea.selectionStart ?? draft.length;
+      const newDraft =
+        draft.slice(0, cursorPos) + `${fn.name}()` + draft.slice(cursorPos);
+      const newPos = cursorPos + fn.name.length + 1;
+      setDraft(newDraft);
+      onChange(newDraft);
+      setTimeout(() => {
+        textarea.setSelectionRange(newPos, newPos);
+        textarea.focus();
       }, 0);
     },
     [draft, onChange]
@@ -74,47 +192,115 @@ export function FormulaEditor({
   return (
     <div className="space-y-2">
       <div className="relative">
-        <Input
-          ref={inputRef}
+        <Textarea
+          ref={textareaRef}
           value={draft}
-          onChange={(e) => {
-            setDraft(e.target.value);
-            onChange(e.target.value);
-          }}
+          onChange={handleChange}
           onKeyDown={handleKeyDown}
-          placeholder='例: { price } * { quantity }'
-          className={`font-mono text-sm ${error ? "border-red-500" : ""}`}
+          placeholder='例: { price } * { quantity } 或 SUM(field1, field2)'
+          className={`font-mono text-sm min-h-[80px] ${error ? "border-red-500" : ""}`}
+          rows={3}
         />
-        {showFieldPicker && (
-          <div className="absolute z-50 top-full mt-1 w-64 max-h-48 overflow-auto border rounded-md bg-background shadow-md">
-            <div className="p-1">
-              <Input
-                placeholder="搜索字段..."
+
+        {/* Autocomplete picker */}
+        {showPicker && (
+          <div className="absolute z-50 top-full mt-1 w-72 max-h-52 overflow-auto border rounded-md bg-background shadow-lg">
+            <div className="p-1.5 border-b">
+              <input
+                placeholder={pickerMode === "field" ? "搜索字段..." : "搜索函数..."}
                 value={pickerFilter}
                 onChange={(e) => setPickerFilter(e.target.value)}
-                className="h-7 text-xs"
+                className="w-full h-6 text-xs bg-transparent outline-none"
                 autoFocus
               />
             </div>
-            {filteredFields.map((field) => (
-              <button
-                key={field.key}
-                className="w-full text-left px-3 py-1.5 text-sm hover:bg-muted/50 flex items-center gap-2"
-                onClick={() => insertField(field)}
-              >
-                <span className="font-mono text-xs text-muted-foreground">{field.key}</span>
-                <span>{field.label}</span>
-              </button>
-            ))}
+
+            {pickerMode === "field" ? (
+              filteredFields.length > 0 ? (
+                filteredFields.map((field) => (
+                  <button
+                    key={field.key}
+                    className="w-full text-left px-3 py-1.5 text-sm hover:bg-muted/50 flex items-center gap-2"
+                    onClick={() => insertField(field)}
+                  >
+                    <span className="font-mono text-xs text-muted-foreground">
+                      {field.key}
+                    </span>
+                    <span>{field.label}</span>
+                  </button>
+                ))
+              ) : (
+                <div className="px-3 py-2 text-xs text-muted-foreground">
+                  无匹配字段
+                </div>
+              )
+            ) : filteredFunctions.length > 0 ? (
+              filteredFunctions.map((fn) => (
+                <button
+                  key={fn.name}
+                  className="w-full text-left px-3 py-1.5 text-sm hover:bg-muted/50"
+                  onClick={() => insertFunction(fn)}
+                >
+                  <span className="font-mono font-medium">{fn.name}</span>
+                  <span className="text-xs text-muted-foreground ml-2">
+                    {fn.description}
+                  </span>
+                </button>
+              ))
+            ) : (
+              <div className="px-3 py-2 text-xs text-muted-foreground">
+                无匹配函数
+              </div>
+            )}
           </div>
         )}
       </div>
+
+      {/* Error */}
       {error && <p className="text-xs text-red-500">{error}</p>}
+
+      {/* Live preview */}
       {livePreview !== undefined && !error && (
         <p className="text-xs text-muted-foreground">
           预览结果: {String(livePreview)}
         </p>
       )}
+
+      {/* Function reference */}
+      <div className="rounded-md border">
+        <button
+          type="button"
+          className="w-full flex items-center justify-between px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted/30"
+          onClick={() => setShowRef(!showRef)}
+        >
+          <span>函数参考</span>
+          <span>{showRef ? "▴" : "▾"}</span>
+        </button>
+        {showRef && (
+          <div className="border-t px-3 py-2 max-h-48 overflow-y-auto">
+            <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+              {FUNCTION_CATALOG.map((cat) => (
+                <div key={cat.label}>
+                  <p className="font-medium text-muted-foreground mb-0.5">
+                    {cat.label}
+                  </p>
+                  {cat.functions.map((fn) => (
+                    <button
+                      key={fn.name}
+                      type="button"
+                      className="block font-mono text-muted-foreground hover:text-foreground truncate w-full text-left"
+                      title={`${fn.syntax} — ${fn.description}`}
+                      onClick={() => insertFromRef(fn)}
+                    >
+                      {fn.name}
+                    </button>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/lib/formula/function-catalog.ts
+++ b/src/lib/formula/function-catalog.ts
@@ -1,0 +1,69 @@
+export interface FunctionEntry {
+  name: string;
+  syntax: string;
+  description: string;
+}
+
+export interface FunctionCategory {
+  label: string;
+  functions: FunctionEntry[];
+}
+
+export const FUNCTION_CATALOG: FunctionCategory[] = [
+  {
+    label: "数学",
+    functions: [
+      { name: "SUM", syntax: "SUM(val1, val2, ...)", description: "求和" },
+      { name: "AVERAGE", syntax: "AVERAGE(val1, val2, ...)", description: "求平均值" },
+      { name: "MIN", syntax: "MIN(val1, val2, ...)", description: "最小值" },
+      { name: "MAX", syntax: "MAX(val1, val2, ...)", description: "最大值" },
+      { name: "ROUND", syntax: "ROUND(value, digits)", description: "四舍五入" },
+      { name: "ABS", syntax: "ABS(value)", description: "绝对值" },
+      { name: "CEILING", syntax: "CEILING(value)", description: "向上取整" },
+      { name: "FLOOR", syntax: "FLOOR(value)", description: "向下取整" },
+    ],
+  },
+  {
+    label: "逻辑",
+    functions: [
+      { name: "IF", syntax: "IF(condition, then, else)", description: "条件判断" },
+      { name: "AND", syntax: "AND(cond1, cond2, ...)", description: "全部为真" },
+      { name: "OR", syntax: "OR(cond1, cond2, ...)", description: "任一为真" },
+      { name: "NOT", syntax: "NOT(condition)", description: "取反" },
+    ],
+  },
+  {
+    label: "文本",
+    functions: [
+      { name: "CONCAT", syntax: "CONCAT(str1, str2, ...)", description: "连接字符串" },
+      { name: "LEN", syntax: "LEN(text)", description: "字符串长度" },
+      { name: "LEFT", syntax: "LEFT(text, count)", description: "取左侧字符" },
+      { name: "RIGHT", syntax: "RIGHT(text, count)", description: "取右侧字符" },
+      { name: "MID", syntax: "MID(text, start, len)", description: "取中间字符" },
+      { name: "UPPER", syntax: "UPPER(text)", description: "转大写" },
+      { name: "LOWER", syntax: "LOWER(text)", description: "转小写" },
+      { name: "TRIM", syntax: "TRIM(text)", description: "去除首尾空格" },
+    ],
+  },
+  {
+    label: "日期",
+    functions: [
+      { name: "NOW", syntax: "NOW()", description: "当前时间" },
+      { name: "YEAR", syntax: "YEAR(date)", description: "提取年份" },
+      { name: "MONTH", syntax: "MONTH(date)", description: "提取月份" },
+      { name: "DAY", syntax: "DAY(date)", description: "提取日期" },
+      { name: "DATE_DIFF", syntax: "DATE_DIFF(date1, date2, unit)", description: "日期差值" },
+    ],
+  },
+  {
+    label: "类型转换",
+    functions: [
+      { name: "NUMBER", syntax: "NUMBER(value)", description: "转为数字" },
+      { name: "TEXT", syntax: "TEXT(value)", description: "转为文本" },
+    ],
+  },
+];
+
+export const ALL_FUNCTIONS = new Map<string, FunctionEntry>(
+  FUNCTION_CATALOG.flatMap((cat) => cat.functions.map((fn) => [fn.name, fn]))
+);

--- a/src/lib/formula/index.ts
+++ b/src/lib/formula/index.ts
@@ -2,3 +2,4 @@ export { tokenize, type Token, type TokenType } from "./tokenizer";
 export { parseFormula, type AstNode, ParseError } from "./ast";
 export { evaluateFormula } from "./evaluator";
 export { extractFieldRefs, detectCircularRefs } from "./dependency-graph";
+export { FUNCTION_CATALOG, ALL_FUNCTIONS, type FunctionEntry, type FunctionCategory } from "./function-catalog";


### PR DESCRIPTION
## Summary

- 增强公式编辑器：统一自动补全（字段引用 + 函数名）、可折叠函数参考面板、语法校验、实时预览
- 新建函数目录常量（function-catalog.ts），26 个函数按 5 个类别分组
- 替换字段配置表单中的 Textarea 为增强版 FormulaEditor 组件

## Test plan

- [ ] 在字段配置中选择 FORMULA 类型，编辑器正确显示
- [ ] 按 `{` 触发字段补全，选择字段后正确插入 `{ field_key }`
- [ ] 输入大写函数名前缀（如 SU）触发函数补全
- [ ] 函数参考面板可折叠，点击函数名插入 `FUNCTION()` 模板
- [ ] 输入无效语法显示红色错误提示
- [ ] 有数据时显示实时预览结果
- [ ] 保存公式后表格中正确计算显示

Closes #76