### PR TITLE
[Feature] 公式编辑器函数说明增强与可扩展性

### DIFF
--- a/src/components/data/formula-editor.tsx
+++ b/src/components/data/formula-editor.tsx
@@ -3,7 +3,7 @@
 import { useRef, useState, useCallback, useMemo } from "react";
 import { Textarea } from "@/components/ui/textarea";
 import type { DataFieldItem } from "@/types/data-table";
-import { ALL_FUNCTIONS, FUNCTION_CATALOG } from "@/lib/formula/function-catalog";
+import { ALL_FUNCTIONS, FUNCTION_CATALOG, type FunctionEntry } from "@/lib/formula/function-catalog";
 
 interface FormulaEditorProps {
   initialValue: string;
@@ -12,6 +12,14 @@ interface FormulaEditorProps {
   error?: string | null;
   livePreview?: unknown;
 }
+
+const TYPE_LABELS: Record<string, string> = {
+  number: "数字",
+  string: "文本",
+  boolean: "布尔",
+  date: "日期",
+  any: "任意",
+};
 
 export function FormulaEditor({
   initialValue,
@@ -25,6 +33,7 @@ export function FormulaEditor({
   const [pickerFilter, setPickerFilter] = useState("");
   const [pickerMode, setPickerMode] = useState<"field" | "function">("field");
   const [showRef, setShowRef] = useState(false);
+  const [selectedFn, setSelectedFn] = useState<FunctionEntry | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const editableFields = useMemo(
@@ -204,7 +213,7 @@ export function FormulaEditor({
 
         {/* Autocomplete picker */}
         {showPicker && (
-          <div className="absolute z-50 top-full mt-1 w-72 max-h-52 overflow-auto border rounded-md bg-background shadow-lg">
+          <div className="absolute z-50 top-full mt-1 w-80 max-h-52 overflow-auto border rounded-md bg-background shadow-lg">
             <div className="p-1.5 border-b">
               <input
                 placeholder={pickerMode === "field" ? "搜索字段..." : "搜索函数..."}
@@ -241,8 +250,13 @@ export function FormulaEditor({
                   className="w-full text-left px-3 py-1.5 text-sm hover:bg-muted/50"
                   onClick={() => insertFunction(fn)}
                 >
-                  <span className="font-mono font-medium">{fn.name}</span>
-                  <span className="text-xs text-muted-foreground ml-2">
+                  <div className="flex items-baseline gap-1">
+                    <span className="font-mono font-medium">{fn.name}</span>
+                    <span className="text-xs text-muted-foreground truncate">
+                      {fn.syntax.replace(fn.name, "")}
+                    </span>
+                  </div>
+                  <span className="text-xs text-muted-foreground block">
                     {fn.description}
                   </span>
                 </button>
@@ -271,13 +285,16 @@ export function FormulaEditor({
         <button
           type="button"
           className="w-full flex items-center justify-between px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted/30"
-          onClick={() => setShowRef(!showRef)}
+          onClick={() => {
+            setShowRef(!showRef);
+            if (showRef) setSelectedFn(null);
+          }}
         >
           <span>函数参考</span>
           <span>{showRef ? "▴" : "▾"}</span>
         </button>
         {showRef && (
-          <div className="border-t px-3 py-2 max-h-48 overflow-y-auto">
+          <div className="border-t px-3 py-2 max-h-64 overflow-y-auto">
             <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
               {FUNCTION_CATALOG.map((cat) => (
                 <div key={cat.label}>
@@ -288,16 +305,70 @@ export function FormulaEditor({
                     <button
                       key={fn.name}
                       type="button"
-                      className="block font-mono text-muted-foreground hover:text-foreground truncate w-full text-left"
-                      title={`${fn.syntax} — ${fn.description}`}
-                      onClick={() => insertFromRef(fn)}
+                      className={`block w-full text-left rounded px-1 py-0.5 ${
+                        selectedFn?.name === fn.name
+                          ? "bg-muted font-medium text-foreground"
+                          : "text-muted-foreground hover:bg-muted/30 hover:text-foreground"
+                      }`}
+                      onClick={() =>
+                        setSelectedFn(selectedFn?.name === fn.name ? null : fn)
+                      }
                     >
-                      {fn.name}
+                      <span className="font-mono">{fn.name}</span>
+                      <span className="ml-1">{fn.description}</span>
                     </button>
                   ))}
                 </div>
               ))}
             </div>
+
+            {/* Detail panel */}
+            {selectedFn && (
+              <div className="mt-2 pt-2 border-t text-xs space-y-1.5">
+                <div className="flex items-center justify-between">
+                  <p className="font-mono font-medium text-sm">{selectedFn.syntax}</p>
+                  <button
+                    type="button"
+                    className="text-primary hover:underline shrink-0 ml-2"
+                    onClick={() => insertFromRef(selectedFn)}
+                  >
+                    插入
+                  </button>
+                </div>
+                <p className="text-muted-foreground">{selectedFn.description}</p>
+                {selectedFn.params.length > 0 && (
+                  <div>
+                    <p className="font-medium mb-0.5">参数:</p>
+                    <ul className="list-disc list-inside space-y-0.5 text-muted-foreground">
+                      {selectedFn.params.map((p) => (
+                        <li key={p.name}>
+                          <span className="font-mono text-foreground">{p.name}</span>
+                          <span className="ml-1">
+                            ({TYPE_LABELS[p.type]}{p.optional ? "，可选" : ""}{p.repeated ? "，可重复" : ""})
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                <p>
+                  返回: <span className="text-muted-foreground">{TYPE_LABELS[selectedFn.returnType]}</span>
+                </p>
+                {selectedFn.example && (
+                  <div>
+                    <p className="font-medium mb-0.5">示例:</p>
+                    <p className="font-mono bg-muted/30 rounded px-1.5 py-0.5">
+                      {selectedFn.example}
+                      {selectedFn.exampleResult && (
+                        <span className="text-muted-foreground ml-1">
+                          = {selectedFn.exampleResult}
+                        </span>
+                      )}
+                    </p>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/src/lib/formula/evaluator.test.ts
+++ b/src/lib/formula/evaluator.test.ts
@@ -63,4 +63,28 @@ describe("evaluateFormula", () => {
   it("should evaluate NOT", () => {
     expect(evaluateFormula("NOT({ active })", data)).toBe(false);
   });
+
+  describe("parameter validation", () => {
+    it("should error on SUM with no args", () => {
+      expect(evaluateFormula("SUM()", data)).toBe("#ERROR:SUM 至少需要 1 个参数");
+    });
+
+    it("should error on IF with one arg", () => {
+      expect(evaluateFormula("IF({ active })", data)).toBe("#ERROR:IF 至少需要 2 个参数");
+    });
+
+    it("should error on unknown function", () => {
+      expect(evaluateFormula("FAKE(1)", data)).toBe("#ERROR");
+    });
+
+    it("should allow optional args in ROUND", () => {
+      expect(evaluateFormula("ROUND(3.456)", data)).toBe(3);
+    });
+
+    it("should allow NOW with no args", () => {
+      const result = evaluateFormula("NOW()", data);
+      expect(typeof result).toBe("string");
+      expect(result).toContain("20");
+    });
+  });
 });

--- a/src/lib/formula/evaluator.ts
+++ b/src/lib/formula/evaluator.ts
@@ -1,4 +1,5 @@
 import { parseFormula, type AstNode } from "./ast";
+import { ALL_FUNCTIONS } from "./function-catalog";
 
 type FormulaValue = number | string | boolean | null;
 
@@ -76,6 +77,10 @@ function toString(v: FormulaValue): string {
 }
 
 function evaluateFunction(name: string, argNodes: AstNode[], data: Record<string, unknown>): FormulaValue {
+  const entry = ALL_FUNCTIONS.get(name);
+  if (entry && argNodes.length < entry.minArgs) {
+    return `#ERROR:${name} 至少需要 ${entry.minArgs} 个参数`;
+  }
   switch (name) {
     case "SUM": return argNodes.reduce((s, n) => s + toNumber(evaluateNode(n, data)), 0);
     case "AVERAGE": {
@@ -131,6 +136,6 @@ function evaluateFunction(name: string, argNodes: AstNode[], data: Record<string
     }
     case "NUMBER": return toNumber(evaluateNode(argNodes[0], data));
     case "TEXT": return toString(evaluateNode(argNodes[0], data));
-    default: return "#ERROR";
+    default: return `#ERROR:未知函数 ${name}`;
   }
 }

--- a/src/lib/formula/function-catalog.ts
+++ b/src/lib/formula/function-catalog.ts
@@ -1,7 +1,19 @@
+export interface ParamDef {
+  name: string;
+  type: "number" | "string" | "boolean" | "date" | "any";
+  repeated?: boolean;
+  optional?: boolean;
+}
+
 export interface FunctionEntry {
   name: string;
   syntax: string;
   description: string;
+  params: ParamDef[];
+  returnType: "number" | "string" | "boolean" | "date";
+  minArgs: number;
+  example?: string;
+  exampleResult?: string;
 }
 
 export interface FunctionCategory {
@@ -13,53 +25,53 @@ export const FUNCTION_CATALOG: FunctionCategory[] = [
   {
     label: "数学",
     functions: [
-      { name: "SUM", syntax: "SUM(val1, val2, ...)", description: "求和" },
-      { name: "AVERAGE", syntax: "AVERAGE(val1, val2, ...)", description: "求平均值" },
-      { name: "MIN", syntax: "MIN(val1, val2, ...)", description: "最小值" },
-      { name: "MAX", syntax: "MAX(val1, val2, ...)", description: "最大值" },
-      { name: "ROUND", syntax: "ROUND(value, digits)", description: "四舍五入" },
-      { name: "ABS", syntax: "ABS(value)", description: "绝对值" },
-      { name: "CEILING", syntax: "CEILING(value)", description: "向上取整" },
-      { name: "FLOOR", syntax: "FLOOR(value)", description: "向下取整" },
+      { name: "SUM", syntax: "SUM(val1, val2, ...)", description: "求和", params: [{ name: "val1", type: "number" }, { name: "val2", type: "number", repeated: true }], returnType: "number", minArgs: 1, example: "SUM({ price }, { quantity })", exampleResult: "150" },
+      { name: "AVERAGE", syntax: "AVERAGE(val1, val2, ...)", description: "求平均值", params: [{ name: "val1", type: "number" }, { name: "val2", type: "number", repeated: true }], returnType: "number", minArgs: 1, example: "AVERAGE(80, 90, 100)", exampleResult: "90" },
+      { name: "MIN", syntax: "MIN(val1, val2, ...)", description: "最小值", params: [{ name: "val1", type: "number" }, { name: "val2", type: "number", repeated: true }], returnType: "number", minArgs: 1, example: "MIN(3, 1, 4, 1, 5)", exampleResult: "1" },
+      { name: "MAX", syntax: "MAX(val1, val2, ...)", description: "最大值", params: [{ name: "val1", type: "number" }, { name: "val2", type: "number", repeated: true }], returnType: "number", minArgs: 1, example: "MAX(3, 1, 4, 1, 5)", exampleResult: "5" },
+      { name: "ROUND", syntax: "ROUND(value, digits)", description: "四舍五入", params: [{ name: "value", type: "number" }, { name: "digits", type: "number", optional: true }], returnType: "number", minArgs: 1, example: "ROUND(3.1415, 2)", exampleResult: "3.14" },
+      { name: "ABS", syntax: "ABS(value)", description: "绝对值", params: [{ name: "value", type: "number" }], returnType: "number", minArgs: 1, example: "ABS(-42)", exampleResult: "42" },
+      { name: "CEILING", syntax: "CEILING(value)", description: "向上取整", params: [{ name: "value", type: "number" }], returnType: "number", minArgs: 1, example: "CEILING(3.2)", exampleResult: "4" },
+      { name: "FLOOR", syntax: "FLOOR(value)", description: "向下取整", params: [{ name: "value", type: "number" }], returnType: "number", minArgs: 1, example: "FLOOR(3.8)", exampleResult: "3" },
     ],
   },
   {
     label: "逻辑",
     functions: [
-      { name: "IF", syntax: "IF(condition, then, else)", description: "条件判断" },
-      { name: "AND", syntax: "AND(cond1, cond2, ...)", description: "全部为真" },
-      { name: "OR", syntax: "OR(cond1, cond2, ...)", description: "任一为真" },
-      { name: "NOT", syntax: "NOT(condition)", description: "取反" },
+      { name: "IF", syntax: "IF(condition, then, else)", description: "条件判断", params: [{ name: "condition", type: "boolean" }, { name: "then", type: "any" }, { name: "else", type: "any", optional: true }], returnType: "number", minArgs: 2, example: 'IF({ score } >= 60, "及格", "不及格")', exampleResult: '"及格"' },
+      { name: "AND", syntax: "AND(cond1, cond2, ...)", description: "全部为真", params: [{ name: "cond1", type: "boolean" }, { name: "cond2", type: "boolean", repeated: true }], returnType: "boolean", minArgs: 1, example: "AND({ age } > 18, { active })", exampleResult: "true" },
+      { name: "OR", syntax: "OR(cond1, cond2, ...)", description: "任一为真", params: [{ name: "cond1", type: "boolean" }, { name: "cond2", type: "boolean", repeated: true }], returnType: "boolean", minArgs: 1, example: "OR({ vip }, { score } > 90)", exampleResult: "true" },
+      { name: "NOT", syntax: "NOT(condition)", description: "取反", params: [{ name: "condition", type: "boolean" }], returnType: "boolean", minArgs: 1, example: "NOT({ disabled })", exampleResult: "true" },
     ],
   },
   {
     label: "文本",
     functions: [
-      { name: "CONCAT", syntax: "CONCAT(str1, str2, ...)", description: "连接字符串" },
-      { name: "LEN", syntax: "LEN(text)", description: "字符串长度" },
-      { name: "LEFT", syntax: "LEFT(text, count)", description: "取左侧字符" },
-      { name: "RIGHT", syntax: "RIGHT(text, count)", description: "取右侧字符" },
-      { name: "MID", syntax: "MID(text, start, len)", description: "取中间字符" },
-      { name: "UPPER", syntax: "UPPER(text)", description: "转大写" },
-      { name: "LOWER", syntax: "LOWER(text)", description: "转小写" },
-      { name: "TRIM", syntax: "TRIM(text)", description: "去除首尾空格" },
+      { name: "CONCAT", syntax: "CONCAT(str1, str2, ...)", description: "连接字符串", params: [{ name: "str1", type: "string" }, { name: "str2", type: "string", repeated: true }], returnType: "string", minArgs: 1, example: 'CONCAT({ last }, " ", { first })', exampleResult: '"张 三"' },
+      { name: "LEN", syntax: "LEN(text)", description: "字符串长度", params: [{ name: "text", type: "string" }], returnType: "number", minArgs: 1, example: 'LEN("Hello")', exampleResult: "5" },
+      { name: "LEFT", syntax: "LEFT(text, count)", description: "取左侧字符", params: [{ name: "text", type: "string" }, { name: "count", type: "number" }], returnType: "string", minArgs: 2, example: 'LEFT("Hello", 3)', exampleResult: '"Hel"' },
+      { name: "RIGHT", syntax: "RIGHT(text, count)", description: "取右侧字符", params: [{ name: "text", type: "string" }, { name: "count", type: "number" }], returnType: "string", minArgs: 2, example: 'RIGHT("Hello", 2)', exampleResult: '"lo"' },
+      { name: "MID", syntax: "MID(text, start, len)", description: "取中间字符", params: [{ name: "text", type: "string" }, { name: "start", type: "number" }, { name: "len", type: "number" }], returnType: "string", minArgs: 3, example: 'MID("Hello", 2, 3)', exampleResult: '"ell"' },
+      { name: "UPPER", syntax: "UPPER(text)", description: "转大写", params: [{ name: "text", type: "string" }], returnType: "string", minArgs: 1, example: 'UPPER("hello")', exampleResult: '"HELLO"' },
+      { name: "LOWER", syntax: "LOWER(text)", description: "转小写", params: [{ name: "text", type: "string" }], returnType: "string", minArgs: 1, example: 'LOWER("HELLO")', exampleResult: '"hello"' },
+      { name: "TRIM", syntax: "TRIM(text)", description: "去除首尾空格", params: [{ name: "text", type: "string" }], returnType: "string", minArgs: 1, example: 'TRIM("  hi  ")', exampleResult: '"hi"' },
     ],
   },
   {
     label: "日期",
     functions: [
-      { name: "NOW", syntax: "NOW()", description: "当前时间" },
-      { name: "YEAR", syntax: "YEAR(date)", description: "提取年份" },
-      { name: "MONTH", syntax: "MONTH(date)", description: "提取月份" },
-      { name: "DAY", syntax: "DAY(date)", description: "提取日期" },
-      { name: "DATE_DIFF", syntax: "DATE_DIFF(date1, date2, unit)", description: "日期差值" },
+      { name: "NOW", syntax: "NOW()", description: "当前时间", params: [], returnType: "date", minArgs: 0, example: "NOW()", exampleResult: "2026-04-16T..." },
+      { name: "YEAR", syntax: "YEAR(date)", description: "提取年份", params: [{ name: "date", type: "date" }], returnType: "number", minArgs: 1, example: 'YEAR("2026-04-16")', exampleResult: "2026" },
+      { name: "MONTH", syntax: "MONTH(date)", description: "提取月份", params: [{ name: "date", type: "date" }], returnType: "number", minArgs: 1, example: 'MONTH("2026-04-16")', exampleResult: "4" },
+      { name: "DAY", syntax: "DAY(date)", description: "提取日期", params: [{ name: "date", type: "date" }], returnType: "number", minArgs: 1, example: 'DAY("2026-04-16")', exampleResult: "16" },
+      { name: "DATE_DIFF", syntax: "DATE_DIFF(date1, date2, unit)", description: "日期差值", params: [{ name: "date1", type: "date" }, { name: "date2", type: "date" }, { name: "unit", type: "string", optional: true }], returnType: "number", minArgs: 2, example: 'DATE_DIFF("2026-01-01", "2026-04-16", "day")', exampleResult: "105" },
     ],
   },
   {
     label: "类型转换",
     functions: [
-      { name: "NUMBER", syntax: "NUMBER(value)", description: "转为数字" },
-      { name: "TEXT", syntax: "TEXT(value)", description: "转为文本" },
+      { name: "NUMBER", syntax: "NUMBER(value)", description: "转为数字", params: [{ name: "value", type: "any" }], returnType: "number", minArgs: 1, example: 'NUMBER("42")', exampleResult: "42" },
+      { name: "TEXT", syntax: "TEXT(value)", description: "转为文本", params: [{ name: "value", type: "any" }], returnType: "string", minArgs: 1, example: "TEXT(3.14)", exampleResult: '"3.14"' },
     ],
   },
 ];

--- a/src/lib/formula/index.ts
+++ b/src/lib/formula/index.ts
@@ -2,4 +2,4 @@ export { tokenize, type Token, type TokenType } from "./tokenizer";
 export { parseFormula, type AstNode, ParseError } from "./ast";
 export { evaluateFormula } from "./evaluator";
 export { extractFieldRefs, detectCircularRefs } from "./dependency-graph";
-export { FUNCTION_CATALOG, ALL_FUNCTIONS, type FunctionEntry, type FunctionCategory } from "./function-catalog";
+export { FUNCTION_CATALOG, ALL_FUNCTIONS, type FunctionEntry, type FunctionCategory, type ParamDef } from "./function-catalog";

--- a/src/lib/formula/tokenizer.ts
+++ b/src/lib/formula/tokenizer.ts
@@ -15,15 +15,11 @@ export interface Token {
   value: string;
 }
 
+import { ALL_FUNCTIONS } from "./function-catalog";
+
 const OPERATORS = new Set(["+", "-", "*", "/", "%"]);
 const COMPARISONS = new Set(["=", "!=", ">", "<", ">=", "<="]);
-const FUNCTIONS = new Set([
-  "SUM", "AVERAGE", "MIN", "MAX", "ROUND", "ABS", "CEILING", "FLOOR",
-  "IF", "AND", "OR", "NOT",
-  "CONCAT", "LEN", "LEFT", "RIGHT", "MID", "UPPER", "LOWER", "TRIM",
-  "DATE_DIFF", "NOW", "YEAR", "MONTH", "DAY",
-  "NUMBER", "TEXT",
-]);
+const FUNCTIONS = new Set(ALL_FUNCTIONS.keys());
 
 export function tokenize(formula: string): Token[] {
   const tokens: Token[] = [];


### PR DESCRIPTION
## Summary
- 扩展 FunctionEntry 元数据：新增 params/returnType/minArgs/example 字段，补全全部 26 个函数
- 函数参考面板重设计：显示名称+描述，点击展开详情（语法、参数类型、示例代码+结果）
- 自动补全增强：显示函数语法概要（如 `SUM(val1, val2, ...)`）
- evaluator 参数数量校验：`SUM()` 无参调用显示 "SUM 至少需要 1 个参数"
- tokenizer 从 catalog 自动派生函数列表，新增函数只需编辑 catalog + evaluator 两个文件

## Test plan
- [ ] 展开函数参考面板，验证每个函数显示名称+描述
- [ ] 点击函数展开详情：语法、参数、返回类型、示例
- [ ] 点击"插入"正确插入函数模板
- [ ] 自动补全显示函数语法概要
- [ ] `SUM()` → 显示参数不足错误
- [ ] `ROUND(3.14)` → 正常计算（可选参数）
- [ ] `npx vitest run src/lib/formula/evaluator.test.ts` 全部通过

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)