### PR TITLE
[Feature] 新增 ROLLUP 汇总字段类型

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -290,6 +290,7 @@ enum FieldType {
   FORMULA
   COUNT         // 自动计数关联记录
   LOOKUP        // 从关联记录拉取指定字段值
+  ROLLUP        // 从关联记录聚合指定字段值
 }
 
 enum ViewType {

--- a/src/app/api/data-tables/[id]/fields/route.ts
+++ b/src/app/api/data-tables/[id]/fields/route.ts
@@ -141,11 +141,12 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       userAgent: getUserAgent(request),
     });
 
-    // Backfill COUNT / LOOKUP field values for newly added fields only
+    // Backfill COUNT / LOOKUP / ROLLUP field values for newly added fields only
     const hasNewCountFields = addedFields.some((f) => f.type === FieldType.COUNT);
     const hasNewLookupFields = addedFields.some((f) => f.type === FieldType.LOOKUP);
+    const hasNewRollupFields = addedFields.some((f) => f.type === FieldType.ROLLUP);
     let backfillWarning = false;
-    if (hasNewCountFields || hasNewLookupFields) {
+    if (hasNewCountFields || hasNewLookupFields || hasNewRollupFields) {
       try {
         await backfillCountFieldValues(id);
       } catch (err) {

--- a/src/components/data/dynamic-record-form.tsx
+++ b/src/components/data/dynamic-record-form.tsx
@@ -174,6 +174,7 @@ export function DynamicRecordForm({
             break;
           case FieldType.COUNT:
           case FieldType.LOOKUP:
+          case FieldType.ROLLUP:
             fieldSchema = z.unknown().nullable().optional();
             break;
           default:
@@ -233,7 +234,6 @@ export function DynamicRecordForm({
     const fieldById = new Map(fields.map((f) => [f.id, f]));
 
     for (const cf of fields) {
-      if (cf.type !== FieldType.COUNT && cf.type !== FieldType.LOOKUP) continue;
       const opts = parseFieldOptions(cf.options);
 
       if (cf.type === FieldType.COUNT && opts.countSourceFieldId) {
@@ -257,6 +257,26 @@ export function DynamicRecordForm({
           if (res.ok) {
             const record = await res.json();
             setValue(cf.key, record?.data?.[opts.lookupTargetFieldKey] ?? null);
+          }
+        } catch {
+          // ignore — value will update on full save
+        }
+      }
+
+      if (cf.type === FieldType.ROLLUP && opts.rollupSourceFieldId && opts.rollupTargetFieldKey) {
+        const src = fieldById.get(opts.rollupSourceFieldId);
+        if (!src || src.key !== fieldKey || src.type !== FieldType.RELATION) continue;
+        const recordId = typeof value === 'string' ? value : null;
+        if (!recordId || !src.relationTo) {
+          setValue(cf.key, null);
+          continue;
+        }
+        try {
+          const res = await fetch(`/api/data-tables/${src.relationTo}/records/${recordId}`);
+          if (res.ok) {
+            const record = await res.json();
+            // SINGLE relation: take value directly, no aggregation
+            setValue(cf.key, record?.data?.[opts.rollupTargetFieldKey] ?? null);
           }
         } catch {
           // ignore — value will update on full save
@@ -421,7 +441,8 @@ export function DynamicRecordForm({
         );
 
       case FieldType.COUNT:
-      case FieldType.LOOKUP: {
+      case FieldType.LOOKUP:
+      case FieldType.ROLLUP: {
         const rawVal = watch(field.key);
         const displayVal = Array.isArray(rawVal) ? rawVal.join(", ") : String(rawVal ?? "");
         return (

--- a/src/components/data/field-config-form.tsx
+++ b/src/components/data/field-config-form.tsx
@@ -30,6 +30,7 @@ import type {
 } from "@/types/data-table";
 import { parseSelectOptions, SELECT_COLORS } from "@/types/data-table";
 import { parseFieldOptions } from "@/types/data-table";
+import type { RollupAggregateType } from "@/types/data-table";
 import type { DataFieldInput } from "@/validators/data-table";
 import { FormulaEditor } from "@/components/data/formula-editor";
 import { parseFormula, evaluateFormula, detectCircularRefs } from "@/lib/formula";
@@ -62,6 +63,7 @@ const FIELD_TYPES = [
   { value: FieldType.FORMULA, label: "公式" },
   { value: FieldType.COUNT, label: "计数" },
   { value: FieldType.LOOKUP, label: "查找" },
+  { value: FieldType.ROLLUP, label: "汇总" },
   { value: FieldType.RELATION, label: "关联字段" },
   { value: FieldType.RELATION_SUBTABLE, label: "关系子表格" },
 ];
@@ -144,6 +146,48 @@ function hasDuplicateRelationSchemaKeys(fields: RelationSchemaFieldDraft[]): boo
   return false;
 }
 
+function getAvailableRollupAggregates(targetFieldType: FieldType): { value: RollupAggregateType; label: string }[] {
+  switch (targetFieldType) {
+    case FieldType.NUMBER:
+      return [
+        { value: "SUM", label: "求和 (SUM)" },
+        { value: "AVG", label: "平均值 (AVG)" },
+        { value: "MIN", label: "最小值 (MIN)" },
+        { value: "MAX", label: "最大值 (MAX)" },
+        { value: "COUNT", label: "计数 (COUNT)" },
+        { value: "COUNTA", label: "非空计数 (COUNTA)" },
+      ];
+    case FieldType.TEXT:
+    case FieldType.EMAIL:
+    case FieldType.PHONE:
+    case FieldType.URL:
+      return [
+        { value: "COUNT", label: "计数 (COUNT)" },
+        { value: "COUNTA", label: "非空计数 (COUNTA)" },
+        { value: "ARRAYJOIN", label: "连接 (ARRAYJOIN)" },
+        { value: "ARRAYUNIQUE", label: "去重连接 (ARRAYUNIQUE)" },
+      ];
+    case FieldType.DATE:
+    case FieldType.SYSTEM_TIMESTAMP:
+      return [
+        { value: "MIN", label: "最早 (MIN)" },
+        { value: "MAX", label: "最晚 (MAX)" },
+        { value: "COUNT", label: "计数 (COUNT)" },
+      ];
+    case FieldType.BOOLEAN:
+      return [
+        { value: "COUNT", label: "计数 (COUNT)" },
+        { value: "TRUE_COUNT", label: "真值计数 (TRUE_COUNT)" },
+        { value: "FALSE_COUNT", label: "假值计数 (FALSE_COUNT)" },
+      ];
+    default:
+      return [
+        { value: "COUNT", label: "计数 (COUNT)" },
+        { value: "COUNTA", label: "非空计数 (COUNTA)" },
+      ];
+  }
+}
+
 export function FieldConfigForm({
   open,
   onOpenChange,
@@ -206,6 +250,21 @@ export function FieldConfigForm({
     return [];
   });
 
+  // ROLLUP state
+  const [rollupSourceFieldId, setRollupSourceFieldId] = useState(() => {
+    const opts = parseFieldOptions(field?.options);
+    return opts.rollupSourceFieldId ?? "";
+  });
+  const [rollupTargetFieldKey, setRollupTargetFieldKey] = useState(() => {
+    const opts = parseFieldOptions(field?.options);
+    return opts.rollupTargetFieldKey ?? "";
+  });
+  const [rollupAggregateType, setRollupAggregateType] = useState<RollupAggregateType | "">(() => {
+    const opts = parseFieldOptions(field?.options);
+    return (opts.rollupAggregateType as RollupAggregateType) ?? "";
+  });
+  const [rollupTargetFields, setRollupTargetFields] = useState<DataFieldItem[]>([]);
+
   // Load target table fields when lookup source field changes
   useEffect(() => {
     if (!lookupSourceFieldId) {
@@ -239,6 +298,36 @@ export function FieldConfigForm({
 
     return () => { cancelled = true; };
   }, [lookupSourceFieldId, allFields, availableTables]);
+
+  // Load target table fields when rollup source field changes
+  useEffect(() => {
+    if (!rollupSourceFieldId) {
+      setRollupTargetFields([]);
+      return;
+    }
+    const sourceField = allFields.find((f) => f.id === rollupSourceFieldId);
+    if (!sourceField?.relationTo) {
+      setRollupTargetFields([]);
+      return;
+    }
+    const localTable = availableTables.find((t) => t.id === sourceField.relationTo);
+    if (localTable?.fields?.length) {
+      setRollupTargetFields(localTable.fields);
+      return;
+    }
+    let cancelled = false;
+    fetch(`/api/data-tables/${sourceField.relationTo}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled) return;
+        const fields = data.data?.fields ?? data.fields ?? [];
+        setRollupTargetFields(fields);
+      })
+      .catch(() => {
+        if (!cancelled) setRollupTargetFields([]);
+      });
+    return () => { cancelled = true; };
+  }, [rollupSourceFieldId, allFields, availableTables]);
 
   // Formula validation
   const formulaError = useMemo(() => {
@@ -495,6 +584,18 @@ export function FieldConfigForm({
       setError("请选择要拉取的字段");
       return;
     }
+    if (fieldType === FieldType.ROLLUP && !rollupSourceFieldId) {
+      setError("请选择源关联字段");
+      return;
+    }
+    if (fieldType === FieldType.ROLLUP && !rollupTargetFieldKey) {
+      setError("请选择要汇总的字段");
+      return;
+    }
+    if (fieldType === FieldType.ROLLUP && !rollupAggregateType) {
+      setError("请选择聚合方式");
+      return;
+    }
 
     let fieldOptions: DataFieldInput["options"] = undefined;
     if (fieldType === FieldType.SELECT || fieldType === FieldType.MULTISELECT) {
@@ -505,6 +606,8 @@ export function FieldConfigForm({
       fieldOptions = { countSourceFieldId };
     } else if (fieldType === FieldType.LOOKUP) {
       fieldOptions = { lookupSourceFieldId, lookupTargetFieldKey };
+    } else if (fieldType === FieldType.ROLLUP) {
+      fieldOptions = { rollupSourceFieldId, rollupTargetFieldKey, rollupAggregateType: rollupAggregateType as RollupAggregateType };
     } else if (fieldType === FieldType.SYSTEM_TIMESTAMP || fieldType === FieldType.SYSTEM_USER) {
       fieldOptions = { kind: systemFieldKind };
     }
@@ -601,6 +704,7 @@ export function FieldConfigForm({
             </div>
 
             {fieldType !== FieldType.COUNT && fieldType !== FieldType.LOOKUP &&
+              fieldType !== FieldType.ROLLUP &&
               fieldType !== FieldType.FORMULA &&
               fieldType !== FieldType.AUTO_NUMBER && fieldType !== FieldType.SYSTEM_TIMESTAMP &&
               fieldType !== FieldType.SYSTEM_USER && (
@@ -807,6 +911,100 @@ export function FieldConfigForm({
 
                 <p className="text-xs text-muted-foreground">
                   从关联记录拉取指定字段值，只读展示
+                </p>
+              </div>
+            )}
+
+            {fieldType === FieldType.ROLLUP && (
+              <div className="grid gap-2">
+                <Label>源关联字段</Label>
+                <Select value={rollupSourceFieldId} onValueChange={(value) => {
+                  setRollupSourceFieldId(value ?? "");
+                  setRollupTargetFieldKey("");
+                  setRollupAggregateType("");
+                }}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="选择源关联字段">
+                      {rollupSourceFieldId
+                        ? allFields.find((f) => f.id === rollupSourceFieldId)?.label ?? rollupSourceFieldId
+                        : null}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {allFields
+                      .filter((f) => f.type === FieldType.RELATION || f.type === FieldType.RELATION_SUBTABLE)
+                      .map((f) => (
+                        <SelectItem key={f.id!} value={f.id!}>
+                          {f.label}
+                          {f.type === FieldType.RELATION && "（单值关联，直接取值）"}
+                        </SelectItem>
+                      ))}
+                  </SelectContent>
+                </Select>
+
+                {rollupSourceFieldId && (() => {
+                  const sourceField = allFields.find((f) => f.id === rollupSourceFieldId);
+                  if (!sourceField?.relationTo) return null;
+                  const targetFields = rollupTargetFields.filter(
+                    (f) =>
+                      f.type !== FieldType.RELATION &&
+                      f.type !== FieldType.RELATION_SUBTABLE &&
+                      f.type !== FieldType.COUNT &&
+                      f.type !== FieldType.LOOKUP &&
+                      f.type !== FieldType.FORMULA &&
+                      f.type !== FieldType.ROLLUP
+                  );
+                  return (
+                    <>
+                      <Label>汇总字段</Label>
+                      <Select value={rollupTargetFieldKey} onValueChange={(value) => {
+                        setRollupTargetFieldKey(value ?? "");
+                        setRollupAggregateType("");
+                      }}>
+                        <SelectTrigger>
+                          <SelectValue placeholder="选择要汇总的字段">
+                            {rollupTargetFieldKey
+                              ? targetFields.find((f) => f.key === rollupTargetFieldKey)?.label ?? rollupTargetFieldKey
+                              : null}
+                          </SelectValue>
+                        </SelectTrigger>
+                        <SelectContent>
+                          {targetFields.map((f) => (
+                            <SelectItem key={f.key} value={f.key}>
+                              {f.label} ({f.type})
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </>
+                  );
+                })()}
+
+                {rollupTargetFieldKey && (() => {
+                  const targetField = rollupTargetFields.find((f) => f.key === rollupTargetFieldKey);
+                  if (!targetField) return null;
+                  const aggs = getAvailableRollupAggregates(targetField.type as FieldType);
+                  return (
+                    <>
+                      <Label>聚合方式</Label>
+                      <Select value={rollupAggregateType} onValueChange={(v) => setRollupAggregateType(v as RollupAggregateType)}>
+                        <SelectTrigger>
+                          <SelectValue placeholder="选择聚合方式" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {aggs.map((agg) => (
+                            <SelectItem key={agg.value} value={agg.value}>
+                              {agg.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </>
+                  );
+                })()}
+
+                <p className="text-xs text-muted-foreground">
+                  从关联记录聚合指定字段值，只读展示
                 </p>
               </div>
             )}
@@ -1118,6 +1316,7 @@ export function FieldConfigForm({
             )}
 
             {fieldType !== FieldType.COUNT && fieldType !== FieldType.LOOKUP &&
+              fieldType !== FieldType.ROLLUP &&
               fieldType !== FieldType.FORMULA &&
               fieldType !== FieldType.AUTO_NUMBER && fieldType !== FieldType.SYSTEM_TIMESTAMP &&
               fieldType !== FieldType.SYSTEM_USER && (

--- a/src/components/data/field-config-list.tsx
+++ b/src/components/data/field-config-list.tsx
@@ -44,6 +44,7 @@ const FIELD_TYPE_LABELS: Record<FieldType, string> = {
   [FieldType.FORMULA]: "公式",
   [FieldType.COUNT]: "计数",
   [FieldType.LOOKUP]: "查找",
+  [FieldType.ROLLUP]: "汇总",
 };
 
 function buildInverseFieldPreview(key: string): string {

--- a/src/components/data/views/find-replace-bar.tsx
+++ b/src/components/data/views/find-replace-bar.tsx
@@ -14,6 +14,7 @@ const SKIP_REPLACE_TYPES: Set<string> = new Set([
   FieldType.RELATION_SUBTABLE,
   FieldType.COUNT,
   FieldType.LOOKUP,
+  FieldType.ROLLUP,
   FieldType.FORMULA,
   FieldType.FILE,
   FieldType.BOOLEAN,

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -152,7 +152,6 @@ function getFrozenStyle(
     position: "sticky",
     left,
     zIndex: index === frozenFieldCount - 1 ? 4 : 3,
-    backgroundColor: "hsl(var(--background))",
   };
 }
 
@@ -186,9 +185,9 @@ function DraggableColumnHeader({
     <th
       ref={ref}
       className={cn(
-        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 relative border-r border-border",
-        isDragging ? "opacity-50 bg-muted" : "cursor-grab active:cursor-grabbing",
-        frozenStyle && "bg-muted",
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 relative border-r border-neutral-400",
+        isDragging ? "opacity-50 bg-muted" : "bg-muted cursor-grab active:cursor-grabbing",
+        frozenStyle && "bg-muted isolate",
         frozenFieldCount && frozenFieldCount > 0 && index === frozenFieldCount - 1 && "frozen-last-col"
       )}
       style={{ width: columnWidth, ...(frozenStyle ?? {}) }}
@@ -679,6 +678,7 @@ export function GridView({
   const READONLY_FIELD_TYPES: readonly string[] = [
     FieldType.AUTO_NUMBER, FieldType.SYSTEM_TIMESTAMP, FieldType.SYSTEM_USER,
     FieldType.FORMULA, FieldType.RELATION_SUBTABLE, FieldType.COUNT, FieldType.LOOKUP,
+    FieldType.ROLLUP,
   ];
 
   const computeFillValue = useCallback((fieldType: string, originalValue: unknown, step: number, mode: "increment" | "copy"): unknown => {
@@ -1125,6 +1125,7 @@ export function GridView({
     const readOnlyTypes: Set<FieldType> = new Set([
       FieldType.RELATION_SUBTABLE, FieldType.AUTO_NUMBER,
       FieldType.SYSTEM_TIMESTAMP, FieldType.SYSTEM_USER, FieldType.FORMULA,
+      FieldType.ROLLUP,
     ]);
     const data: Record<string, unknown> = {};
     for (const field of orderedVisibleFields) {
@@ -1409,7 +1410,7 @@ export function GridView({
       const rowContent = (
         <>
           <td
-            className="w-10 sticky left-0 z-[5] bg-background border-r px-1"
+            className="w-10 sticky left-0 z-[5] bg-background isolate border-r px-1"
             onContextMenu={(e) => captureRowHeader(e, record.id, flatRowIndex)}
           >
             <Checkbox
@@ -1454,12 +1455,12 @@ export function GridView({
                 data-col={fieldIndex}
                 style={Object.keys(mergedStyle).length > 0 ? mergedStyle : undefined}
                 className={cn(
-                  "align-middle border-r border-border", rhClasses.td,
+                  "align-middle border-r border-neutral-400", rhClasses.td,
                   // Only apply overflow-hidden when NOT editing a field with a dropdown (RELATION)
                   !(isEditing && field.type === FieldType.RELATION) && "overflow-hidden",
                   (rowHeight ?? 40) < 56 && "whitespace-nowrap",
                   rhClasses.text,
-                  frozenTdStyle && "bg-background",
+                  frozenTdStyle && "bg-background isolate",
                   frozenFieldCountValue > 0 &&
                     fieldIndex === frozenFieldCountValue - 1 &&
                     "frozen-last-col relative",
@@ -1679,7 +1680,7 @@ export function GridView({
           </colgroup>
           <DragDropProvider onDragEnd={handleColumnDragEnd}>
             <thead className="[&_tr]:border-b">
-              <tr className="border-b transition-colors hover:bg-muted/50 sticky top-0 z-10 bg-muted">
+              <tr className="border-b sticky top-0 z-10 bg-muted">
               <th className="w-10 h-10 sticky left-0 z-[13] bg-muted border-r px-1">
                 <Checkbox
                   checked={records.length > 0 && selectedIdsSet.size === records.length}
@@ -1732,7 +1733,7 @@ export function GridView({
                 </DraggableColumnHeader>
               );
               })}
-              <th className="h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 w-[80px]">操作</th>
+              <th className="h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 w-[80px] bg-muted">操作</th>
             </tr>
           </thead>
         </DragDropProvider>
@@ -1808,7 +1809,7 @@ export function GridView({
                   className="border-b hover:bg-primary/5 cursor-pointer group"
                   onClick={handleQuickAddRow}
                 >
-                  <td className="w-10 sticky left-0 z-[5] bg-background border-r" />
+                  <td className="w-10 sticky left-0 z-[5] bg-background isolate border-r" />
                   {canDragSort && <td className="w-8" />}
                   <td
                     colSpan={orderedVisibleFields.length + 1}
@@ -1831,12 +1832,12 @@ export function GridView({
               <td className="p-2 text-xs text-muted-foreground w-10" />
               {orderedVisibleFields.map((field) => {
                 const agg = columnAggregations?.[field.key];
-                if (!agg) return <td key={field.key} className="p-2 border-r border-border" />;
+                if (!agg) return <td key={field.key} className="p-2 border-r border-neutral-400" />;
                 const summary = summaryData[field.key];
                 return (
                   <td
                     key={field.key}
-                    className="p-2 text-xs text-muted-foreground cursor-pointer hover:bg-muted/50 border-r border-border"
+                    className="p-2 text-xs text-muted-foreground cursor-pointer hover:bg-muted/50 border-r border-neutral-400"
                     style={{ width: columnWidths[field.key] ?? DEFAULT_COL_WIDTH }}
                     onClick={() => {
                       const cycle = getAvailableAggTypes(field.type);

--- a/src/lib/format-cell.tsx
+++ b/src/lib/format-cell.tsx
@@ -211,6 +211,11 @@ export function formatCellValue(
         return <span className="text-muted-foreground">{value.join(", ")}</span>;
       }
       return <span className="text-muted-foreground">{String(value)}</span>;
+    case FieldType.ROLLUP:
+      if (value === null || value === undefined) return <span className="text-zinc-400">-</span>;
+      if (typeof value === "number") return <span className="text-muted-foreground">{value.toLocaleString()}</span>;
+      if (Array.isArray(value)) return <span className="text-muted-foreground">{value.join(", ")}</span>;
+      return <span className="text-muted-foreground">{String(value)}</span>;
     default:
       return String(value);
   }
@@ -236,6 +241,7 @@ export function formatCellText(field: DataFieldItem, value: unknown): string {
     case FieldType.FORMULA:
     case FieldType.COUNT:
     case FieldType.LOOKUP:
+    case FieldType.ROLLUP:
       return String(value ?? "");
     default:
       return String(value);

--- a/src/lib/services/data-record.service.ts
+++ b/src/lib/services/data-record.service.ts
@@ -43,7 +43,7 @@ interface FieldChange {
 }
 
 const SKIP_HISTORY_FIELD_TYPES = new Set([
-  "RELATION_SUBTABLE", "SYSTEM_TIMESTAMP", "SYSTEM_USER", "FORMULA", "COUNT",
+  "RELATION_SUBTABLE", "SYSTEM_TIMESTAMP", "SYSTEM_USER", "FORMULA", "COUNT", "ROLLUP",
 ]);
 
 function detectFieldChanges(
@@ -251,7 +251,7 @@ function splitRecordDataByFieldType(
       continue;
     }
     // Skip computed read-only fields — they are recalculated by refreshRelationSnapshots
-    if (fieldType === "COUNT" || fieldType === "LOOKUP") {
+    if (fieldType === "COUNT" || fieldType === "LOOKUP" || fieldType === "ROLLUP") {
       continue;
     }
 
@@ -1236,7 +1236,8 @@ export function validateRecordData(
       field.type === "SYSTEM_USER" ||
       field.type === "FORMULA" ||
       field.type === "COUNT" ||
-      field.type === "LOOKUP"
+      field.type === "LOOKUP" ||
+      field.type === "ROLLUP"
     ) {
       continue;
     }

--- a/src/lib/services/data-relation.service.ts
+++ b/src/lib/services/data-relation.service.ts
@@ -1,6 +1,7 @@
 import type {
   RelationCardinality,
   RelationSubtableValueItem,
+  RollupAggregateType,
   ServiceResult,
 } from "@/types/data-table";
 import { parseFieldOptions } from "@/types/data-table";
@@ -346,6 +347,50 @@ async function lockRelationRecords(
   );
 }
 
+// ─── Rollup aggregation ──────────────────────────────────────────────
+
+function computeRollupAggregate(
+  values: unknown[],
+  aggregateType: RollupAggregateType
+): unknown {
+  if (values.length === 0) {
+    if (aggregateType === "COUNT" || aggregateType === "COUNTA" ||
+        aggregateType === "TRUE_COUNT" || aggregateType === "FALSE_COUNT") {
+      return 0;
+    }
+    return null;
+  }
+
+  switch (aggregateType) {
+    case "SUM":
+      return values.reduce((s: number, v) => s + (Number(v) || 0), 0);
+    case "AVG": {
+      const nums = values.map(Number).filter((n) => !isNaN(n));
+      return nums.length > 0 ? nums.reduce((s, v) => s + v, 0) / nums.length : null;
+    }
+    case "MIN": {
+      const nums = values.map(Number).filter((n) => !isNaN(n));
+      return nums.length > 0 ? Math.min(...nums) : null;
+    }
+    case "MAX": {
+      const nums = values.map(Number).filter((n) => !isNaN(n));
+      return nums.length > 0 ? Math.max(...nums) : null;
+    }
+    case "COUNT":
+      return values.length;
+    case "COUNTA":
+      return values.filter((v) => v !== null && v !== undefined && v !== "").length;
+    case "ARRAYJOIN":
+      return values.map(String).join(", ");
+    case "ARRAYUNIQUE":
+      return [...new Set(values.map(String))];
+    case "TRUE_COUNT":
+      return values.filter((v) => v === true || v === 1 || v === "true").length;
+    case "FALSE_COUNT":
+      return values.filter((v) => v !== true && v !== 1 && v !== "true").length;
+  }
+}
+
 async function refreshRelationSnapshotsForRecords(
   tx: RelationTxClient,
   recordIds: Iterable<string>
@@ -392,7 +437,15 @@ async function refreshRelationSnapshotsForRecords(
     },
   });
 
-  // Load RELATION fields for COUNT/Lookup source resolution
+  // Load ROLLUP fields for aggregation computation
+  const rollupFields = await tx.dataField.findMany({
+    where: {
+      tableId: { in: tableIds },
+      type: "ROLLUP",
+    },
+  });
+
+  // Load RELATION fields for COUNT/Lookup/Rollup source resolution
   const relationLinkFields = await tx.dataField.findMany({
     where: {
       tableId: { in: tableIds },
@@ -400,7 +453,7 @@ async function refreshRelationSnapshotsForRecords(
     },
   });
 
-  if (relationFields.length === 0 && countFields.length === 0 && lookupFields.length === 0) {
+  if (relationFields.length === 0 && countFields.length === 0 && lookupFields.length === 0 && rollupFields.length === 0) {
     return;
   }
 
@@ -424,6 +477,15 @@ async function refreshRelationSnapshotsForRecords(
   for (const field of lookupFields) {
     lookupFieldsByTableId.set(field.tableId, [
       ...(lookupFieldsByTableId.get(field.tableId) ?? []),
+      field,
+    ]);
+  }
+
+  // Group rollupFields by tableId
+  const rollupFieldsByTableId = new Map<string, RelationFieldRow[]>();
+  for (const field of rollupFields) {
+    rollupFieldsByTableId.set(field.tableId, [
+      ...(rollupFieldsByTableId.get(field.tableId) ?? []),
       field,
     ]);
   }
@@ -464,14 +526,25 @@ async function refreshRelationSnapshotsForRecords(
     }
   }
 
-  // Collect linked record IDs from RELATION fields for LOOKUP resolution
-  if (lookupFields.length > 0 || countFields.length > 0) {
+  // Collect linked record IDs from RELATION fields for LOOKUP/ROLLUP resolution
+  if (lookupFields.length > 0 || countFields.length > 0 || rollupFields.length > 0) {
     for (const record of records) {
       const recordData = toRecordData(record.data);
       for (const lookupField of lookupFieldsByTableId.get(record.tableId) ?? []) {
         const opts = parseFieldOptions(lookupField.options);
         if (!opts.lookupSourceFieldId || !opts.lookupTargetFieldKey) continue;
         const sourceField = sourceFieldById.get(opts.lookupSourceFieldId);
+        if (sourceField?.type === "RELATION") {
+          const linkedId = recordData[sourceField.key];
+          if (typeof linkedId === "string" && linkedId) {
+            relatedRecordIds.add(linkedId);
+          }
+        }
+      }
+      for (const rollupField of rollupFieldsByTableId.get(record.tableId) ?? []) {
+        const opts = parseFieldOptions(rollupField.options);
+        if (!opts.rollupSourceFieldId || !opts.rollupTargetFieldKey) continue;
+        const sourceField = sourceFieldById.get(opts.rollupSourceFieldId);
         if (sourceField?.type === "RELATION") {
           const linkedId = recordData[sourceField.key];
           if (typeof linkedId === "string" && linkedId) {
@@ -599,6 +672,38 @@ async function refreshRelationSnapshotsForRecords(
       }
     }
 
+    // Compute ROLLUP field values
+    for (const rollupField of rollupFieldsByTableId.get(record.tableId) ?? []) {
+      const opts = parseFieldOptions(rollupField.options);
+      if (!opts.rollupSourceFieldId || !opts.rollupTargetFieldKey || !opts.rollupAggregateType) continue;
+      const sourceField = sourceFieldById.get(opts.rollupSourceFieldId);
+      if (!sourceField) continue;
+
+      if (sourceField.type === "RELATION_SUBTABLE") {
+        const snapshots = snapshotItemsByFieldId.get(opts.rollupSourceFieldId) ?? [];
+        const targetKey = opts.rollupTargetFieldKey;
+        const values = snapshots.map((r: RelationSubtableValueItem) => {
+          const recordData = relatedRecordById.get(r.targetRecordId);
+          if (recordData && targetKey) return recordData[targetKey as keyof typeof recordData] as unknown;
+          return r.attributes?.[targetKey] ?? null;
+        });
+        nextData[rollupField.key] = computeRollupAggregate(values, opts.rollupAggregateType as RollupAggregateType);
+      } else if (sourceField.type === "RELATION") {
+        const sourceValue = nextData[sourceField.key];
+        const linkedRecordId = (typeof sourceValue === "object" && sourceValue !== null)
+          ? (sourceValue as Record<string, unknown>).id as string | undefined
+          : typeof sourceValue === "string" && sourceValue
+            ? sourceValue
+            : undefined;
+        if (linkedRecordId) {
+          const linkedRecordData = relatedRecordById.get(linkedRecordId);
+          nextData[rollupField.key] = linkedRecordData?.[opts.rollupTargetFieldKey] ?? null;
+        } else {
+          nextData[rollupField.key] = null;
+        }
+      }
+    }
+
     await tx.dataRecord.update({
       where: { id: record.id },
       data: { data: nextData },
@@ -623,7 +728,11 @@ export async function backfillCountFieldValues(
     where: { tableId, type: "LOOKUP" },
   });
 
-  if (countFields.length === 0 && lookupFields.length === 0) {
+  const rollupFields = await db.dataField.findMany({
+    where: { tableId, type: "ROLLUP" },
+  });
+
+  if (countFields.length === 0 && lookupFields.length === 0 && rollupFields.length === 0) {
     return { success: true, data: null };
   }
 

--- a/src/types/data-table.ts
+++ b/src/types/data-table.ts
@@ -85,6 +85,12 @@ export interface FieldOptions {
   lookupSourceFieldId?: string;
   /** LOOKUP: target field key in the related table to read from */
   lookupTargetFieldKey?: string;
+  /** ROLLUP: source relation field ID */
+  rollupSourceFieldId?: string;
+  /** ROLLUP: target field key in the related table to aggregate */
+  rollupTargetFieldKey?: string;
+  /** ROLLUP: aggregation function */
+  rollupAggregateType?: RollupAggregateType;
 }
 
 export function parseFieldOptions(raw: unknown): FieldOptions {
@@ -257,6 +263,11 @@ export type AggregateType =
   | "latest"
   | "checked"
   | "unchecked";
+
+export type RollupAggregateType =
+  | "SUM" | "AVG" | "MIN" | "MAX" | "COUNT" | "COUNTA"
+  | "ARRAYJOIN" | "ARRAYUNIQUE"
+  | "TRUE_COUNT" | "FALSE_COUNT";
 
 export interface SummaryRowData {
   [fieldKey: string]: {

--- a/src/validators/data-table.ts
+++ b/src/validators/data-table.ts
@@ -52,6 +52,14 @@ export const dataFieldItemSchema = z.object({
     z.object({ kind: z.enum(["created", "updated"]) }),
     z.object({ countSourceFieldId: z.string() }),
     z.object({ lookupSourceFieldId: z.string(), lookupTargetFieldKey: z.string() }),
+    z.object({
+      rollupSourceFieldId: z.string(),
+      rollupTargetFieldKey: z.string(),
+      rollupAggregateType: z.enum([
+        "SUM", "AVG", "MIN", "MAX", "COUNT", "COUNTA",
+        "ARRAYJOIN", "ARRAYUNIQUE", "TRUE_COUNT", "FALSE_COUNT",
+      ]),
+    }),
   ]).nullable().optional(),
   relationTo: z.string().nullable().optional(),
   displayField: z.string().nullable().optional(),


### PR DESCRIPTION
## Summary
- 新增 ROLLUP 字段类型，支持对关联记录的指定字段做聚合计算
- 支持 10 种聚合函数：SUM、AVG、MIN、MAX、COUNT、COUNTA、ARRAYJOIN、ARRAYUNIQUE、TRUE_COUNT、FALSE_COUNT
- RELATION 源直接取值（等同 LOOKUP），RELATION_SUBTABLE 源支持多值聚合
- 聚合选项根据目标字段类型自动筛选
- 编辑页面 RELATION 变更后 ROLLUP 即时刷新
- 新增字段自动回填已有记录

## 涉及文件
| 文件 | 改动 |
|------|------|
| `prisma/schema.prisma` | FieldType 枚举新增 ROLLUP |
| `src/types/data-table.ts` | RollupAggregateType + FieldOptions 扩展 |
| `src/validators/data-table.ts` | options union 新增 rollup schema |
| `src/lib/services/data-relation.service.ts` | computeRollupAggregate + ROLLUP 值计算 |
| `src/lib/services/data-record.service.ts` | skip ROLLUP 验证/分割/审计 |
| `src/app/api/data-tables/[id]/fields/route.ts` | ROLLUP 回填触发 |
| `src/components/data/field-config-form.tsx` | ROLLUP 配置 UI（3 个 Select） |
| `src/components/data/field-config-list.tsx` | FIELD_TYPE_LABELS 新增汇总 |
| `src/lib/format-cell.tsx` | ROLLUP 单元格展示 |
| `src/components/data/dynamic-record-form.tsx` | ROLLUP 只读表单 + 客户端刷新 |
| `src/components/data/views/grid-view.tsx` | ROLLUP 只读/排除复制 |
| `src/components/data/views/find-replace-bar.tsx` | SKIP_REPLACE_TYPES |

## Test plan
- [x] 字段配置 UI 正确显示"汇总"选项
- [x] 聚合方式根据目标字段类型筛选（TEXT→COUNT/COUNTA/ARRAYJOIN/ARRAYUNIQUE）
- [x] 字段成功保存到数据库
- [x] 表格视图正确显示 ROLLUP 列
- [x] 编辑页面显示只读 ROLLUP 字段
- [x] RELATION 变更后 ROLLUP 即时刷新
- [ ] RELATION_SUBTABLE 源的多值聚合测试
- [ ] 不同聚合类型测试（SUM、AVG 等）

Closes #88