### PR TITLE
[Feature] 关联字段筛选和排序增强：支持按关联记录字段值筛选/排序

### DIFF
--- a/src/components/data/column-header.tsx
+++ b/src/components/data/column-header.tsx
@@ -25,6 +25,7 @@ import type {
   FilterCondition,
   SortConfig,
 } from "@/types/data-table";
+import { parseRelationFieldRef } from "@/types/data-table";
 
 interface ColumnHeaderProps {
   field: DataFieldItem;
@@ -32,6 +33,8 @@ interface ColumnHeaderProps {
   sort: SortConfig | null;
   onFilterChange: (filter: FilterCondition | null) => void;
   onSortChange: (sort: SortConfig | null) => void;
+  /** Fetches fields for a related table (by table ID) */
+  onFetchRelatedFields?: (tableId: string) => Promise<DataFieldItem[]>;
   groupBy?: string | null;
   onGroupByChange?: (fieldKey: string | null) => void;
   frozenFieldCount?: number;
@@ -88,7 +91,10 @@ function getOperatorsForType(type: FieldType): FilterOperator[] {
     case FieldType.FORMULA:
       return ["eq", "ne", "gt", "lt", "gte", "lte", "between", "isempty", "isnotempty"];
     case FieldType.COUNT:
+    case FieldType.ROLLUP:
       return ["eq", "ne", "gt", "lt", "gte", "lte", "between", "isempty"];
+    case FieldType.LOOKUP:
+      return ["eq", "ne", "contains", "notcontains", "isempty", "isnotempty"];
     default:
       return ["eq", "ne", "contains", "isempty", "isnotempty"];
   }
@@ -107,10 +113,32 @@ export function ColumnHeader({
   frozenFieldCount,
   index,
   onFrozenFieldCountChange,
+  onFetchRelatedFields,
 }: ColumnHeaderProps) {
   const [open, setOpen] = useState(false);
+
+  const isRelationField = field.type === FieldType.RELATION || field.type === FieldType.RELATION_SUBTABLE;
+  const relationFieldKey = field.key;
+  const relationTableId = field.relationTo;
+
+  // Parse existing filter to detect cross-table reference
+  const existingRef = filter ? parseRelationFieldRef(filter.fieldKey) : null;
+  const initialTargetFieldKey = existingRef?.relationFieldKey === relationFieldKey ? existingRef.targetFieldKey : "";
+
+  const [targetFieldKey, setTargetFieldKey] = useState<string>(initialTargetFieldKey);
+  const [relatedFields, setRelatedFields] = useState<DataFieldItem[]>([]);
+  const [loadingRelated, setLoadingRelated] = useState(false);
+
+  // Resolve target field for operator selection
+  const effectiveFieldType = (() => {
+    if (!isRelationField) return field.type;
+    if (!targetFieldKey) return null; // No target selected yet
+    const tf = relatedFields.find((f) => f.key === targetFieldKey);
+    return tf?.type ?? null;
+  })();
+
   const [filterOp, setFilterOp] = useState<FilterOperator>(
-    filter?.op ?? getOperatorsForType(field.type)[0]
+    filter?.op ?? (effectiveFieldType ? getOperatorsForType(effectiveFieldType)[0] : "eq")
   );
   const [filterValue, setFilterValue] = useState<string>(
     filter
@@ -123,10 +151,31 @@ export function ColumnHeader({
   );
 
   // When popover opens, sync local state with props
-  const handleOpenChange = (nextOpen: boolean) => {
+  const handleOpenChange = async (nextOpen: boolean) => {
     setOpen(nextOpen);
     if (nextOpen) {
-      setFilterOp(filter?.op ?? getOperatorsForType(field.type)[0]);
+      // Parse existing filter for cross-table reference
+      const ref = filter ? parseRelationFieldRef(filter.fieldKey) : null;
+      const tfk = ref?.relationFieldKey === relationFieldKey ? ref.targetFieldKey : "";
+      setTargetFieldKey(tfk);
+
+      // Load related fields if needed
+      if (isRelationField && relationTableId && onFetchRelatedFields) {
+        setLoadingRelated(true);
+        try {
+          const fields = await onFetchRelatedFields(relationTableId);
+          setRelatedFields(fields.filter((f) =>
+            f.type !== "RELATION" && f.type !== "RELATION_SUBTABLE"
+          ));
+        } catch { /* ignore */ }
+        setLoadingRelated(false);
+      }
+
+      const resolvedType = isRelationField
+        ? (tfk ? (relatedFields.find((f) => f.key === tfk)?.type ?? "TEXT") : "TEXT")
+        : field.type;
+
+      setFilterOp(filter?.op ?? getOperatorsForType(resolvedType as FieldType)[0]);
       setFilterValue(
         filter
           ? filter.op === "between"
@@ -140,27 +189,34 @@ export function ColumnHeader({
   };
 
   const handleApplyFilter = () => {
+    const resolvedFieldKey = isRelationField && targetFieldKey
+      ? `${relationFieldKey}.${targetFieldKey}`
+      : field.key;
+    const resolvedType = isRelationField && targetFieldKey
+      ? (relatedFields.find((f) => f.key === targetFieldKey)?.type ?? "TEXT")
+      : field.type;
+
     if (NO_VALUE_OPS.includes(filterOp)) {
-      onFilterChange({ fieldKey: field.key, op: filterOp, value: "" });
+      onFilterChange({ fieldKey: resolvedFieldKey, op: filterOp, value: "" });
     } else if (filterOp === "between") {
       const parts = filterValue.split("-").map((s) => s.trim());
-      const min = field.type === FieldType.NUMBER ? Number(parts[0]) : parts[0] ?? "";
-      const max = field.type === FieldType.NUMBER ? Number(parts[1]) : parts[1] ?? "";
+      const min = resolvedType === FieldType.NUMBER ? Number(parts[0]) : parts[0] ?? "";
+      const max = resolvedType === FieldType.NUMBER ? Number(parts[1]) : parts[1] ?? "";
       if (!isNaN(Number(min)) && !isNaN(Number(max))) {
-        onFilterChange({ fieldKey: field.key, op: filterOp, value: { min, max } });
+        onFilterChange({ fieldKey: resolvedFieldKey, op: filterOp, value: { min, max } });
       }
     } else if (filterOp === "in" || filterOp === "notin") {
       const items = filterValue.split(",").map((s) => s.trim()).filter(Boolean);
       if (items.length > 0) {
-        const value = field.type === FieldType.NUMBER ? items.map(Number) : items;
-        onFilterChange({ fieldKey: field.key, op: filterOp, value });
+        const value = resolvedType === FieldType.NUMBER ? items.map(Number) : items;
+        onFilterChange({ fieldKey: resolvedFieldKey, op: filterOp, value });
       }
     } else if (filterValue) {
       const value: string | number =
-        field.type === FieldType.NUMBER && !isNaN(Number(filterValue))
+        resolvedType === FieldType.NUMBER && !isNaN(Number(filterValue))
           ? Number(filterValue)
           : filterValue;
-      onFilterChange({ fieldKey: field.key, op: filterOp, value });
+      onFilterChange({ fieldKey: resolvedFieldKey, op: filterOp, value });
     }
     setOpen(false);
   };
@@ -171,16 +227,22 @@ export function ColumnHeader({
     setOpen(false);
   };
 
-  const handleSortClick = (order: "asc" | "desc") => {
-    if (sort?.fieldKey === field.key && sort?.order === order) {
-      // Click same sort again -> toggle off
+  const handleSortClick = (order: "asc" | "desc", sortTargetField?: string) => {
+    const resolvedFieldKey = isRelationField && sortTargetField
+      ? `${relationFieldKey}.${sortTargetField}`
+      : field.key;
+    if (sort?.fieldKey === resolvedFieldKey && sort?.order === order) {
       onSortChange(null);
     } else {
-      onSortChange({ fieldKey: field.key, order });
+      onSortChange({ fieldKey: resolvedFieldKey, order });
     }
   };
 
-  const operators = getOperatorsForType(field.type);
+  const operators: FilterOperator[] = effectiveFieldType
+    ? getOperatorsForType(effectiveFieldType)
+    : isRelationField
+      ? (["eq", "isempty"] as FilterOperator[])
+      : getOperatorsForType(field.type);
   const hideValue = NO_VALUE_OPS.includes(filterOp);
 
   // Build filter summary text
@@ -231,12 +293,30 @@ export function ColumnHeader({
         {/* Sort section */}
         <div className="flex flex-col gap-1">
           <Label className="text-xs text-muted-foreground mb-1">排序</Label>
+          {isRelationField && relatedFields.length > 0 && (
+            <Select
+              value={(() => {
+                const sortRef = sort ? parseRelationFieldRef(sort.fieldKey) : null;
+                return sortRef?.relationFieldKey === relationFieldKey ? sortRef.targetFieldKey : field.displayField ?? "";
+              })()}
+              onValueChange={(v) => { if (v) setTargetFieldKey(v); }}
+            >
+              <SelectTrigger size="sm" className="w-full mb-1">
+                <SelectValue placeholder="选择排序依据字段" />
+              </SelectTrigger>
+              <SelectContent>
+                {relatedFields.map((f) => (
+                  <SelectItem key={f.key} value={f.key}>{f.label}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
           <div className="flex gap-1">
             <Button
               variant={sort?.order === "asc" ? "secondary" : "ghost"}
               size="sm"
               className="flex-1 text-xs"
-              onClick={() => handleSortClick("asc")}
+              onClick={() => handleSortClick("asc", isRelationField ? targetFieldKey || undefined : undefined)}
             >
               <ArrowUp className="h-3 w-3 mr-1" />
               升序
@@ -245,7 +325,7 @@ export function ColumnHeader({
               variant={sort?.order === "desc" ? "secondary" : "ghost"}
               size="sm"
               className="flex-1 text-xs"
-              onClick={() => handleSortClick("desc")}
+              onClick={() => handleSortClick("desc", isRelationField ? targetFieldKey || undefined : undefined)}
             >
               <ArrowDown className="h-3 w-3 mr-1" />
               降序
@@ -310,60 +390,94 @@ export function ColumnHeader({
         {/* Filter section */}
         <div className="flex flex-col gap-2">
           <Label className="text-xs text-muted-foreground">筛选</Label>
-          <Select
-            value={filterOp}
-            onValueChange={(v) => {
-              if (!v) return;
-              setFilterOp(v as FilterOperator);
-            }}
-          >
-            <SelectTrigger size="sm" className="w-full">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {operators.map((op) => (
-                <SelectItem key={op} value={op}>
-                  {OPERATOR_LABELS[op]}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-
-          {!hideValue &&
-            (field.type === FieldType.SELECT && field.options && filterOp !== "in" && filterOp !== "notin" ? (
-              <Select
-                value={filterValue}
-                onValueChange={(v) => {
-                  if (!v) return;
-                  setFilterValue(v);
-                }}
-              >
-                <SelectTrigger size="sm" className="w-full">
-                  <SelectValue placeholder="选择值" />
-                </SelectTrigger>
-                <SelectContent>
-                  {parseSelectOptions(field.options).map((opt) => (
-                    <SelectItem key={opt.label} value={opt.label}>
-                      {opt.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            ) : (
-              <Input
-                placeholder={
-                  filterOp === "between"
-                    ? "最小值-最大值（如 10-100）"
-                    : filterOp === "in" || filterOp === "notin"
-                      ? "多个值，逗号分隔"
-                      : "输入值"
+          {isRelationField && relatedFields.length > 0 && (
+            <Select
+              value={targetFieldKey}
+              onValueChange={(v) => {
+                if (!v) return;
+                setTargetFieldKey(v);
+                const tf = relatedFields.find((f) => f.key === v);
+                if (tf) {
+                  setFilterOp(getOperatorsForType(tf.type)[0]);
                 }
-                value={filterValue}
-                onChange={(e) => setFilterValue(e.target.value)}
-                onKeyDown={(e) => e.key === "Enter" && handleApplyFilter()}
-                type={field.type === FieldType.NUMBER && filterOp !== "between" ? "number" : "text"}
-              />
-            ))}
+                setFilterValue("");
+              }}
+            >
+              <SelectTrigger size="sm" className="w-full">
+                <SelectValue placeholder="选择目标字段" />
+              </SelectTrigger>
+              <SelectContent>
+                {relatedFields.map((f) => (
+                  <SelectItem key={f.key} value={f.key}>{f.label}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          {(isRelationField ? targetFieldKey : true) && (
+            <Select
+              value={filterOp}
+              onValueChange={(v) => {
+                if (!v) return;
+                setFilterOp(v as FilterOperator);
+              }}
+            >
+              <SelectTrigger size="sm" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {operators.map((op) => (
+                  <SelectItem key={op} value={op}>
+                    {OPERATOR_LABELS[op]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+
+          {!hideValue && (isRelationField ? targetFieldKey : true) &&
+            (() => {
+              const targetField = isRelationField
+                ? relatedFields.find((f) => f.key === targetFieldKey)
+                : field;
+              const isSelectWithOpts = targetField?.type === FieldType.SELECT && targetField.options && filterOp !== "in" && filterOp !== "notin";
+              if (isSelectWithOpts) {
+                return (
+                  <Select
+                    value={filterValue}
+                    onValueChange={(v) => {
+                      if (!v) return;
+                      setFilterValue(v);
+                    }}
+                  >
+                    <SelectTrigger size="sm" className="w-full">
+                      <SelectValue placeholder="选择值" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {parseSelectOptions(targetField!.options).map((opt: { label: string }) => (
+                        <SelectItem key={opt.label} value={opt.label}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                );
+              }
+              return (
+                <Input
+                  placeholder={
+                    filterOp === "between"
+                      ? "最小值-最大值（如 10-100）"
+                      : filterOp === "in" || filterOp === "notin"
+                        ? "多个值，逗号分隔"
+                        : "输入值"
+                  }
+                  value={filterValue}
+                  onChange={(e) => setFilterValue(e.target.value)}
+                  onKeyDown={(e) => e.key === "Enter" && handleApplyFilter()}
+                  type={effectiveFieldType === FieldType.NUMBER && filterOp !== "between" ? "number" : "text"}
+                />
+              );
+            })()}
         </div>
 
         <Separator />

--- a/src/components/data/column-header.tsx
+++ b/src/components/data/column-header.tsx
@@ -160,19 +160,21 @@ export function ColumnHeader({
       setTargetFieldKey(tfk);
 
       // Load related fields if needed
+      let loadedRelatedFields = relatedFields;
       if (isRelationField && relationTableId && onFetchRelatedFields) {
         setLoadingRelated(true);
         try {
           const fields = await onFetchRelatedFields(relationTableId);
-          setRelatedFields(fields.filter((f) =>
+          loadedRelatedFields = fields.filter((f) =>
             f.type !== "RELATION" && f.type !== "RELATION_SUBTABLE"
-          ));
+          );
+          setRelatedFields(loadedRelatedFields);
         } catch { /* ignore */ }
         setLoadingRelated(false);
       }
 
       const resolvedType = isRelationField
-        ? (tfk ? (relatedFields.find((f) => f.key === tfk)?.type ?? "TEXT") : "TEXT")
+        ? (tfk ? (loadedRelatedFields.find((f) => f.key === tfk)?.type ?? "TEXT") : "TEXT")
         : field.type;
 
       setFilterOp(filter?.op ?? getOperatorsForType(resolvedType as FieldType)[0]);

--- a/src/components/data/record-table.tsx
+++ b/src/components/data/record-table.tsx
@@ -218,6 +218,17 @@ export function RecordTable({
     router.push(`/data/${tableId}/fields`);
   }, [router, tableId]);
 
+  // ── Fetch related table fields for cross-table filter/sort ────────────
+  const handleFetchRelatedFields = useCallback(async (targetTableId: string) => {
+    try {
+      const res = await fetch(`/api/data-tables/${targetTableId}/fields`);
+      if (!res.ok) return [];
+      return await res.json();
+    } catch {
+      return [];
+    }
+  }, []);
+
   // ── Frozen fields ──────────────────────────────────────────────────────
   const frozenFieldCount = (currentConfig.viewOptions.frozenFieldCount as number) ?? 0;
 
@@ -320,6 +331,7 @@ export function RecordTable({
             onColumnAggregationsChange={setColumnAggregations}
             onOpenFieldsConfig={handleOpenFieldsConfig}
             rowHeight={rowHeight}
+            onFetchRelatedFields={handleFetchRelatedFields}
           />
         );
       case "KANBAN":

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -88,6 +88,7 @@ interface GridViewProps {
   columnAggregations?: Record<string, AggregateType>;
   onColumnAggregationsChange?: (aggregations: Record<string, AggregateType>) => void;
   rowHeight?: number;
+  onFetchRelatedFields?: (tableId: string) => Promise<DataFieldItem[]>;
 }
 
 // ─── Grouping helpers ───────────────────────────────────────────────────────
@@ -264,6 +265,7 @@ export function GridView({
   columnAggregations,
   onColumnAggregationsChange,
   rowHeight,
+  onFetchRelatedFields,
 }: GridViewProps) {
   const frozenFieldCountValue = frozenFieldCount ?? 0;
 
@@ -1715,7 +1717,7 @@ export function GridView({
                     filter={
                       findFilterForField(field.key)
                     }
-                    sort={sorts.find((s) => s.fieldKey === field.key) ?? null}
+                    sort={sorts.find((s) => s.fieldKey === field.key || s.fieldKey.startsWith(field.key + ".")) ?? null}
                     onFilterChange={(filter) =>
                       onFilterChange(filter, field.key)
                     }
@@ -1729,6 +1731,7 @@ export function GridView({
                     frozenFieldCount={frozenFieldCountValue}
                     index={index}
                     onFrozenFieldCountChange={onFrozenFieldCountChange}
+                    onFetchRelatedFields={onFetchRelatedFields}
                   />
                 </DraggableColumnHeader>
               );

--- a/src/lib/services/data-record.service.ts
+++ b/src/lib/services/data-record.service.ts
@@ -11,7 +11,7 @@ import type {
   FilterGroup,
   AggregateType,
 } from "@/types/data-table";
-import { normalizeFilters, parseFieldOptions } from "@/types/data-table";
+import { normalizeFilters, parseFieldOptions, parseRelationFieldRef } from "@/types/data-table";
 import { evaluateFormula } from "@/lib/formula";
 
 // Strip control characters (U+0000-U+001F except TAB/LF/CR) from string values
@@ -348,9 +348,42 @@ export async function listRecords(
     }
 
     // Build view-level filter conditions from FilterCondition[]
-    if (filters.filterConditions && filters.filterConditions.length > 0) {
+    // Separate cross-table (dot-notation) from local conditions
+    const normalizedFilterGroups = normalizeFilters(filters.filterConditions ?? []);
+    const { localGroups, crossFilters } = separateFilterConditions(
+      normalizedFilterGroups,
+      tableResult.data.fields
+    );
+
+    // Resolve cross-table filters to matching source record IDs
+    let crossTableSourceIds: Set<string> | null = null;
+    if (crossFilters.length > 0) {
+      for (const cf of crossFilters) {
+        const ids = await resolveCrossTableFilter(cf);
+        if (crossTableSourceIds === null) {
+          crossTableSourceIds = ids;
+        } else {
+          // AND intersection
+          for (const id of crossTableSourceIds) {
+            if (!ids.has(id)) crossTableSourceIds.delete(id);
+          }
+        }
+      }
+      // Early return if no matches
+      if (crossTableSourceIds !== null && crossTableSourceIds.size === 0) {
+        return {
+          success: true,
+          data: { records: [], total: 0, page: filters.page, pageSize: filters.pageSize, totalPages: 0 },
+        };
+      }
+      if (crossTableSourceIds !== null) {
+        where.id = { in: Array.from(crossTableSourceIds) };
+      }
+    }
+
+    if (localGroups.length > 0) {
       const viewFilterConditions = buildFilterConditionsFromSpec(
-        filters.filterConditions,
+        localGroups,
         tableResult.data.fields
       );
       if (viewFilterConditions.length > 0) {
@@ -361,13 +394,16 @@ export async function listRecords(
 
     // 当有 sortBy 或内存过滤运算符时，需要先取全部数据再分页
     const hasSort = filters.sortBy && filters.sortBy.length > 0;
+    const allFields = tableResult.data.fields;
     const sortableFields = hasSort
-      ? filters.sortBy!.filter((sortConfig) =>
-          tableResult.data.fields.some((field) => field.key === sortConfig.fieldKey)
-        )
+      ? filters.sortBy!.filter((sortConfig) => {
+          const ref = parseRelationFieldRef(sortConfig.fieldKey);
+          if (ref) return allFields.some((f) => f.key === ref.relationFieldKey);
+          return allFields.some((f) => f.key === sortConfig.fieldKey);
+        })
       : [];
-    const memoryFilterGroups = (filters.filterConditions && filters.filterConditions.length > 0)
-      ? normalizeFilters(filters.filterConditions).map(g => ({
+    const memoryFilterGroups = localGroups.length > 0
+      ? localGroups.map(g => ({
           ...g,
           conditions: g.conditions.filter(c => c.op === "between" || c.op === "in" || c.op === "notin"),
         })).filter(g => g.conditions.length > 0)
@@ -391,9 +427,34 @@ export async function listRecords(
       ]);
       processedRecords = allRecords.map(mapRecordToItem);
       if (sortableFields.length > 0) {
+        // Pre-resolve dot-notation sort field values for cross-table sorting
+        const sortValueMaps = new Map<string, Map<string, unknown>>();
+        for (const { fieldKey } of sortableFields) {
+          const ref = parseRelationFieldRef(fieldKey);
+          if (ref) {
+            const relField = allFields.find((f) => f.key === ref.relationFieldKey);
+            if (relField?.relationTo) {
+              const valueMap = await resolveSortValuesForRelationField(
+                processedRecords, relField, ref.targetFieldKey
+              );
+              sortValueMaps.set(fieldKey, valueMap);
+            }
+          }
+        }
+
         processedRecords.sort((a, b) => {
           for (const { fieldKey, order } of sortableFields) {
-            const result = compareRecordValues(a.data[fieldKey], b.data[fieldKey], order);
+            const ref = parseRelationFieldRef(fieldKey);
+            let aValue: unknown;
+            let bValue: unknown;
+            if (ref && sortValueMaps.has(fieldKey)) {
+              aValue = sortValueMaps.get(fieldKey)!.get(a.id) ?? null;
+              bValue = sortValueMaps.get(fieldKey)!.get(b.id) ?? null;
+            } else {
+              aValue = a.data[fieldKey];
+              bValue = b.data[fieldKey];
+            }
+            const result = compareRecordValues(aValue, bValue, order);
             if (result !== 0) return result;
           }
           return 0;
@@ -1218,6 +1279,205 @@ function buildFilterConditionsFromSpec(
       return built.length === 1 ? built[0] : { AND: built }
     })
     .filter(Boolean) as Record<string, unknown>[]
+}
+
+// ── Cross-table Relation Filter Helpers ──
+
+interface CrossTableFilter {
+  relationField: DataFieldItem;
+  targetFieldKey: string;
+  condition: FilterCondition;
+}
+
+function separateFilterConditions(
+  groups: FilterGroup[],
+  fields: DataFieldItem[]
+): { localGroups: FilterGroup[]; crossFilters: CrossTableFilter[] } {
+  const crossFilters: CrossTableFilter[] = [];
+  const localGroups = groups.map((group) => {
+    const localConditions: FilterCondition[] = [];
+    for (const cond of group.conditions) {
+      const ref = parseRelationFieldRef(cond.fieldKey);
+      if (ref) {
+        const relField = fields.find((f) => f.key === ref.relationFieldKey);
+        if (
+          relField &&
+          (relField.type === "RELATION" || relField.type === "RELATION_SUBTABLE") &&
+          relField.relationTo
+        ) {
+          crossFilters.push({
+            relationField: relField,
+            targetFieldKey: ref.targetFieldKey,
+            condition: { ...cond, fieldKey: ref.targetFieldKey },
+          });
+          continue;
+        }
+      }
+      localConditions.push(cond);
+    }
+    return { ...group, conditions: localConditions };
+  });
+  return { localGroups, crossFilters };
+}
+
+/** In-memory condition evaluation (for between/in/notin operators on target records) */
+function matchConditionInMemory(val: unknown, cond: FilterCondition): boolean {
+  const resolved = typeof val === "object" && val !== null
+    ? ((val as Record<string, unknown>).display ?? (val as Record<string, unknown>).displayValue ?? val)
+    : val;
+  switch (cond.op) {
+    case "eq": return String(resolved ?? "") === String(cond.value);
+    case "ne": return String(resolved ?? "") !== String(cond.value);
+    case "contains": return String(resolved ?? "").includes(String(cond.value));
+    case "notcontains": return !String(resolved ?? "").includes(String(cond.value));
+    case "startswith": return String(resolved ?? "").startsWith(String(cond.value));
+    case "endswith": return String(resolved ?? "").endsWith(String(cond.value));
+    case "isempty": return resolved == null || resolved === "";
+    case "isnotempty": return resolved != null && resolved !== "";
+    case "gt": return Number(resolved) > Number(cond.value);
+    case "lt": return Number(resolved) < Number(cond.value);
+    case "gte": return Number(resolved) >= Number(cond.value);
+    case "lte": return Number(resolved) <= Number(cond.value);
+    case "between": {
+      const range = cond.value as { min: number | string; max: number | string };
+      const num = Number(resolved);
+      return num >= Number(range.min) && num <= Number(range.max);
+    }
+    case "in": {
+      const list = Array.isArray(cond.value) ? cond.value : [cond.value];
+      return list.some((v) => String(resolved ?? "") === String(v));
+    }
+    case "notin": {
+      const list = Array.isArray(cond.value) ? cond.value : [cond.value];
+      return !list.some((v) => String(resolved ?? "") === String(v));
+    }
+    default: return true;
+  }
+}
+
+/**
+ * Two-step query for cross-table filtering:
+ * 1. Find target record IDs matching the condition on the target table
+ * 2. Find source record IDs linked via DataRelationRow
+ */
+async function resolveCrossTableFilter(
+  crossFilter: CrossTableFilter
+): Promise<Set<string>> {
+  const { relationField, targetFieldKey, condition } = crossFilter;
+  const targetTableId = relationField.relationTo!;
+
+  // Step 1: Get target table fields metadata
+  const targetTableResult = await getTable(targetTableId);
+  if (!targetTableResult.success) return new Set();
+  const targetFields = targetTableResult.data.fields;
+
+  // Step 2: Try Prisma JSONB filter first, fall back to in-memory
+  const prismaCondition = buildConditionFromFilter(condition, targetFields);
+
+  let targetIds: string[];
+  if (prismaCondition) {
+    const matching = await db.dataRecord.findMany({
+      where: { tableId: targetTableId, AND: [prismaCondition] },
+      select: { id: true },
+    });
+    targetIds = matching.map((r) => r.id);
+  } else {
+    // In-memory filter for between/in/notin operators
+    const allTarget = await db.dataRecord.findMany({
+      where: { tableId: targetTableId },
+    });
+    targetIds = allTarget
+      .filter((r) => {
+        const data = r.data as Record<string, unknown>;
+        return matchConditionInMemory(data[targetFieldKey], condition);
+      })
+      .map((r) => r.id);
+  }
+
+  if (targetIds.length === 0) return new Set();
+
+  // Step 3: Find source record IDs via junction table
+  const relationRows = await db.dataRelationRow.findMany({
+    where: {
+      fieldId: relationField.id,
+      targetRecordId: { in: targetIds },
+    },
+    select: { sourceRecordId: true },
+  });
+
+  return new Set(relationRows.map((r) => r.sourceRecordId));
+}
+
+/**
+ * Resolve sort values for a dot-notation relation field reference.
+ * Returns a Map of recordId -> target field value for sorting.
+ */
+async function resolveSortValuesForRelationField(
+  records: DataRecordItem[],
+  relationField: DataFieldItem,
+  targetFieldKey: string
+): Promise<Map<string, unknown>> {
+  const result = new Map<string, unknown>();
+
+  if (relationField.type === "RELATION") {
+    // Collect single target IDs
+    const targetIds = new Set<string>();
+    for (const record of records) {
+      const raw = record.data[relationField.key];
+      if (typeof raw === "string" && raw) targetIds.add(raw);
+      else if (typeof raw === "object" && raw !== null) {
+        const obj = raw as Record<string, unknown>;
+        if (typeof obj.id === "string") targetIds.add(obj.id);
+      }
+    }
+    if (targetIds.size === 0) return result;
+
+    const targetRecords = await db.dataRecord.findMany({
+      where: { id: { in: Array.from(targetIds) } },
+    });
+    const targetDataMap = new Map(targetRecords.map((r) => [r.id, r.data as Record<string, unknown>]));
+
+    for (const record of records) {
+      const raw = record.data[relationField.key];
+      let targetId: string | undefined;
+      if (typeof raw === "string") targetId = raw;
+      else if (typeof raw === "object" && raw !== null) {
+        targetId = (raw as Record<string, unknown>).id as string;
+      }
+      result.set(record.id, targetId ? (targetDataMap.get(targetId)?.[targetFieldKey] ?? null) : null);
+    }
+  } else if (relationField.type === "RELATION_SUBTABLE") {
+    // Collect all target IDs from snapshot arrays
+    const targetIds = new Set<string>();
+    for (const record of records) {
+      const snapshot = record.data[relationField.key];
+      if (Array.isArray(snapshot)) {
+        for (const item of snapshot as RelationSubtableValueItem[]) {
+          if (item.targetRecordId) targetIds.add(item.targetRecordId);
+        }
+      }
+    }
+    if (targetIds.size === 0) return result;
+
+    const targetRecords = await db.dataRecord.findMany({
+      where: { id: { in: Array.from(targetIds) } },
+    });
+    const targetDataMap = new Map(targetRecords.map((r) => [r.id, r.data as Record<string, unknown>]));
+
+    for (const record of records) {
+      const snapshot = record.data[relationField.key];
+      if (Array.isArray(snapshot)) {
+        const items = snapshot as RelationSubtableValueItem[];
+        // Use first related record's value for sorting
+        const firstItem = items[0];
+        result.set(record.id, firstItem ? (targetDataMap.get(firstItem.targetRecordId)?.[targetFieldKey] ?? null) : null);
+      } else {
+        result.set(record.id, null);
+      }
+    }
+  }
+
+  return result;
 }
 
 // ── Validation ──

--- a/src/lib/services/data-record.service.ts
+++ b/src/lib/services/data-record.service.ts
@@ -350,22 +350,36 @@ export async function listRecords(
     // Build view-level filter conditions from FilterCondition[]
     // Separate cross-table (dot-notation) from local conditions
     const normalizedFilterGroups = normalizeFilters(filters.filterConditions ?? []);
-    const { localGroups, crossFilters } = separateFilterConditions(
+    const { localGroups, crossFilterGroups } = separateFilterConditions(
       normalizedFilterGroups,
       tableResult.data.fields
     );
 
     // Resolve cross-table filters to matching source record IDs
     let crossTableSourceIds: Set<string> | null = null;
-    if (crossFilters.length > 0) {
-      for (const cf of crossFilters) {
-        const ids = await resolveCrossTableFilter(cf);
+    if (crossFilterGroups.length > 0) {
+      // Groups are AND-combined; conditions within each group use the group's operator
+      for (const group of crossFilterGroups) {
+        let groupIds: Set<string> | null = null;
+        for (const cf of group.filters) {
+          const ids = await resolveCrossTableFilter(cf);
+          if (groupIds === null) {
+            groupIds = ids;
+          } else if (group.operator === "OR") {
+            for (const id of ids) groupIds.add(id);
+          } else {
+            // AND: intersection
+            for (const id of groupIds) {
+              if (!ids.has(id)) groupIds.delete(id);
+            }
+          }
+        }
+        // Merge group result into overall result (groups are AND-combined)
         if (crossTableSourceIds === null) {
-          crossTableSourceIds = ids;
+          crossTableSourceIds = groupIds ?? new Set();
         } else {
-          // AND intersection
           for (const id of crossTableSourceIds) {
-            if (!ids.has(id)) crossTableSourceIds.delete(id);
+            if (!groupIds?.has(id)) crossTableSourceIds.delete(id);
           }
         }
       }
@@ -1289,13 +1303,19 @@ interface CrossTableFilter {
   condition: FilterCondition;
 }
 
+interface CrossTableFilterGroup {
+  operator: "AND" | "OR";
+  filters: CrossTableFilter[];
+}
+
 function separateFilterConditions(
   groups: FilterGroup[],
   fields: DataFieldItem[]
-): { localGroups: FilterGroup[]; crossFilters: CrossTableFilter[] } {
-  const crossFilters: CrossTableFilter[] = [];
+): { localGroups: FilterGroup[]; crossFilterGroups: CrossTableFilterGroup[] } {
+  const crossFilterGroups: CrossTableFilterGroup[] = [];
   const localGroups = groups.map((group) => {
     const localConditions: FilterCondition[] = [];
+    const crossConditions: CrossTableFilter[] = [];
     for (const cond of group.conditions) {
       const ref = parseRelationFieldRef(cond.fieldKey);
       if (ref) {
@@ -1305,7 +1325,7 @@ function separateFilterConditions(
           (relField.type === "RELATION" || relField.type === "RELATION_SUBTABLE") &&
           relField.relationTo
         ) {
-          crossFilters.push({
+          crossConditions.push({
             relationField: relField,
             targetFieldKey: ref.targetFieldKey,
             condition: { ...cond, fieldKey: ref.targetFieldKey },
@@ -1315,9 +1335,12 @@ function separateFilterConditions(
       }
       localConditions.push(cond);
     }
+    if (crossConditions.length > 0) {
+      crossFilterGroups.push({ operator: group.operator, filters: crossConditions });
+    }
     return { ...group, conditions: localConditions };
   });
-  return { localGroups, crossFilters };
+  return { localGroups, crossFilterGroups };
 }
 
 /** In-memory condition evaluation (for between/in/notin operators on target records) */
@@ -1385,6 +1408,7 @@ async function resolveCrossTableFilter(
     // In-memory filter for between/in/notin operators
     const allTarget = await db.dataRecord.findMany({
       where: { tableId: targetTableId },
+      take: 10000,
     });
     targetIds = allTarget
       .filter((r) => {

--- a/src/types/data-table.ts
+++ b/src/types/data-table.ts
@@ -100,6 +100,13 @@ export function parseFieldOptions(raw: unknown): FieldOptions {
   return raw as FieldOptions;
 }
 
+/** Parse "relationFieldKey.targetFieldKey" dot-notation for cross-table filter/sort references */
+export function parseRelationFieldRef(fieldKey: string): { relationFieldKey: string; targetFieldKey: string } | null {
+  const i = fieldKey.indexOf('.');
+  if (i <= 0 || i === fieldKey.length - 1 || fieldKey.indexOf('.', i + 1) !== -1) return null;
+  return { relationFieldKey: fieldKey.slice(0, i), targetFieldKey: fieldKey.slice(i + 1) };
+}
+
 export interface DataFieldItem {
   id: string;
   key: string;

--- a/src/validators/data-table.ts
+++ b/src/validators/data-table.ts
@@ -165,7 +165,7 @@ export const patchFieldSchema = z.object({
 });
 
 export const sortConfigSchema = z.object({
-  fieldKey: z.string(),
+  fieldKey: z.string().regex(/^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)?$/),
   order: z.enum(["asc", "desc"]),
 });
 

--- a/src/validators/data-table.ts
+++ b/src/validators/data-table.ts
@@ -32,7 +32,7 @@ export const businessKeySchema = z.object({
 // ========== Filter Schemas (shared by views and rollup conditions) ==========
 
 export const filterConditionSchema = z.object({
-  fieldKey: z.string(),
+  fieldKey: z.string().regex(/^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)?$/),
   op: z.enum([
     "eq", "ne", "gt", "lt", "gte", "lte",
     "contains", "notcontains", "startswith", "endswith",


### PR DESCRIPTION
## Summary
- 新增 `parseRelationFieldRef()` 支持 `"relationField.targetField"` 点号表示法
- 后端两步查询实现跨表筛选：先查目标表匹配记录，再通过 DataRelationRow 反查源记录
- 排序支持跨表字段：批量解析关联目标记录数据后进行内存排序
- RELATION/RELATION_SUBTABLE 列头显示目标字段选择器，支持按目标表字段筛选和排序
- ROLLUP/LOOKUP 字段增加完整数值/文本筛选运算符
- 向后兼容：不含点的 fieldKey 走原有逻辑

## 涉及文件
| 文件 | 改动 |
|------|------|
| `src/types/data-table.ts` | 新增 `parseRelationFieldRef()` 辅助函数 |
| `src/validators/data-table.ts` | `sortConfigSchema` 支持点号 fieldKey |
| `src/lib/services/data-record.service.ts` | 跨表筛选/排序核心逻辑 |
| `src/components/data/column-header.tsx` | 关联列目标字段选择器 + ROLLUP/LOOKUP 运算符 |
| `src/components/data/views/grid-view.tsx` | 传递 `onFetchRelatedFields` |
| `src/components/data/record-table.tsx` | 实现 `onFetchRelatedFields` 回调 |

## Test plan
- [ ] 类型检查通过
- [ ] 论文表中按"作者的组别"筛选（RELATION_SUBTABLE → 目标表字段）
- [ ] 论文表中按"作者数"筛选（COUNT 字段，gt 运算符）
- [ ] 论文表中按关联字段的目标字段排序
- [ ] 不含点的 fieldKey 筛选/排序不受影响
- [ ] 空结果集正确处理

Closes #90