### PR TITLE
[Feature] 数据表新增 COUNT 字段类型

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -742,6 +742,7 @@ enum AuditAction {
   FORM_SHARE_CREATE
   FORM_SHARE_DELETE
   FORM_SUBMIT
+  DATA_TABLE_FIELD_UPDATE
 }
 
 model AuditLog {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -288,6 +288,7 @@ enum FieldType {
   SYSTEM_TIMESTAMP
   SYSTEM_USER
   FORMULA
+  COUNT         // 自动计数关联记录
 }
 
 enum ViewType {

--- a/src/app/(dashboard)/admin/audit-logs/page.tsx
+++ b/src/app/(dashboard)/admin/audit-logs/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, Fragment } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import {
@@ -36,6 +36,10 @@ const actionLabels: Record<string, string> = {
   USER_DELETE: "删除用户",
   API_TOKEN_CREATE: "创建API令牌",
   API_TOKEN_REVOKE: "撤销API令牌",
+  FORM_SHARE_CREATE: "创建表单分享",
+  FORM_SHARE_DELETE: "删除表单分享",
+  FORM_SUBMIT: "表单提交",
+  DATA_TABLE_FIELD_UPDATE: "更新字段配置",
 };
 
 const actionOptions = Object.entries(actionLabels);
@@ -236,9 +240,8 @@ export default function AuditLogsPage() {
               </thead>
               <tbody>
                 {logs.map((log) => (
-                  <>
+                  <Fragment key={log.id}>
                     <tr
-                      key={log.id}
                       className="border-t hover:bg-muted/30 cursor-pointer"
                       onClick={() => setExpandedId(expandedId === log.id ? null : log.id)}
                     >
@@ -289,6 +292,44 @@ export default function AuditLogsPage() {
                                 </div>
                               ))}
                             </div>
+                          ) : log.action === "DATA_TABLE_FIELD_UPDATE" ? (
+                            <div className="space-y-2">
+                              {Array.isArray(log.detail.addedFields) && (log.detail.addedFields as { key: string; label: string; type: string }[]).length > 0 && (
+                                <div>
+                                  <div className="text-xs font-medium text-green-700 dark:text-green-400 mb-1">新增字段</div>
+                                  {(log.detail.addedFields as { key: string; label: string; type: string }[]).map((f) => (
+                                    <div key={f.key} className="text-xs flex items-center gap-2">
+                                      <span className="font-mono">{f.key}</span>
+                                      <span className="text-muted-foreground">{f.label}</span>
+                                      <Badge variant="outline" className="text-[10px] px-1 py-0">{f.type}</Badge>
+                                    </div>
+                                  ))}
+                                </div>
+                              )}
+                              {Array.isArray(log.detail.removedFields) && (log.detail.removedFields as { key: string; label: string; type: string }[]).length > 0 && (
+                                <div>
+                                  <div className="text-xs font-medium text-destructive mb-1">删除字段</div>
+                                  {(log.detail.removedFields as { key: string; label: string; type: string }[]).map((f) => (
+                                    <div key={f.key} className="text-xs flex items-center gap-2">
+                                      <span className="font-mono">{f.key}</span>
+                                      <span className="text-muted-foreground">{f.label}</span>
+                                      <Badge variant="outline" className="text-[10px] px-1 py-0">{f.type}</Badge>
+                                    </div>
+                                  ))}
+                                </div>
+                              )}
+                              {Array.isArray(log.detail.updatedFieldKeys) && (log.detail.updatedFieldKeys as string[]).length > 0 && (
+                                <div>
+                                  <div className="text-xs font-medium text-muted-foreground mb-1">修改字段</div>
+                                  <div className="text-xs font-mono text-muted-foreground">
+                                    {(log.detail.updatedFieldKeys as string[]).join(", ")}
+                                  </div>
+                                </div>
+                              )}
+                              <div className="text-xs text-muted-foreground">
+                                共 {String(log.detail.totalFields ?? "?")} 个字段
+                              </div>
+                            </div>
                           ) : (
                             <pre className="text-xs whitespace-pre-wrap break-all max-h-40 overflow-auto">
                               {JSON.stringify(log.detail, null, 2)}
@@ -297,7 +338,7 @@ export default function AuditLogsPage() {
                         </td>
                       </tr>
                     )}
-                  </>
+                  </Fragment>
                 ))}
                 {logs.length === 0 && (
                   <tr>

--- a/src/app/api/data-tables/[id]/fields/route.ts
+++ b/src/app/api/data-tables/[id]/fields/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { updateFields, getTable } from "@/lib/services/data-table.service";
 import { updateFieldsSchema } from "@/validators/data-table";
+import { logAudit } from "@/lib/services/audit-log.service";
+import { getClientIp, getUserAgent } from "@/lib/request-utils";
 import { ZodError } from "zod";
 
 interface RouteParams {
@@ -51,6 +53,12 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     const body = await request.json();
     const validated = updateFieldsSchema.parse(body);
 
+    // Fetch existing table info for audit diff
+    const existingTable = await getTable(id);
+    const existingFields = existingTable.success ? existingTable.data.fields : [];
+    const existingFieldIds = new Set(existingFields.map((f) => f.id));
+    const tableName = existingTable.success ? existingTable.data.name : id;
+
     const result = await updateFields(id, validated.fields, validated.businessKeys);
 
     if (!result.success) {
@@ -59,6 +67,36 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
         { status: 400 }
       );
     }
+
+    // Audit log
+    const addedFields = validated.fields.filter(
+      (f) => f.id && !existingFieldIds.has(f.id)
+    );
+    const removedFields = existingFields.filter(
+      (f) => !validated.fields.some((nf) => nf.id === f.id)
+    );
+    const updatedFields = validated.fields.filter(
+      (f) => f.id && existingFieldIds.has(f.id)
+    );
+
+    await logAudit({
+      userId: session.user.id,
+      userName: session.user.name,
+      userEmail: session.user.email,
+      action: "DATA_TABLE_FIELD_UPDATE",
+      targetType: "DataTable",
+      targetId: id,
+      targetName: tableName,
+      detail: {
+        addedFields: addedFields.map((f) => ({ key: f.key, label: f.label, type: f.type })),
+        removedFields: removedFields.map((f) => ({ key: f.key, label: f.label, type: f.type })),
+        updatedFieldKeys: updatedFields.map((f) => f.key),
+        totalFields: validated.fields.length,
+        businessKeys: validated.businessKeys,
+      },
+      ipAddress: getClientIp(request),
+      userAgent: getUserAgent(request),
+    });
 
     return NextResponse.json(result.data);
   } catch (error) {

--- a/src/app/api/data-tables/[id]/fields/route.ts
+++ b/src/app/api/data-tables/[id]/fields/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { updateFields, getTable } from "@/lib/services/data-table.service";
+import { backfillCountFieldValues } from "@/lib/services/data-relation.service";
 import { updateFieldsSchema } from "@/validators/data-table";
 import { logAudit } from "@/lib/services/audit-log.service";
 import { getClientIp, getUserAgent } from "@/lib/request-utils";
 import { ZodError } from "zod";
+import { FieldType } from "@/generated/prisma/enums";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -97,6 +99,14 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       ipAddress: getClientIp(request),
       userAgent: getUserAgent(request),
     });
+
+    // Backfill COUNT field values for newly added COUNT fields
+    const hasNewCountFields = addedFields.some((f) => f.type === FieldType.COUNT);
+    if (hasNewCountFields) {
+      backfillCountFieldValues(id).catch((err) => {
+        console.error("COUNT 字段回填失败:", err);
+      });
+    }
 
     return NextResponse.json(result.data);
   } catch (error) {

--- a/src/components/data/column-header.tsx
+++ b/src/components/data/column-header.tsx
@@ -87,6 +87,8 @@ function getOperatorsForType(type: FieldType): FilterOperator[] {
       return ["eq", "gt", "lt", "gte", "lte", "between", "isempty"];
     case FieldType.FORMULA:
       return ["eq", "ne", "gt", "lt", "gte", "lte", "between", "isempty", "isnotempty"];
+    case FieldType.COUNT:
+      return ["eq", "ne", "gt", "lt", "gte", "lte", "between", "isempty"];
     default:
       return ["eq", "ne", "contains", "isempty", "isnotempty"];
   }

--- a/src/components/data/field-config-form.tsx
+++ b/src/components/data/field-config-form.tsx
@@ -60,6 +60,7 @@ const FIELD_TYPES = [
   { value: FieldType.SYSTEM_TIMESTAMP, label: "创建/修改时间" },
   { value: FieldType.SYSTEM_USER, label: "创建/修改人" },
   { value: FieldType.FORMULA, label: "公式" },
+  { value: FieldType.COUNT, label: "计数" },
   { value: FieldType.RELATION, label: "关联字段" },
   { value: FieldType.RELATION_SUBTABLE, label: "关系子表格" },
 ];
@@ -184,6 +185,10 @@ export function FieldConfigForm({
     const opts = parseFieldOptions(field?.options);
     return opts.formula ?? "";
   });
+  const [countSourceFieldId, setCountSourceFieldId] = useState(() => {
+    const opts = parseFieldOptions(field?.options);
+    return opts.countSourceFieldId ?? "";
+  });
 
   // Formula validation
   const formulaError = useMemo(() => {
@@ -250,6 +255,7 @@ export function FieldConfigForm({
       : undefined;
     setRelationFields(relTable?.fields ?? []);
     setFormulaExpression(opts.formula ?? "");
+    setCountSourceFieldId(opts.countSourceFieldId ?? "");
     setSystemFieldKind(opts.kind ?? "created");
     setError("");
   }, [field, availableTables]);
@@ -426,11 +432,18 @@ export function FieldConfigForm({
       return;
     }
 
+    if (fieldType === FieldType.COUNT && !countSourceFieldId) {
+      setError("请选择要计数的关联字段");
+      return;
+    }
+
     let fieldOptions: DataFieldInput["options"] = undefined;
     if (fieldType === FieldType.SELECT || fieldType === FieldType.MULTISELECT) {
       fieldOptions = selectOptions.filter((o) => o.label.trim());
     } else if (fieldType === FieldType.FORMULA) {
       fieldOptions = { formula: formulaExpression.trim() };
+    } else if (fieldType === FieldType.COUNT) {
+      fieldOptions = { countSourceFieldId };
     } else if (fieldType === FieldType.SYSTEM_TIMESTAMP || fieldType === FieldType.SYSTEM_USER) {
       fieldOptions = { kind: systemFieldKind };
     }
@@ -526,10 +539,14 @@ export function FieldConfigForm({
               </Select>
             </div>
 
-            <div className="flex items-center justify-between">
-              <Label htmlFor="required">是否必填</Label>
-              <Switch id="required" checked={required} onCheckedChange={setRequired} />
-            </div>
+            {fieldType !== FieldType.COUNT && fieldType !== FieldType.FORMULA &&
+              fieldType !== FieldType.AUTO_NUMBER && fieldType !== FieldType.SYSTEM_TIMESTAMP &&
+              fieldType !== FieldType.SYSTEM_USER && (
+              <div className="flex items-center justify-between">
+                <Label htmlFor="required">是否必填</Label>
+                <Switch id="required" checked={required} onCheckedChange={setRequired} />
+              </div>
+            )}
 
             {(fieldType === FieldType.SELECT || fieldType === FieldType.MULTISELECT) && (
               <div className="grid gap-2">
@@ -607,6 +624,46 @@ export function FieldConfigForm({
                   error={formulaError}
                   livePreview={formulaPreview}
                 />
+              </div>
+            )}
+
+            {fieldType === FieldType.COUNT && (
+              <div className="grid gap-2">
+                <Label>计数字段</Label>
+                {allFields.filter(
+                  (f) => f.type === FieldType.RELATION || f.type === FieldType.RELATION_SUBTABLE
+                ).length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    当前表没有关联字段，无法创建计数字段
+                  </p>
+                ) : (
+                  <Select
+                    value={countSourceFieldId}
+                    onValueChange={(value) => setCountSourceFieldId(value ?? "")}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="选择要计数的关联字段">
+                        {countSourceFieldId
+                          ? allFields.find((f) => f.id === countSourceFieldId)?.label ??
+                            countSourceFieldId
+                          : null}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent>
+                      {allFields
+                        .filter((f) => f.type === FieldType.RELATION || f.type === FieldType.RELATION_SUBTABLE)
+                        .map((f) => (
+                          <SelectItem key={f.id} value={f.id!}>
+                            {f.label}
+                            {f.type === FieldType.RELATION && "（单值关联，结果为 0 或 1）"}
+                          </SelectItem>
+                        ))}
+                    </SelectContent>
+                  </Select>
+                )}
+                <p className="text-xs text-muted-foreground">
+                  自动统计关联记录数量，当关联记录增删时自动更新
+                </p>
               </div>
             )}
 
@@ -916,15 +973,19 @@ export function FieldConfigForm({
               </>
             )}
 
-            <div className="grid gap-2">
-              <Label htmlFor="defaultValue">默认值</Label>
-              <Input
-                id="defaultValue"
-                placeholder="可选"
-                value={defaultValue}
-                onChange={(event) => setDefaultValue(event.target.value)}
-              />
-            </div>
+            {fieldType !== FieldType.COUNT && fieldType !== FieldType.FORMULA &&
+              fieldType !== FieldType.AUTO_NUMBER && fieldType !== FieldType.SYSTEM_TIMESTAMP &&
+              fieldType !== FieldType.SYSTEM_USER && (
+              <div className="grid gap-2">
+                <Label htmlFor="defaultValue">默认值</Label>
+                <Input
+                  id="defaultValue"
+                  placeholder="可选"
+                  value={defaultValue}
+                  onChange={(event) => setDefaultValue(event.target.value)}
+                />
+              </div>
+            )}
 
             {error && <p className="text-sm text-red-500">{error}</p>}
           </div>

--- a/src/components/data/field-config-list.tsx
+++ b/src/components/data/field-config-list.tsx
@@ -42,6 +42,7 @@ const FIELD_TYPE_LABELS: Record<FieldType, string> = {
   [FieldType.SYSTEM_TIMESTAMP]: "创建/修改时间",
   [FieldType.SYSTEM_USER]: "创建/修改人",
   [FieldType.FORMULA]: "公式",
+  [FieldType.COUNT]: "计数",
 };
 
 function buildInverseFieldPreview(key: string): string {

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -186,7 +186,7 @@ function DraggableColumnHeader({
     <th
       ref={ref}
       className={cn(
-        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 relative",
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 relative border-r border-neutral-400",
         isDragging ? "opacity-50 bg-muted" : "cursor-grab active:cursor-grabbing",
         frozenStyle && "bg-background",
         frozenFieldCount && frozenFieldCount > 0 && index === frozenFieldCount - 1 && "frozen-last-col"
@@ -670,7 +670,7 @@ export function GridView({
 
   const READONLY_FIELD_TYPES: readonly string[] = [
     FieldType.AUTO_NUMBER, FieldType.SYSTEM_TIMESTAMP, FieldType.SYSTEM_USER,
-    FieldType.FORMULA, FieldType.RELATION_SUBTABLE,
+    FieldType.FORMULA, FieldType.RELATION_SUBTABLE, FieldType.COUNT,
   ];
 
   const computeFillValue = useCallback((fieldType: string, originalValue: unknown, step: number, mode: "increment" | "copy"): unknown => {
@@ -1443,7 +1443,7 @@ export function GridView({
                 data-col={fieldIndex}
                 style={Object.keys(mergedStyle).length > 0 ? mergedStyle : undefined}
                 className={cn(
-                  "align-middle overflow-hidden", rhClasses.td,
+                  "align-middle overflow-hidden border-r border-neutral-400", rhClasses.td,
                   (rowHeight ?? 40) < 56 && "whitespace-nowrap",
                   rhClasses.text,
                   frozenTdStyle && "bg-background",
@@ -1461,7 +1461,8 @@ export function GridView({
                     && field.type !== FieldType.SYSTEM_TIMESTAMP
                     && field.type !== FieldType.SYSTEM_USER
                     && field.type !== FieldType.FORMULA
-                    && field.type !== FieldType.BOOLEAN;
+                    && field.type !== FieldType.BOOLEAN
+                    && field.type !== FieldType.COUNT;
                   if (canEdit) {
                     startEditing(record.id, field.key);
                   }
@@ -1520,7 +1521,7 @@ export function GridView({
       }
 
       return (
-        <tr key={record.id} className="border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted" style={rowStyle}>
+        <tr key={record.id} className="border-b transition-colors hover:bg-primary/8 data-[state=selected]:bg-muted" style={rowStyle}>
           {rowContent}
         </tr>
       );
@@ -1790,7 +1791,7 @@ export function GridView({
               {/* Quick add row */}
               {isAdmin && (
                 <tr
-                  className="border-b hover:bg-muted/30 cursor-pointer group"
+                  className="border-b hover:bg-primary/5 cursor-pointer group"
                   onClick={handleQuickAddRow}
                 >
                   <td className="w-10 sticky left-0 z-[5] bg-background border-r" />
@@ -1816,12 +1817,12 @@ export function GridView({
               <td className="p-2 text-xs text-muted-foreground w-10" />
               {orderedVisibleFields.map((field) => {
                 const agg = columnAggregations?.[field.key];
-                if (!agg) return <td key={field.key} className="p-2" />;
+                if (!agg) return <td key={field.key} className="p-2 border-r border-neutral-400" />;
                 const summary = summaryData[field.key];
                 return (
                   <td
                     key={field.key}
-                    className="p-2 text-xs text-muted-foreground cursor-pointer hover:bg-muted/50"
+                    className="p-2 text-xs text-muted-foreground cursor-pointer hover:bg-muted/50 border-r border-neutral-400"
                     style={{ width: columnWidths[field.key] ?? DEFAULT_COL_WIDTH }}
                     onClick={() => {
                       const cycle = getAvailableAggTypes(field.type);

--- a/src/lib/format-cell.tsx
+++ b/src/lib/format-cell.tsx
@@ -201,6 +201,9 @@ export function formatCellValue(
       if (value === null || value === undefined) return <span className="text-zinc-400">-</span>;
       if (typeof value === "number") return value.toLocaleString();
       return String(value);
+    case FieldType.COUNT:
+      if (value === null || value === undefined) return <span className="text-zinc-400">0</span>;
+      return <span className="text-muted-foreground font-mono">{Number(value).toLocaleString()}</span>;
     default:
       return String(value);
   }
@@ -222,6 +225,7 @@ export function formatCellText(field: DataFieldItem, value: unknown): string {
     case FieldType.SYSTEM_TIMESTAMP:
     case FieldType.SYSTEM_USER:
     case FieldType.FORMULA:
+    case FieldType.COUNT:
       return String(value ?? "");
     default:
       return String(value);

--- a/src/lib/services/data-record.service.ts
+++ b/src/lib/services/data-record.service.ts
@@ -42,7 +42,7 @@ interface FieldChange {
 }
 
 const SKIP_HISTORY_FIELD_TYPES = new Set([
-  "RELATION_SUBTABLE", "SYSTEM_TIMESTAMP", "SYSTEM_USER", "FORMULA",
+  "RELATION_SUBTABLE", "SYSTEM_TIMESTAMP", "SYSTEM_USER", "FORMULA", "COUNT",
 ]);
 
 function detectFieldChanges(
@@ -241,7 +241,8 @@ function splitRecordDataByFieldType(
   > = {};
 
   for (const [fieldKey, value] of Object.entries(data)) {
-    if (fieldTypeByKey.get(fieldKey) === "RELATION_SUBTABLE") {
+    if (fieldTypeByKey.get(fieldKey) === "RELATION_SUBTABLE" ||
+        fieldTypeByKey.get(fieldKey) === "COUNT") {
       relationData[fieldKey] = value as
         | RelationSubtableValueItem[]
         | RelationSubtableValueItem
@@ -1212,7 +1213,8 @@ export function validateRecordData(
       field.type === "AUTO_NUMBER" ||
       field.type === "SYSTEM_TIMESTAMP" ||
       field.type === "SYSTEM_USER" ||
-      field.type === "FORMULA"
+      field.type === "FORMULA" ||
+      field.type === "COUNT"
     ) {
       continue;
     }

--- a/src/lib/services/data-relation.service.ts
+++ b/src/lib/services/data-relation.service.ts
@@ -3,12 +3,15 @@ import type {
   RelationSubtableValueItem,
   ServiceResult,
 } from "@/types/data-table";
+import { parseFieldOptions } from "@/types/data-table";
+import { db } from "@/lib/db";
 
 type RelationFieldRow = {
   id: string;
   tableId: string;
   key: string;
   type: string;
+  options: unknown;
   relationTo: string | null;
   displayField: string | null;
   relationCardinality: RelationCardinality | null;
@@ -373,8 +376,39 @@ async function refreshRelationSnapshotsForRecords(
     },
   });
 
-  if (relationFields.length === 0) {
+  // Load COUNT fields for count computation
+  const countFields = await tx.dataField.findMany({
+    where: {
+      tableId: { in: tableIds },
+      type: "COUNT",
+    },
+  });
+
+  // Load RELATION fields for COUNT source resolution (single-link: 0 or 1)
+  const relationLinkFields = await tx.dataField.findMany({
+    where: {
+      tableId: { in: tableIds },
+      type: "RELATION",
+    },
+  });
+
+  if (relationFields.length === 0 && countFields.length === 0) {
     return;
+  }
+
+  // Build source field lookup (RELATION + RELATION_SUBTABLE) for COUNT resolution
+  const sourceFieldById = new Map<string, RelationFieldRow>();
+  for (const field of [...relationFields, ...relationLinkFields]) {
+    sourceFieldById.set(field.id, field);
+  }
+
+  // Group countFields by tableId
+  const countFieldsByTableId = new Map<string, RelationFieldRow[]>();
+  for (const field of countFields) {
+    countFieldsByTableId.set(field.tableId, [
+      ...(countFieldsByTableId.get(field.tableId) ?? []),
+      field,
+    ]);
   }
 
   const relationFieldById = new Map(relationFields.map((field) => [field.id, field]));
@@ -388,17 +422,20 @@ async function refreshRelationSnapshotsForRecords(
     inverseFieldIds.add(field.id);
   }
 
-  const relationRows = await tx.dataRelationRow.findMany({
-    where: {
-      OR: [
-        { sourceRecordId: { in: affectedRecordIds } },
-        { targetRecordId: { in: affectedRecordIds } },
-      ],
-    },
-    include: {
-      field: true,
-    },
-  });
+  // Only query relation rows when there are RELATION_SUBTABLE fields
+  const relationRows = relationFields.length > 0
+    ? await tx.dataRelationRow.findMany({
+        where: {
+          OR: [
+            { sourceRecordId: { in: affectedRecordIds } },
+            { targetRecordId: { in: affectedRecordIds } },
+          ],
+        },
+        include: {
+          field: true,
+        },
+      })
+    : [];
 
   const relatedRecordIds = new Set<string>();
   for (const row of relationRows) {
@@ -473,11 +510,69 @@ async function refreshRelationSnapshotsForRecords(
       );
     }
 
+    // Compute COUNT field values
+    for (const countField of countFieldsByTableId.get(record.tableId) ?? []) {
+      const opts = parseFieldOptions(countField.options);
+      if (!opts.countSourceFieldId) continue;
+
+      const sourceField = sourceFieldById.get(opts.countSourceFieldId);
+      if (!sourceField) continue;
+
+      if (sourceField.type === "RELATION_SUBTABLE") {
+        // Count = snapshot array length
+        nextData[countField.key] = snapshotItemsByFieldId.get(opts.countSourceFieldId)?.length ?? 0;
+      } else if (sourceField.type === "RELATION") {
+        // Single-link: 1 if linked, 0 if not
+        const sourceValue = nextData[sourceField.key];
+        nextData[countField.key] = (sourceValue != null && sourceValue !== "") ? 1 : 0;
+      }
+    }
+
     await tx.dataRecord.update({
       where: { id: record.id },
       data: { data: nextData },
     });
   }
+}
+
+/**
+ * Backfill COUNT field values for all records in a table.
+ * Called after a new COUNT field is created.
+ */
+export async function backfillCountFieldValues(
+  tableId: string
+): Promise<ServiceResult<null>> {
+  const BATCH_SIZE = 500;
+
+  const countFields = await db.dataField.findMany({
+    where: { tableId, type: "COUNT" },
+  });
+
+  if (countFields.length === 0) {
+    return { success: true, data: null };
+  }
+
+  const totalRecords = await db.dataRecord.count({ where: { tableId } });
+  if (totalRecords === 0) {
+    return { success: true, data: null };
+  }
+
+  // Process in batches to avoid large transactions
+  for (let offset = 0; offset < totalRecords; offset += BATCH_SIZE) {
+    const records = await db.dataRecord.findMany({
+      where: { tableId },
+      select: { id: true },
+      skip: offset,
+      take: BATCH_SIZE,
+    });
+
+    const recordIds = records.map((r) => r.id);
+    await db.$transaction(async (tx) => {
+      await refreshRelationSnapshotsForRecords(asTxClient(tx), recordIds);
+    });
+  }
+
+  return { success: true, data: null };
 }
 
 export async function syncRelationSubtableValues(input: {

--- a/src/types/data-table.ts
+++ b/src/types/data-table.ts
@@ -79,6 +79,8 @@ export interface FieldOptions {
   kind?: "created" | "updated";
   /** FORMULA: formula expression string */
   formula?: string;
+  /** COUNT: ID of the RELATION or RELATION_SUBTABLE field to count */
+  countSourceFieldId?: string;
 }
 
 export function parseFieldOptions(raw: unknown): FieldOptions {

--- a/src/validators/data-table.ts
+++ b/src/validators/data-table.ts
@@ -50,6 +50,7 @@ export const dataFieldItemSchema = z.object({
     z.object({ formula: z.string() }),
     z.object({ nextValue: z.number() }),
     z.object({ kind: z.enum(["created", "updated"]) }),
+    z.object({ countSourceFieldId: z.string() }),
   ]).nullable().optional(),
   relationTo: z.string().nullable().optional(),
   displayField: z.string().nullable().optional(),


### PR DESCRIPTION
## Summary

- 新增 **COUNT 字段类型**，可绑定关联/关联子表格字段，自动统计关联记录数量
- 单值关联（RELATION）计数结果为 0 或 1，关联子表格为实际数量
- 修复编辑 COUNT 字段时源字段下拉显示 ID 而非字段名的 bug
- COUNT 字段创建时自动禁用必填选项

## Test plan

- [ ] 添加字段时选择"计数"类型，能正确显示计数字段选择器
- [ ] 选择关联作者（单值关联），保存后数据表页面正确显示 0 或 1
- [ ] 编辑已有 COUNT 字段，源字段下拉显示字段名而非 ID
- [ ] 删除关联记录后 COUNT 值自动更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #86