### PR TITLE
[Feature] 条件 Rollup：带过滤条件的关联记录聚合

### DIFF
--- a/src/app/api/data-tables/[id]/fields/route.ts
+++ b/src/app/api/data-tables/[id]/fields/route.ts
@@ -145,8 +145,15 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     const hasNewCountFields = addedFields.some((f) => f.type === FieldType.COUNT);
     const hasNewLookupFields = addedFields.some((f) => f.type === FieldType.LOOKUP);
     const hasNewRollupFields = addedFields.some((f) => f.type === FieldType.ROLLUP);
+    // Detect ROLLUP option changes (e.g. conditions added/modified) to trigger recomputation
+    const rollupOptionChanged = updatedFields.some((f) => {
+      if (f.type !== FieldType.ROLLUP || !f.id) return false;
+      const oldField = existingFieldById.get(f.id);
+      if (!oldField) return false;
+      return JSON.stringify(oldField.options) !== JSON.stringify(f.options);
+    });
     let backfillWarning = false;
-    if (hasNewCountFields || hasNewLookupFields || hasNewRollupFields) {
+    if (hasNewCountFields || hasNewLookupFields || hasNewRollupFields || rollupOptionChanged) {
       try {
         await backfillCountFieldValues(id);
       } catch (err) {

--- a/src/components/data/field-config-form.tsx
+++ b/src/components/data/field-config-form.tsx
@@ -30,7 +30,7 @@ import type {
 } from "@/types/data-table";
 import { parseSelectOptions, SELECT_COLORS } from "@/types/data-table";
 import { parseFieldOptions } from "@/types/data-table";
-import type { RollupAggregateType } from "@/types/data-table";
+import type { RollupAggregateType, FilterCondition, FilterGroup } from "@/types/data-table";
 import type { DataFieldInput } from "@/validators/data-table";
 import { FormulaEditor } from "@/components/data/formula-editor";
 import { parseFormula, evaluateFormula, detectCircularRefs } from "@/lib/formula";
@@ -264,6 +264,10 @@ export function FieldConfigForm({
     return (opts.rollupAggregateType as RollupAggregateType) ?? "";
   });
   const [rollupTargetFields, setRollupTargetFields] = useState<DataFieldItem[]>([]);
+  const [rollupConditions, setRollupConditions] = useState<FilterGroup[]>(() => {
+    const opts = parseFieldOptions(field?.options);
+    return (opts.rollupConditions as FilterGroup[]) ?? [];
+  });
 
   // Load target table fields when lookup source field changes
   useEffect(() => {
@@ -607,7 +611,11 @@ export function FieldConfigForm({
     } else if (fieldType === FieldType.LOOKUP) {
       fieldOptions = { lookupSourceFieldId, lookupTargetFieldKey };
     } else if (fieldType === FieldType.ROLLUP) {
-      fieldOptions = { rollupSourceFieldId, rollupTargetFieldKey, rollupAggregateType: rollupAggregateType as RollupAggregateType };
+      const srcField = allFields.find((f) => f.id === rollupSourceFieldId);
+      const hasConditions = srcField?.type === "RELATION_SUBTABLE" && rollupConditions.some((g) => g.conditions.length > 0);
+      fieldOptions = hasConditions
+        ? { rollupSourceFieldId, rollupTargetFieldKey, rollupAggregateType: rollupAggregateType as RollupAggregateType, rollupConditions: rollupConditions.filter((g) => g.conditions.length > 0) }
+        : { rollupSourceFieldId, rollupTargetFieldKey, rollupAggregateType: rollupAggregateType as RollupAggregateType };
     } else if (fieldType === FieldType.SYSTEM_TIMESTAMP || fieldType === FieldType.SYSTEM_USER) {
       fieldOptions = { kind: systemFieldKind };
     }
@@ -922,6 +930,7 @@ export function FieldConfigForm({
                   setRollupSourceFieldId(value ?? "");
                   setRollupTargetFieldKey("");
                   setRollupAggregateType("");
+                  setRollupConditions([]);
                 }}>
                   <SelectTrigger>
                     <SelectValue placeholder="选择源关联字段">
@@ -999,6 +1008,166 @@ export function FieldConfigForm({
                           ))}
                         </SelectContent>
                       </Select>
+                    </>
+                  );
+                })()}
+
+                {/* Rollup filter conditions — only for RELATION_SUBTABLE source */}
+                {rollupSourceFieldId && allFields.find((f) => f.id === rollupSourceFieldId)?.type === "RELATION_SUBTABLE" && (() => {
+                  const condTargetFields = rollupTargetFields.filter(
+                    (f) =>
+                      f.type !== "RELATION" &&
+                      f.type !== "RELATION_SUBTABLE" &&
+                      f.type !== "COUNT" &&
+                      f.type !== "LOOKUP" &&
+                      f.type !== "FORMULA" &&
+                      f.type !== "ROLLUP"
+                  );
+                  const OPERATOR_OPTIONS = [
+                    { value: "eq", label: "等于" }, { value: "ne", label: "不等于" },
+                    { value: "contains", label: "包含" }, { value: "notcontains", label: "不包含" },
+                    { value: "startswith", label: "开头是" }, { value: "endswith", label: "结尾是" },
+                    { value: "isempty", label: "为空" }, { value: "isnotempty", label: "不为空" },
+                    { value: "gt", label: "大于" }, { value: "lt", label: "小于" },
+                    { value: "gte", label: "大于等于" }, { value: "lte", label: "小于等于" },
+                    { value: "between", label: "范围" },
+                    { value: "in", label: "属于" }, { value: "notin", label: "不属于" },
+                  ];
+                  const NO_VALUE_OPS = ["isempty", "isnotempty"];
+
+                  if (condTargetFields.length === 0) return null;
+                  return (
+                    <>
+                      <Label>筛选条件（可选）</Label>
+                      <p className="text-xs text-muted-foreground -mt-1">仅汇总满足条件的关联记录</p>
+                      {rollupConditions.map((group, gi) => (
+                        <div key={gi} className="border rounded-md p-2 space-y-2">
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-1">
+                              <span className="text-xs text-muted-foreground">条件组 {gi + 1}</span>
+                              <Select
+                                value={group.operator}
+                                onValueChange={(v) => {
+                                  const updated = [...rollupConditions];
+                                  updated[gi] = { ...updated[gi], operator: (v ?? "AND") as "AND" | "OR" };
+                                  setRollupConditions(updated);
+                                }}
+                              >
+                                <SelectTrigger className="h-7 w-[80px] text-xs">
+                                  <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  <SelectItem value="AND">AND</SelectItem>
+                                  <SelectItem value="OR">OR</SelectItem>
+                                </SelectContent>
+                              </Select>
+                            </div>
+                            {rollupConditions.length > 1 && (
+                              <Button variant="ghost" size="sm" className="h-7 px-1 text-xs" onClick={() => {
+                                setRollupConditions(rollupConditions.filter((_, i) => i !== gi));
+                              }}>
+                                删除组
+                              </Button>
+                            )}
+                          </div>
+                          {group.conditions.map((cond, ci) => (
+                            <div key={ci} className="flex items-center gap-1">
+                              <Select value={cond.fieldKey} onValueChange={(v) => {
+                                const updated = [...rollupConditions];
+                                const conds = [...updated[gi].conditions];
+                                conds[ci] = { ...conds[ci], fieldKey: v ?? "" };
+                                updated[gi] = { ...updated[gi], conditions: conds };
+                                setRollupConditions(updated);
+                              }}>
+                                <SelectTrigger className="h-7 flex-1 text-xs">
+                                  <SelectValue placeholder="选择字段" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {condTargetFields.map((f) => (
+                                    <SelectItem key={f.key} value={f.key}>{f.label}</SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                              <Select value={cond.op} onValueChange={(v) => {
+                                const updated = [...rollupConditions];
+                                const conds = [...updated[gi].conditions];
+                                conds[ci] = { ...conds[ci], op: (v ?? "eq") as FilterCondition["op"] };
+                                updated[gi] = { ...updated[gi], conditions: conds };
+                                setRollupConditions(updated);
+                              }}>
+                                <SelectTrigger className="h-7 w-[100px] text-xs">
+                                  <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {OPERATOR_OPTIONS.map((o) => (
+                                    <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                              {!NO_VALUE_OPS.includes(cond.op) && (
+                                <Input
+                                  className="h-7 flex-1 text-xs"
+                                  value={
+                                    cond.op === "between"
+                                      ? `${(cond.value as { min: unknown; max: unknown }).min ?? ""}-${(cond.value as { min: unknown; max: unknown }).max ?? ""}`
+                                      : Array.isArray(cond.value)
+                                        ? cond.value.join(",")
+                                        : String(cond.value ?? "")
+                                  }
+                                  onChange={(e) => {
+                                    const raw = e.target.value;
+                                    let newVal: string | number | (string | number)[] | { min: string | number; max: string | number };
+                                    if (cond.op === "between") {
+                                      const parts = raw.split("-").map((s) => s.trim());
+                                      newVal = { min: parts[0] ?? "", max: parts[1] ?? "" };
+                                    } else if (cond.op === "in" || cond.op === "notin") {
+                                      newVal = raw.split(",").map((s) => s.trim()).filter(Boolean);
+                                    } else {
+                                      newVal = raw;
+                                    }
+                                    const updated = [...rollupConditions];
+                                    const conds = [...updated[gi].conditions];
+                                    conds[ci] = { ...conds[ci], value: newVal };
+                                    updated[gi] = { ...updated[gi], conditions: conds };
+                                    setRollupConditions(updated);
+                                  }}
+                                  placeholder={
+                                    cond.op === "between" ? "最小值-最大值"
+                                      : cond.op === "in" || cond.op === "notin" ? "逗号分隔"
+                                      : "值"
+                                  }
+                                />
+                              )}
+                              <Button variant="ghost" size="sm" className="h-7 px-1 text-xs" onClick={() => {
+                                const updated = [...rollupConditions];
+                                const conds = updated[gi].conditions.filter((_, i) => i !== ci);
+                                updated[gi] = { ...updated[gi], conditions: conds };
+                                setRollupConditions(updated);
+                              }}>
+                                ×
+                              </Button>
+                            </div>
+                          ))}
+                          <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={() => {
+                            const updated = [...rollupConditions];
+                            updated[gi] = {
+                              ...updated[gi],
+                              conditions: [...updated[gi].conditions, { fieldKey: condTargetFields[0]?.key ?? "", op: "eq" as const, value: "" }],
+                            };
+                            setRollupConditions(updated);
+                          }}>
+                            + 添加条件
+                          </Button>
+                        </div>
+                      ))}
+                      <Button variant="outline" size="sm" className="w-full text-xs" onClick={() => {
+                        setRollupConditions([...rollupConditions, {
+                          operator: "AND" as const,
+                          conditions: [{ fieldKey: condTargetFields[0]?.key ?? "", op: "eq" as const, value: "" }],
+                        }]);
+                      }}>
+                        + 添加条件组
+                      </Button>
                     </>
                   );
                 })()}

--- a/src/components/data/field-config-form.tsx
+++ b/src/components/data/field-config-form.tsx
@@ -72,6 +72,19 @@ const RELATION_SCHEMA_FIELD_TYPES = FIELD_TYPES.filter(
   (item) => item.value !== FieldType.RELATION && item.value !== FieldType.RELATION_SUBTABLE
 );
 
+const ROLLUP_CONDITION_OPERATOR_OPTIONS = [
+  { value: "eq", label: "等于" }, { value: "ne", label: "不等于" },
+  { value: "contains", label: "包含" }, { value: "notcontains", label: "不包含" },
+  { value: "startswith", label: "开头是" }, { value: "endswith", label: "结尾是" },
+  { value: "isempty", label: "为空" }, { value: "isnotempty", label: "不为空" },
+  { value: "gt", label: "大于" }, { value: "lt", label: "小于" },
+  { value: "gte", label: "大于等于" }, { value: "lte", label: "小于等于" },
+  { value: "between", label: "范围" },
+  { value: "in", label: "属于" }, { value: "notin", label: "不属于" },
+];
+
+const NO_VALUE_OPS = ["isempty", "isnotempty"];
+
 type RelationSchemaFieldDraft = {
   key: string;
   label: string;
@@ -399,6 +412,10 @@ export function FieldConfigForm({
     setRelationFields(relTable?.fields ?? []);
     setFormulaExpression(opts.formula ?? "");
     setCountSourceFieldId(opts.countSourceFieldId ?? "");
+    setRollupSourceFieldId(opts.rollupSourceFieldId ?? "");
+    setRollupTargetFieldKey(opts.rollupTargetFieldKey ?? "");
+    setRollupAggregateType((opts.rollupAggregateType as RollupAggregateType) ?? "");
+    setRollupConditions((opts.rollupConditions as FilterGroup[]) ?? []);
     setSystemFieldKind(opts.kind ?? "created");
     setError("");
   }, [field, availableTables]);
@@ -1023,17 +1040,6 @@ export function FieldConfigForm({
                       f.type !== "FORMULA" &&
                       f.type !== "ROLLUP"
                   );
-                  const OPERATOR_OPTIONS = [
-                    { value: "eq", label: "等于" }, { value: "ne", label: "不等于" },
-                    { value: "contains", label: "包含" }, { value: "notcontains", label: "不包含" },
-                    { value: "startswith", label: "开头是" }, { value: "endswith", label: "结尾是" },
-                    { value: "isempty", label: "为空" }, { value: "isnotempty", label: "不为空" },
-                    { value: "gt", label: "大于" }, { value: "lt", label: "小于" },
-                    { value: "gte", label: "大于等于" }, { value: "lte", label: "小于等于" },
-                    { value: "between", label: "范围" },
-                    { value: "in", label: "属于" }, { value: "notin", label: "不属于" },
-                  ];
-                  const NO_VALUE_OPS = ["isempty", "isnotempty"];
 
                   if (condTargetFields.length === 0) return null;
                   return (
@@ -1099,7 +1105,7 @@ export function FieldConfigForm({
                                   <SelectValue />
                                 </SelectTrigger>
                                 <SelectContent>
-                                  {OPERATOR_OPTIONS.map((o) => (
+                                  {ROLLUP_CONDITION_OPERATOR_OPTIONS.map((o) => (
                                     <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
                                   ))}
                                 </SelectContent>

--- a/src/lib/services/data-relation.service.ts
+++ b/src/lib/services/data-relation.service.ts
@@ -1,4 +1,6 @@
 import type {
+  FilterCondition,
+  FilterGroup,
   RelationCardinality,
   RelationSubtableValueItem,
   RollupAggregateType,
@@ -347,6 +349,68 @@ async function lockRelationRecords(
   );
 }
 
+// ─── Rollup condition filtering ──────────────────────────────────────────
+
+function evaluateFilterCondition(
+  recordData: Record<string, unknown>,
+  condition: FilterCondition
+): boolean {
+  const raw = recordData[condition.fieldKey];
+  switch (condition.op) {
+    case "eq":
+      return String(raw ?? "") === String(condition.value);
+    case "ne":
+      return String(raw ?? "") !== String(condition.value);
+    case "contains":
+      return String(raw ?? "").includes(String(condition.value));
+    case "notcontains":
+      return !String(raw ?? "").includes(String(condition.value));
+    case "startswith":
+      return String(raw ?? "").startsWith(String(condition.value));
+    case "endswith":
+      return String(raw ?? "").endsWith(String(condition.value));
+    case "isempty":
+      return raw === undefined || raw === null || raw === "";
+    case "isnotempty":
+      return raw !== undefined && raw !== null && raw !== "";
+    case "gt":
+      return Number(raw) > Number(condition.value);
+    case "lt":
+      return Number(raw) < Number(condition.value);
+    case "gte":
+      return Number(raw) >= Number(condition.value);
+    case "lte":
+      return Number(raw) <= Number(condition.value);
+    case "between": {
+      const range = condition.value as { min: number | string; max: number | string };
+      const num = Number(raw);
+      return num >= Number(range.min) && num <= Number(range.max);
+    }
+    case "in":
+      return Array.isArray(condition.value) &&
+        condition.value.some((v) => String(raw ?? "") === String(v));
+    case "notin":
+      return !Array.isArray(condition.value) ||
+        !condition.value.some((v) => String(raw ?? "") === String(v));
+    default:
+      return true;
+  }
+}
+
+function recordMatchesFilterGroups(
+  recordData: Record<string, unknown>,
+  groups: FilterGroup[] | undefined
+): boolean {
+  if (!groups || groups.length === 0) return true;
+  // Groups are OR-combined; conditions within a group follow group.operator
+  return groups.some((group) => {
+    if (group.conditions.length === 0) return true;
+    return group.operator === "OR"
+      ? group.conditions.some((c) => evaluateFilterCondition(recordData, c))
+      : group.conditions.every((c) => evaluateFilterCondition(recordData, c));
+  });
+}
+
 // ─── Rollup aggregation ──────────────────────────────────────────────
 
 function computeRollupAggregate(
@@ -680,8 +744,16 @@ async function refreshRelationSnapshotsForRecords(
       if (!sourceField) continue;
 
       if (sourceField.type === "RELATION_SUBTABLE") {
-        const snapshots = snapshotItemsByFieldId.get(opts.rollupSourceFieldId) ?? [];
+        let snapshots = snapshotItemsByFieldId.get(opts.rollupSourceFieldId) ?? [];
         const targetKey = opts.rollupTargetFieldKey;
+        const conditions = opts.rollupConditions as FilterGroup[] | undefined;
+        // Apply filter conditions before aggregation
+        if (conditions && conditions.length > 0) {
+          snapshots = snapshots.filter((r: RelationSubtableValueItem) => {
+            const recordData = relatedRecordById.get(r.targetRecordId);
+            return recordData ? recordMatchesFilterGroups(recordData, conditions) : true;
+          });
+        }
         const values = snapshots.map((r: RelationSubtableValueItem) => {
           const recordData = relatedRecordById.get(r.targetRecordId);
           if (recordData && targetKey) return recordData[targetKey as keyof typeof recordData] as unknown;

--- a/src/lib/services/data-relation.service.ts
+++ b/src/lib/services/data-relation.service.ts
@@ -386,12 +386,14 @@ function evaluateFilterCondition(
       const num = Number(raw);
       return num >= Number(range.min) && num <= Number(range.max);
     }
-    case "in":
-      return Array.isArray(condition.value) &&
-        condition.value.some((v) => String(raw ?? "") === String(v));
-    case "notin":
-      return !Array.isArray(condition.value) ||
-        !condition.value.some((v) => String(raw ?? "") === String(v));
+    case "in": {
+      const inValues = Array.isArray(condition.value) ? condition.value : [condition.value];
+      return inValues.some((v) => String(raw ?? "") === String(v));
+    }
+    case "notin": {
+      const notInValues = Array.isArray(condition.value) ? condition.value : [condition.value];
+      return !notInValues.some((v) => String(raw ?? "") === String(v));
+    }
     default:
       return true;
   }

--- a/src/types/data-table.ts
+++ b/src/types/data-table.ts
@@ -91,6 +91,8 @@ export interface FieldOptions {
   rollupTargetFieldKey?: string;
   /** ROLLUP: aggregation function */
   rollupAggregateType?: RollupAggregateType;
+  /** ROLLUP: filter conditions applied to target records before aggregation */
+  rollupConditions?: FilterGroup[];
 }
 
 export function parseFieldOptions(raw: unknown): FieldOptions {

--- a/src/validators/data-table.ts
+++ b/src/validators/data-table.ts
@@ -59,6 +59,23 @@ export const dataFieldItemSchema = z.object({
         "SUM", "AVG", "MIN", "MAX", "COUNT", "COUNTA",
         "ARRAYJOIN", "ARRAYUNIQUE", "TRUE_COUNT", "FALSE_COUNT",
       ]),
+      rollupConditions: z.array(z.object({
+        operator: z.enum(["AND", "OR"]),
+        conditions: z.array(z.object({
+          fieldKey: z.string(),
+          op: z.enum([
+            "eq", "ne", "gt", "lt", "gte", "lte",
+            "contains", "notcontains", "startswith", "endswith",
+            "isempty", "isnotempty",
+            "between", "in", "notin",
+          ]),
+          value: z.union([
+            z.string(), z.number(),
+            z.array(z.union([z.string(), z.number()])),
+            z.object({ min: z.union([z.string(), z.number()]), max: z.union([z.string(), z.number()]) }),
+          ]),
+        })),
+      })).optional(),
     }),
   ]).nullable().optional(),
   relationTo: z.string().nullable().optional(),

--- a/src/validators/data-table.ts
+++ b/src/validators/data-table.ts
@@ -29,6 +29,28 @@ export const businessKeySchema = z.object({
   fieldKeys: z.array(z.string()).min(1).max(5),
 });
 
+// ========== Filter Schemas (shared by views and rollup conditions) ==========
+
+export const filterConditionSchema = z.object({
+  fieldKey: z.string(),
+  op: z.enum([
+    "eq", "ne", "gt", "lt", "gte", "lte",
+    "contains", "notcontains", "startswith", "endswith",
+    "isempty", "isnotempty",
+    "between", "in", "notin",
+  ]),
+  value: z.union([
+    z.string(), z.number(),
+    z.array(z.union([z.string(), z.number()])),
+    z.object({ min: z.union([z.string(), z.number()]), max: z.union([z.string(), z.number()]) }),
+  ]),
+});
+
+export const filterGroupSchema = z.object({
+  operator: z.enum(["AND", "OR"]),
+  conditions: z.array(filterConditionSchema),
+});
+
 // ========== Field Schemas ==========
 
 export const dataFieldItemSchema = z.object({
@@ -59,23 +81,7 @@ export const dataFieldItemSchema = z.object({
         "SUM", "AVG", "MIN", "MAX", "COUNT", "COUNTA",
         "ARRAYJOIN", "ARRAYUNIQUE", "TRUE_COUNT", "FALSE_COUNT",
       ]),
-      rollupConditions: z.array(z.object({
-        operator: z.enum(["AND", "OR"]),
-        conditions: z.array(z.object({
-          fieldKey: z.string(),
-          op: z.enum([
-            "eq", "ne", "gt", "lt", "gte", "lte",
-            "contains", "notcontains", "startswith", "endswith",
-            "isempty", "isnotempty",
-            "between", "in", "notin",
-          ]),
-          value: z.union([
-            z.string(), z.number(),
-            z.array(z.union([z.string(), z.number()])),
-            z.object({ min: z.union([z.string(), z.number()]), max: z.union([z.string(), z.number()]) }),
-          ]),
-        })),
-      })).optional(),
+      rollupConditions: z.array(filterGroupSchema).optional(),
     }),
   ]).nullable().optional(),
   relationTo: z.string().nullable().optional(),
@@ -161,26 +167,6 @@ export const patchFieldSchema = z.object({
 export const sortConfigSchema = z.object({
   fieldKey: z.string(),
   order: z.enum(["asc", "desc"]),
-});
-
-export const filterConditionSchema = z.object({
-  fieldKey: z.string(),
-  op: z.enum([
-    "eq", "ne", "gt", "lt", "gte", "lte",
-    "contains", "notcontains", "startswith", "endswith",
-    "isempty", "isnotempty",
-    "between", "in", "notin",
-  ]),
-  value: z.union([
-    z.string(), z.number(),
-    z.array(z.union([z.string(), z.number()])),
-    z.object({ min: z.union([z.string(), z.number()]), max: z.union([z.string(), z.number()]) }),
-  ]),
-});
-
-export const filterGroupSchema = z.object({
-  operator: z.enum(["AND", "OR"]),
-  conditions: z.array(filterConditionSchema),
 });
 
 export const reorderSchema = z.object({


### PR DESCRIPTION
## Summary
- 扩展 ROLLUP 字段支持过滤条件，仅聚合满足条件的关联记录
- 新增 `evaluateFilterCondition` / `recordMatchesFilterGroups` 过滤评估函数，支持全部 15 种运算符
- RELATION_SUBTABLE 源在聚合前应用条件过滤，RELATION（单值）源不受影响
- 字段配置 UI 新增内联条件编辑器（仅 RELATION_SUBTABLE 源显示）
- ROLLUP 选项变更时自动触发重算所有记录

## 涉及文件
| 文件 | 改动 |
|------|------|
| `src/types/data-table.ts` | FieldOptions 新增 `rollupConditions` |
| `src/validators/data-table.ts` | rollup options schema 新增可选 `rollupConditions` |
| `src/lib/services/data-relation.service.ts` | 过滤评估函数 + 聚合前应用过滤 |
| `src/components/data/field-config-form.tsx` | 内联条件编辑器 UI |
| `src/app/api/data-tables/[id]/fields/route.ts` | ROLLUP 选项变更触发重算 |

## Test plan
- [ ] 类型检查通过
- [ ] 添加 RELATION_SUBTABLE 源的 ROLLUP 字段，配置过滤条件
- [ ] 验证仅汇总满足条件的关联记录
- [ ] 无条件时等同普通 ROLLUP（向后兼容）
- [ ] RELATION（单值）源不显示条件编辑器
- [ ] 修改条件后自动重算

Closes #89