### PR TITLE
[Feature] 关联选择器增强：分页加载、新建记录、预览弹窗、多选

### DIFF
--- a/src/app/api/data-tables/[id]/relation-options/route.ts
+++ b/src/app/api/data-tables/[id]/relation-options/route.ts
@@ -32,9 +32,11 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   }
 
   const { id } = await params;
-  const search = request.nextUrl.searchParams.get("search") || undefined;
-  const displayFieldParam =
-    request.nextUrl.searchParams.get("displayField") || undefined;
+  const sp = request.nextUrl.searchParams;
+  const search = sp.get("search") || undefined;
+  const displayFieldParam = sp.get("displayField") || undefined;
+  const pageParam = sp.get("page");
+  const pageSizeParam = sp.get("pageSize");
 
   const tableResult = await getTable(id);
   if (!tableResult.success) {
@@ -49,9 +51,15 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     displayFieldParam
   );
 
+  const isPaginated = pageParam !== null;
+  const page = isPaginated ? Math.max(1, parseInt(pageParam, 10) || 1) : 1;
+  const pageSize = isPaginated
+    ? Math.min(200, Math.max(1, parseInt(pageSizeParam || "50", 10) || 50))
+    : (search ? 50 : 500);
+
   const result = await listRecords(id, {
-    page: 1,
-    pageSize: search ? 50 : 500,
+    page,
+    pageSize,
     search: search || undefined,
   });
 
@@ -76,5 +84,16 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       return option.label.toLowerCase().includes(search.toLowerCase());
     });
 
+  if (isPaginated) {
+    return NextResponse.json({
+      options,
+      total: result.data.total,
+      page,
+      pageSize,
+      hasMore: page * pageSize < result.data.total,
+    });
+  }
+
+  // Backward-compatible: flat array
   return NextResponse.json(options);
 }

--- a/src/components/data/cell-editors/relation-cell-editor.tsx
+++ b/src/components/data/cell-editors/relation-cell-editor.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 import { useSession } from "next-auth/react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
 import { useRelationOptions } from "@/hooks/use-relation-options";
 import { RelationQuickCreateForm } from "@/components/data/relation-quick-create-form";
 
@@ -109,10 +110,14 @@ export function RelationCellEditor({
   }
 
   async function handleCreate(data: Record<string, unknown>) {
-    const newOption = await createRecord(data);
-    if (newOption) {
-      committedRef.current = true;
-      onCommit({ id: newOption.id, display: newOption.label });
+    try {
+      const newOption = await createRecord(data);
+      if (newOption) {
+        committedRef.current = true;
+        onCommit({ id: newOption.id, display: newOption.label });
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "创建失败");
     }
   }
 

--- a/src/components/data/cell-editors/relation-cell-editor.tsx
+++ b/src/components/data/cell-editors/relation-cell-editor.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState, useCallback } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { useSession } from "next-auth/react";
 import { Input } from "@/components/ui/input";
-import type { RelationTargetOption } from "@/components/data/relation-target-picker";
+import { Button } from "@/components/ui/button";
+import { useRelationOptions } from "@/hooks/use-relation-options";
+import { RelationQuickCreateForm } from "@/components/data/relation-quick-create-form";
 
 interface RelationCellEditorProps {
   value: string | { id: string; display?: string } | null;
@@ -20,9 +23,8 @@ export function RelationCellEditor({
   relationTableId,
   displayField,
 }: RelationCellEditorProps) {
-  const [search, setSearch] = useState("");
-  const [options, setOptions] = useState<RelationTargetOption[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
+  const { data: session } = useSession();
+  const isAdmin = session?.user?.role === "ADMIN";
   const [isOpen, setIsOpen] = useState(true);
   const [dropdownPos, setDropdownPos] = useState<{ top: number; left: number } | null>(null);
   const [mounted, setMounted] = useState(false);
@@ -30,48 +32,36 @@ export function RelationCellEditor({
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Calculate dropdown position using fixed positioning
-  const updatePosition = useCallback(() => {
+  const {
+    options,
+    isLoading,
+    isLoadingMore,
+    hasMore,
+    search,
+    setSearch,
+    sentinelRef,
+    createRecord,
+    isCreating,
+    showCreateForm,
+    setShowCreateForm,
+    requiredFields,
+  } = useRelationOptions({
+    relationTableId: relationTableId ?? "",
+    displayField,
+  });
+
+  const updatePosition = () => {
     if (inputRef.current) {
       const rect = inputRef.current.getBoundingClientRect();
       setDropdownPos({ top: rect.bottom + 2, left: rect.left });
     }
-  }, []);
-
-  // Fetch options from API
-  useEffect(() => {
-    if (!relationTableId) return;
-
-    const controller = new AbortController();
-    async function fetchOptions() {
-      setIsLoading(true);
-      try {
-        const params = new URLSearchParams();
-        if (search) params.set("search", search);
-        if (displayField) params.set("displayField", displayField);
-
-        const res = await fetch(
-          `/api/data-tables/${relationTableId}/relation-options?${params}`,
-          { signal: controller.signal }
-        );
-        if (!res.ok) return;
-        const data = (await res.json()) as RelationTargetOption[];
-        setOptions(Array.isArray(data) ? data : []);
-      } catch {
-        // abort is fine
-      } finally {
-        if (!controller.signal.aborted) setIsLoading(false);
-      }
-    }
-    fetchOptions();
-    return () => controller.abort();
-  }, [relationTableId, displayField, search]);
+  };
 
   useEffect(() => {
     inputRef.current?.focus();
     updatePosition();
     setMounted(true);
-  }, [updatePosition]);
+  }, []);
 
   // Close dropdown on outside click
   useEffect(() => {
@@ -118,6 +108,14 @@ export function RelationCellEditor({
     onCommit(null);
   }
 
+  async function handleCreate(data: Record<string, unknown>) {
+    const newOption = await createRecord(data);
+    if (newOption) {
+      committedRef.current = true;
+      onCommit({ id: newOption.id, display: newOption.label });
+    }
+  }
+
   // Fallback: plain text input when no relationTableId configured
   if (!relationTableId) {
     return (
@@ -135,12 +133,6 @@ export function RelationCellEditor({
     );
   }
 
-  const filteredOptions = search
-    ? options.filter((o) =>
-        o.label.toLowerCase().includes(search.toLowerCase())
-      )
-    : options;
-
   const dropdown = isOpen && dropdownPos ? createPortal(
     <div
       id="relation-dropdown-portal"
@@ -152,33 +144,73 @@ export function RelationCellEditor({
       }}
       className="w-64 bg-background border rounded-md shadow-lg"
     >
-      <div className="max-h-48 overflow-auto">
-        {isLoading ? (
-          <div className="p-3 text-center text-sm text-muted-foreground">
-            加载中...
+      {showCreateForm ? (
+        <RelationQuickCreateForm
+          fields={requiredFields}
+          onSubmit={handleCreate}
+          onCancel={() => setShowCreateForm(false)}
+          isSubmitting={isCreating}
+        />
+      ) : (
+        <>
+          <div className="max-h-48 overflow-auto">
+            {isLoading ? (
+              <div className="p-3 text-center text-sm text-muted-foreground">加载中...</div>
+            ) : options.length === 0 ? (
+              <div className="p-3 text-center text-sm text-muted-foreground">
+                {search ? "无匹配结果" : "暂无记录"}
+              </div>
+            ) : (
+              <>
+                {options.map((option) => (
+                  <button
+                    key={option.id}
+                    type="button"
+                    className={`w-full text-left px-3 py-1.5 text-sm hover:bg-muted truncate ${
+                      option.id === rawId ? "bg-muted font-medium" : ""
+                    }`}
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      handleSelect(option.id, option.label);
+                    }}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+                {hasMore && (
+                  <div ref={sentinelRef} className="p-2 text-center text-xs text-muted-foreground">
+                    {isLoadingMore ? "加载更多..." : ""}
+                  </div>
+                )}
+              </>
+            )}
           </div>
-        ) : filteredOptions.length === 0 ? (
-          <div className="p-3 text-center text-sm text-muted-foreground">
-            {search ? "无匹配结果" : "暂无记录"}
-          </div>
-        ) : (
-          filteredOptions.map((option) => (
-            <button
-              key={option.id}
-              type="button"
-              className={`w-full text-left px-3 py-1.5 text-sm hover:bg-muted truncate ${
-                option.id === rawId ? "bg-muted font-medium" : ""
-              }`}
-              onMouseDown={(e) => {
-                e.preventDefault();
-                handleSelect(option.id, option.label);
-              }}
-            >
-              {option.label}
-            </button>
-          ))
-        )}
-      </div>
+          {(rawId || isAdmin) && (
+            <div className="border-t p-1 flex gap-1">
+              {rawId && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="flex-1 h-7 text-xs"
+                  onMouseDown={(e) => { e.preventDefault(); handleClear(); }}
+                >
+                  清除
+                </Button>
+              )}
+              {isAdmin && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="flex-1 h-7 text-xs"
+                  onMouseDown={(e) => { e.preventDefault(); setShowCreateForm(true); }}
+                >
+                  新建记录
+                </Button>
+              )}
+            </div>
+          )}
+        </>
+      )}
     </div>,
     document.body
   ) : null;

--- a/src/components/data/relation-preview-popover.tsx
+++ b/src/components/data/relation-preview-popover.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef, type ReactNode } from "react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Badge } from "@/components/ui/badge";
+import type { DataFieldItem, DataRecordItem } from "@/types/data-table";
+import { FieldType } from "@/generated/prisma/enums";
+
+const PREVIEW_SKIPPED_TYPES = new Set([
+  "RELATION", "RELATION_SUBTABLE", "COUNT", "LOOKUP", "ROLLUP",
+  "FORMULA", "AUTO_NUMBER", "SYSTEM_TIMESTAMP", "SYSTEM_USER",
+]);
+
+// Simple in-memory cache (per session, by recordId)
+const recordCache = new Map<string, { data: DataRecordItem; timestamp: number }>();
+const CACHE_TTL = 60_000; // 1 minute
+
+interface RelationPreviewPopoverProps {
+  recordId: string;
+  tableId: string;
+  displayValue: string;
+  children: ReactNode;
+  onNavigate?: (recordId: string) => void;
+}
+
+export function RelationPreviewPopover({
+  recordId,
+  tableId,
+  displayValue,
+  children,
+  onNavigate,
+}: RelationPreviewPopoverProps) {
+  const [open, setOpen] = useState(false);
+  const [record, setRecord] = useState<DataRecordItem | null>(null);
+  const [fields, setFields] = useState<DataFieldItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const fetchRef = useRef(false);
+
+  const fetchData = useCallback(async () => {
+    if (fetchRef.current) return;
+    fetchRef.current = true;
+
+    // Check cache
+    const cached = recordCache.get(recordId);
+    if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+      setRecord(cached.data);
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const [recordRes, fieldsRes] = await Promise.all([
+        fetch(`/api/data-tables/${tableId}/records/${recordId}`),
+        fetch(`/api/data-tables/${tableId}/fields`),
+      ]);
+      if (recordRes.ok) {
+        const rec = await recordRes.json();
+        setRecord(rec);
+        recordCache.set(recordId, { data: rec, timestamp: Date.now() });
+      }
+      if (fieldsRes.ok) {
+        setFields(await fieldsRes.json());
+      }
+    } catch { /* ignore */ }
+    setLoading(false);
+  }, [recordId, tableId]);
+
+  useEffect(() => {
+    if (open) {
+      setLoading(true);
+      fetchRef.current = false;
+      fetchData();
+    } else {
+      fetchRef.current = false;
+    }
+  }, [open, fetchData]);
+
+  const previewFields = fields
+    .filter((f) => !PREVIEW_SKIPPED_TYPES.has(f.type) && !f.key.startsWith("_"))
+    .slice(0, 5);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <Badge
+            variant="outline"
+            className="cursor-pointer hover:bg-accent transition-colors"
+          />
+        }
+      >
+        {children}
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        side="bottom"
+        className="w-64 p-3"
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+      >
+        {loading ? (
+          <div className="text-xs text-muted-foreground text-center py-2">加载中...</div>
+        ) : record ? (
+          <div className="space-y-2">
+            <div className="font-medium text-sm truncate">{displayValue}</div>
+            <div className="space-y-1">
+              {previewFields.map((f) => {
+                const val = record.data[f.key];
+                return (
+                  <div key={f.key} className="flex justify-between text-xs gap-2">
+                    <span className="text-muted-foreground shrink-0">{f.label}</span>
+                    <span className="truncate text-right">
+                      {val != null && val !== "" ? String(val) : "-"}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+            {onNavigate && (
+              <button
+                type="button"
+                className="w-full text-xs text-blue-600 hover:underline pt-1"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setOpen(false);
+                  onNavigate(recordId);
+                }}
+              >
+                查看详情
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="text-xs text-muted-foreground text-center py-2">无法加载</div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/data/relation-preview-popover.tsx
+++ b/src/components/data/relation-preview-popover.tsx
@@ -60,6 +60,13 @@ export function RelationPreviewPopover({
       if (recordRes.ok) {
         const rec = await recordRes.json();
         setRecord(rec);
+        // Evict expired entries when cache grows large
+        if (recordCache.size > 100) {
+          const now = Date.now();
+          for (const [key, val] of recordCache) {
+            if (now - val.timestamp >= CACHE_TTL) recordCache.delete(key);
+          }
+        }
         recordCache.set(recordId, { data: rec, timestamp: Date.now() });
       }
       if (fieldsRes.ok) {

--- a/src/components/data/relation-quick-create-form.tsx
+++ b/src/components/data/relation-quick-create-form.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { DataFieldItem } from "@/types/data-table";
+import { parseSelectOptions } from "@/types/data-table";
+import { FieldType } from "@/generated/prisma/enums";
+
+interface RelationQuickCreateFormProps {
+  fields: DataFieldItem[];
+  onSubmit: (data: Record<string, unknown>) => Promise<void>;
+  onCancel: () => void;
+  isSubmitting: boolean;
+}
+
+export function RelationQuickCreateForm({
+  fields,
+  onSubmit,
+  onCancel,
+  isSubmitting,
+}: RelationQuickCreateFormProps) {
+  const { register, handleSubmit, setValue, watch } = useForm({
+    defaultValues: Object.fromEntries(fields.map((f) => [f.key, ""])),
+  });
+
+  const handleFormSubmit = async (data: Record<string, unknown>) => {
+    // Convert number fields
+    const cleaned: Record<string, unknown> = {};
+    for (const field of fields) {
+      const val = data[field.key];
+      if (val === "" || val == null) {
+        cleaned[field.key] = null;
+      } else if (field.type === FieldType.NUMBER) {
+        cleaned[field.key] = Number(val);
+      } else {
+        cleaned[field.key] = val;
+      }
+    }
+    await onSubmit(cleaned);
+  };
+
+  if (fields.length === 0) {
+    return (
+      <div className="p-3 text-center text-xs text-muted-foreground">
+        没有必填字段，无法快速创建
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit(handleFormSubmit)} className="p-2 space-y-2">
+      {fields.map((field) => (
+        <div key={field.key} className="space-y-1">
+          <Label className="text-xs">{field.label} *</Label>
+          {field.type === FieldType.SELECT ? (
+            <Select
+              value={watch(field.key) ?? ""}
+              onValueChange={(v) => { if (v) setValue(field.key, v); }}
+            >
+              <SelectTrigger size="sm" className="h-7 text-xs">
+                <SelectValue placeholder={`选择${field.label}`} />
+              </SelectTrigger>
+              <SelectContent>
+                {parseSelectOptions(field.options).map((opt) => (
+                  <SelectItem key={opt.label} value={opt.label}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <Input
+              size={1}
+              className="h-7 text-xs"
+              type={field.type === FieldType.NUMBER ? "number" : field.type === FieldType.DATE ? "date" : "text"}
+              step={field.type === FieldType.NUMBER ? "any" : undefined}
+              placeholder={`输入${field.label}`}
+              {...register(field.key)}
+            />
+          )}
+        </div>
+      ))}
+      <div className="flex gap-1 pt-1">
+        <Button type="button" variant="ghost" size="sm" className="flex-1 h-7 text-xs" onClick={onCancel}>
+          取消
+        </Button>
+        <Button type="submit" size="sm" className="flex-1 h-7 text-xs" disabled={isSubmitting}>
+          {isSubmitting ? "创建中..." : "创建"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/data/relation-quick-create-form.tsx
+++ b/src/components/data/relation-quick-create-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -28,9 +29,16 @@ export function RelationQuickCreateForm({
   onCancel,
   isSubmitting,
 }: RelationQuickCreateFormProps) {
-  const { register, handleSubmit, setValue, watch } = useForm({
+  const { register, handleSubmit, setValue, watch, reset } = useForm({
     defaultValues: Object.fromEntries(fields.map((f) => [f.key, ""])),
   });
+
+  // Re-sync form when fields load asynchronously
+  useEffect(() => {
+    if (fields.length > 0) {
+      reset(Object.fromEntries(fields.map((f) => [f.key, ""])));
+    }
+  }, [fields, reset]);
 
   const handleFormSubmit = async (data: Record<string, unknown>) => {
     // Convert number fields

--- a/src/components/data/relation-select.tsx
+++ b/src/components/data/relation-select.tsx
@@ -1,19 +1,16 @@
 "use client";
 
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useRef, useEffect } from "react";
+import { useSession } from "next-auth/react";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { Input } from "@/components/ui/input";
-
-interface RelationOption {
-  id: string;
-  label: string;
-}
+import { Button } from "@/components/ui/button";
+import { useRelationOptions, type RelationOption } from "@/hooks/use-relation-options";
+import { RelationQuickCreateForm } from "@/components/data/relation-quick-create-form";
 
 interface RelationSelectProps {
   value: string | null | undefined;
@@ -32,124 +29,143 @@ export function RelationSelect({
   placeholder = "选择关联记录",
   disabled = false,
 }: RelationSelectProps) {
-  const [allOptions, setAllOptions] = useState<RelationOption[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [search, setSearch] = useState("");
+  const { data: session } = useSession();
+  const isAdmin = session?.user?.role === "ADMIN";
+  const [open, setOpen] = useState(false);
 
-  // Initial load — fetch all options (pageSize=500)
+  const {
+    options,
+    isLoading,
+    isLoadingMore,
+    hasMore,
+    search,
+    setSearch,
+    sentinelRef,
+    createRecord,
+    isCreating,
+    showCreateForm,
+    setShowCreateForm,
+    requiredFields,
+  } = useRelationOptions({
+    relationTableId,
+    displayField,
+  });
+
+  // Find current label
+  const currentOption = options.find((o) => o.id === value);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  // Reset search when popover closes
   useEffect(() => {
-    const fetchOptions = async () => {
-      setIsLoading(true);
-      try {
-        const params = new URLSearchParams({ pageSize: "500" });
-        if (displayField && displayField !== "id") {
-          params.set("displayField", displayField);
-        }
-        const res = await fetch(
-          `/api/data-tables/${relationTableId}/relation-options?${params}`
-        );
-        if (res.ok) {
-          const data = (await res.json()) as RelationOption[];
-          setAllOptions(Array.isArray(data) ? data : []);
-        }
-      } catch {
-        // ignore
-      } finally {
-        setIsLoading(false);
-      }
-    };
-    fetchOptions();
-  }, [relationTableId, displayField]);
-
-  // Search with debounce — re-query server when typing
-  const [searchResults, setSearchResults] = useState<RelationOption[] | null>(null);
-  const [isSearching, setIsSearching] = useState(false);
-
-  useEffect(() => {
-    if (!search) {
-      setSearchResults(null);
-      return;
+    if (!open) {
+      setSearch("");
+      setShowCreateForm(false);
     }
-    const controller = new AbortController();
-    const doSearch = async () => {
-      setIsSearching(true);
-      try {
-        const params = new URLSearchParams({ search });
-        if (displayField && displayField !== "id") {
-          params.set("displayField", displayField);
-        }
-        const res = await fetch(
-          `/api/data-tables/${relationTableId}/relation-options?${params}`,
-          { signal: controller.signal }
-        );
-        if (res.ok) {
-          const data = (await res.json()) as RelationOption[];
-          setSearchResults(Array.isArray(data) ? data : []);
-        }
-      } catch {
-        // abort is fine
-      } finally {
-        if (!controller.signal.aborted) setIsSearching(false);
-      }
-    };
-    const timer = setTimeout(doSearch, 200);
-    return () => {
-      clearTimeout(timer);
-      controller.abort();
-    };
-  }, [search, relationTableId, displayField]);
+  }, [open, setSearch, setShowCreateForm]);
 
-  // Merge: use searchResults when searching, otherwise allOptions
-  const displayedOptions = useMemo(() => {
-    if (search && searchResults !== null) return searchResults;
-    if (search) {
-      // Fallback client-side filter while server results are pending
-      const lower = search.toLowerCase();
-      return allOptions.filter((o) => o.label.toLowerCase().includes(lower));
+  const handleSelect = (option: RelationOption) => {
+    onChange(option.id);
+    setOpen(false);
+  };
+
+  const handleClear = () => {
+    onChange(null);
+  };
+
+  const handleCreate = async (data: Record<string, unknown>) => {
+    const newOption = await createRecord(data);
+    if (newOption) {
+      onChange(newOption.id);
+      setOpen(false);
     }
-    return allOptions;
-  }, [search, searchResults, allOptions]);
-
-  const selectedOption = allOptions.find((o) => o.id === value);
+  };
 
   return (
-    <Select
-      value={value ?? ""}
-      onValueChange={(v) => onChange(v || null)}
-      disabled={disabled}
-    >
-      <SelectTrigger>
-        {selectedOption ? (
-          <span className="flex-1 text-left truncate">{selectedOption.label}</span>
-        ) : (
-          <SelectValue placeholder={placeholder} />
-        )}
-      </SelectTrigger>
-      <SelectContent>
-        <div className="p-2 border-b">
-          <Input
-            placeholder="搜索..."
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="h-8"
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <button
+            ref={triggerRef}
+            className="flex h-9 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 text-left"
+            disabled={disabled}
           />
-        </div>
-        <div className="max-h-60 overflow-auto">
-          {(isLoading || isSearching) ? (
-            <div className="p-2 text-center text-zinc-500">加载中...</div>
-          ) : displayedOptions.length === 0 ? (
-            <div className="p-2 text-center text-zinc-500">
-              {search ? "无匹配结果" : "暂无记录"}
+        }
+      >
+        {currentOption ? (
+          <span className="truncate">{currentOption.label}</span>
+        ) : (
+          <span className="text-muted-foreground">{placeholder}</span>
+        )}
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-[var(--trigger-width)] p-0" style={{ minWidth: 200 }}>
+        {showCreateForm ? (
+          <RelationQuickCreateForm
+            fields={requiredFields}
+            onSubmit={handleCreate}
+            onCancel={() => setShowCreateForm(false)}
+            isSubmitting={isCreating}
+          />
+        ) : (
+          <>
+            <div className="p-2 border-b">
+              <Input
+                placeholder="搜索..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="h-8"
+              />
             </div>
-          ) : (
-            displayedOptions.map((option) => (
-              <SelectItem key={option.id} value={option.id}>
-                {option.label}
-              </SelectItem>
-            ))
-          )}
-        </div>
-      </SelectContent>
-    </Select>
+            <div className="max-h-60 overflow-auto">
+              {isLoading ? (
+                <div className="p-3 text-center text-sm text-muted-foreground">加载中...</div>
+              ) : options.length === 0 ? (
+                <div className="p-3 text-center text-sm text-muted-foreground">
+                  {search ? "无匹配结果" : "暂无记录"}
+                </div>
+              ) : (
+                <>
+                  {options.map((option) => (
+                    <button
+                      key={option.id}
+                      type="button"
+                      className={`w-full text-left px-3 py-1.5 text-sm hover:bg-muted truncate ${
+                        option.id === value ? "bg-muted font-medium" : ""
+                      }`}
+                      onClick={() => handleSelect(option)}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                  {hasMore && (
+                    <div ref={sentinelRef} className="p-2 text-center text-xs text-muted-foreground">
+                      {isLoadingMore ? "加载更多..." : ""}
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+            {(value || isAdmin) && (
+              <div className="border-t p-1 flex gap-1">
+                {value && (
+                  <Button variant="ghost" size="sm" className="flex-1 h-7 text-xs" onClick={handleClear}>
+                    清除
+                  </Button>
+                )}
+                {isAdmin && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="flex-1 h-7 text-xs"
+                    onClick={() => setShowCreateForm(true)}
+                  >
+                    新建记录
+                  </Button>
+                )}
+              </div>
+            )}
+          </>
+        )}
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/src/components/data/relation-select.tsx
+++ b/src/components/data/relation-select.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/popover";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
 import { useRelationOptions, type RelationOption } from "@/hooks/use-relation-options";
 import { RelationQuickCreateForm } from "@/components/data/relation-quick-create-form";
 
@@ -73,10 +74,14 @@ export function RelationSelect({
   };
 
   const handleCreate = async (data: Record<string, unknown>) => {
-    const newOption = await createRecord(data);
-    if (newOption) {
-      onChange(newOption.id);
-      setOpen(false);
+    try {
+      const newOption = await createRecord(data);
+      if (newOption) {
+        onChange(newOption.id);
+        setOpen(false);
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "创建失败");
     }
   };
 

--- a/src/components/data/relation-subtable-editor.tsx
+++ b/src/components/data/relation-subtable-editor.tsx
@@ -94,6 +94,23 @@ export function RelationSubtableEditor({
   const isSingle = field.relationCardinality === "SINGLE";
   const canAddRow = !isSingle || rows.length === 0;
 
+  const handleMultiAdd = (items: Array<{ id: string; label: string }>) => {
+    const existingIds = new Set(rows.map((r) => r.targetRecordId));
+    const newRows = items
+      .filter((item) => !existingIds.has(item.id))
+      .map((item, i) => ({
+        targetRecordId: item.id,
+        displayValue: item.label,
+        attributes: Object.fromEntries(
+          schemaFields.map((sf) => [sf.key, sf.type === FieldType.MULTISELECT ? [] : null])
+        ),
+        sortOrder: rows.length + i,
+      }));
+    if (newRows.length > 0) {
+      emitRows([...rows, ...newRows]);
+    }
+  };
+
   const emitRows = (nextRows: RelationSubtableValueItem[]) => {
     onChange(
       normalizeRowsByCurrentOrder(
@@ -268,9 +285,21 @@ export function RelationSubtableEditor({
           disabled={!canAddRow}
         >
           <Plus className="h-4 w-4" />
-          添加关联记录
+          {isSingle ? "选择记录" : "添加关联记录"}
         </Button>
       </div>
+
+      {!isSingle && (
+        <RelationTargetPicker
+          value={null}
+          onChange={() => {}}
+          relationTableId={field.relationTo ?? ""}
+          displayField={field.displayField ?? "id"}
+          placeholder="批量选择目标记录..."
+          multiSelect
+          onChangeMulti={handleMultiAdd}
+        />
+      )}
 
       {rows.length === 0 ? (
         <div className="rounded-md bg-muted p-3 text-sm text-muted-foreground">

--- a/src/components/data/relation-target-picker.tsx
+++ b/src/components/data/relation-target-picker.tsx
@@ -11,6 +11,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { X } from "lucide-react";
+import { toast } from "sonner";
 import { useRelationOptions, type RelationOption } from "@/hooks/use-relation-options";
 import { RelationQuickCreateForm } from "@/components/data/relation-quick-create-form";
 
@@ -100,14 +101,18 @@ export function RelationTargetPicker({
   };
 
   const handleCreate = async (data: Record<string, unknown>) => {
-    const newOption = await createRecord(data);
-    if (newOption) {
-      if (multiSelect) {
-        // Already auto-selected by hook
-      } else {
-        onChange({ id: newOption.id, label: newOption.label });
-        setOpen(false);
+    try {
+      const newOption = await createRecord(data);
+      if (newOption) {
+        if (multiSelect) {
+          // Already auto-selected by hook
+        } else {
+          onChange({ id: newOption.id, label: newOption.label });
+          setOpen(false);
+        }
       }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "创建失败");
     }
   };
 

--- a/src/components/data/relation-target-picker.tsx
+++ b/src/components/data/relation-target-picker.tsx
@@ -1,14 +1,18 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { Input } from "@/components/ui/input";
+import { useState, useRef, useEffect } from "react";
+import { useSession } from "next-auth/react";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { X } from "lucide-react";
+import { useRelationOptions, type RelationOption } from "@/hooks/use-relation-options";
+import { RelationQuickCreateForm } from "@/components/data/relation-quick-create-form";
 
 export interface RelationTargetOption {
   id: string;
@@ -23,6 +27,12 @@ interface RelationTargetPickerProps {
   triggerId?: string;
   placeholder?: string;
   disabled?: boolean;
+  /** Enable multi-select mode */
+  multiSelect?: boolean;
+  /** Selected items in multi-select mode */
+  valueMulti?: RelationTargetOption[];
+  /** Callback for multi-select changes */
+  onChangeMulti?: (items: RelationTargetOption[]) => void;
 }
 
 export function RelationTargetPicker({
@@ -33,133 +43,269 @@ export function RelationTargetPicker({
   triggerId,
   placeholder = "选择目标记录",
   disabled = false,
+  multiSelect = false,
+  valueMulti = [],
+  onChangeMulti,
 }: RelationTargetPickerProps) {
-  const [options, setOptions] = useState<RelationTargetOption[]>([]);
-  const [search, setSearch] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
-  const [errorMessage, setErrorMessage] = useState("");
+  const { data: session } = useSession();
+  const isAdmin = session?.user?.role === "ADMIN";
+  const [open, setOpen] = useState(false);
+
+  const {
+    options,
+    isLoading,
+    isLoadingMore,
+    hasMore,
+    search,
+    setSearch,
+    sentinelRef,
+    selectedIds,
+    toggleSelect,
+    removeSelect,
+    selectedItems,
+    createRecord,
+    isCreating,
+    showCreateForm,
+    setShowCreateForm,
+    requiredFields,
+  } = useRelationOptions({
+    relationTableId,
+    displayField,
+    multiSelect,
+  });
+
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-    if (!relationTableId) {
-      setOptions([]);
-      setErrorMessage("");
-      return;
+    if (!open) {
+      setSearch("");
+      setShowCreateForm(false);
     }
+  }, [open, setSearch, setShowCreateForm]);
 
-    const controller = new AbortController();
+  // Sync multi-select external state
+  useEffect(() => {
+    if (multiSelect && onChangeMulti && open) {
+      onChangeMulti(selectedItems);
+    }
+  }, [selectedItems, multiSelect, onChangeMulti, open]);
 
-    async function fetchOptions() {
-      setIsLoading(true);
-      try {
-        const params = new URLSearchParams();
-        if (search) {
-          params.set("search", search);
-        }
-        if (displayField) {
-          params.set("displayField", displayField);
-        }
+  const handleSingleSelect = (option: RelationOption) => {
+    onChange({ id: option.id, label: option.label });
+    setOpen(false);
+  };
 
-        const response = await fetch(
-          `/api/data-tables/${relationTableId}/relation-options?${params.toString()}`,
-          { signal: controller.signal }
-        );
+  const handleMultiSelect = (option: RelationOption) => {
+    toggleSelect(option.id, option.label);
+  };
 
-        if (!response.ok) {
-          setOptions([]);
-          setErrorMessage("加载关联记录失败");
-          return;
-        }
-
-        const result = (await response.json()) as RelationTargetOption[];
-        setOptions(Array.isArray(result) ? result : []);
-        setErrorMessage("");
-      } catch (error) {
-        if (
-          error instanceof Error &&
-          error.name !== "AbortError"
-        ) {
-          console.error("加载目标记录失败:", error);
-          setOptions([]);
-          setErrorMessage("加载关联记录失败");
-        }
-      } finally {
-        if (!controller.signal.aborted) {
-          setIsLoading(false);
-        }
+  const handleCreate = async (data: Record<string, unknown>) => {
+    const newOption = await createRecord(data);
+    if (newOption) {
+      if (multiSelect) {
+        // Already auto-selected by hook
+      } else {
+        onChange({ id: newOption.id, label: newOption.label });
+        setOpen(false);
       }
     }
+  };
 
-    fetchOptions();
+  const handleRemoveMulti = (id: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    removeSelect(id);
+  };
 
-    return () => {
-      controller.abort();
-    };
-  }, [displayField, relationTableId, search]);
-
-  const optionMap = useMemo(() => {
-    return new Map(options.map((option) => [option.id, option]));
-  }, [options]);
-
-  const selectedLabel = value?.id
-    ? optionMap.get(value.id)?.label ?? value.label
-    : null;
-
-  return (
-    <Select
-      value={value?.id ?? ""}
-      onValueChange={(nextId) => {
-        if (!nextId) {
-          onChange(null);
-          return;
-        }
-
-        const nextOption = optionMap.get(nextId);
-        onChange(
-          nextOption ?? { id: nextId, label: nextId }
-        );
-      }}
-      disabled={disabled || !relationTableId}
-    >
-      <SelectTrigger id={triggerId} className="w-full">
-        {selectedLabel ? (
-          <span className="flex-1 truncate text-left">
-            {selectedLabel}
-          </span>
-        ) : (
-          <SelectValue placeholder={placeholder} />
-        )}
-      </SelectTrigger>
-      <SelectContent>
-        <div className="border-b p-2">
-          <Input
-            value={search}
-            onChange={(event) => setSearch(event.target.value)}
-            placeholder="搜索..."
-            className="h-8"
-          />
-        </div>
-        <div className="max-h-60 overflow-auto">
-          {isLoading ? (
-            <div className="p-2 text-center text-sm text-zinc-500">
-              加载中...
-            </div>
-          ) : errorMessage ? (
-            <div className="p-2 text-center text-sm text-red-500">
-              {errorMessage}
-            </div>
-          ) : options.length === 0 ? (
-            <div className="p-2 text-center text-sm text-zinc-500">
-              {search ? "无匹配结果" : "暂无记录"}
-            </div>
+  // Multi-select trigger with badges
+  if (multiSelect) {
+    return (
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger
+          render={
+            <button
+              id={triggerId}
+              ref={triggerRef}
+              className="flex min-h-9 w-full flex-wrap items-center gap-1 rounded-md border border-input bg-background px-3 py-1.5 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 text-left"
+              disabled={disabled || !relationTableId}
+            />
+          }
+        >
+          {selectedItems.length === 0 ? (
+            <span className="text-muted-foreground">{placeholder}</span>
           ) : (
-            options.map((option) => (
-              <SelectItem key={option.id} value={option.id}>
-                {option.label}
-              </SelectItem>
+            selectedItems.map((item) => (
+              <Badge key={item.id} variant="secondary" className="gap-1 text-xs">
+                {item.label}
+                <button
+                  type="button"
+                  className="hover:text-destructive"
+                  onClick={(e) => handleRemoveMulti(item.id, e)}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </Badge>
             ))
           )}
-        </div>
-      </SelectContent>
-    </Select>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-[var(--trigger-width)] p-0" style={{ minWidth: 200 }}>
+          {showCreateForm ? (
+            <RelationQuickCreateForm
+              fields={requiredFields}
+              onSubmit={handleCreate}
+              onCancel={() => setShowCreateForm(false)}
+              isSubmitting={isCreating}
+            />
+          ) : (
+            <>
+              <div className="p-2 border-b">
+                <Input
+                  placeholder="搜索..."
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  className="h-8"
+                />
+              </div>
+              <div className="max-h-60 overflow-auto">
+                {isLoading ? (
+                  <div className="p-3 text-center text-sm text-muted-foreground">加载中...</div>
+                ) : options.length === 0 ? (
+                  <div className="p-3 text-center text-sm text-muted-foreground">
+                    {search ? "无匹配结果" : "暂无记录"}
+                  </div>
+                ) : (
+                  <>
+                    {options.map((option) => (
+                      <button
+                        key={option.id}
+                        type="button"
+                        className={`w-full text-left px-3 py-1.5 text-sm hover:bg-muted flex items-center gap-2 ${
+                          selectedIds.has(option.id) ? "bg-muted font-medium" : ""
+                        }`}
+                        onClick={() => handleMultiSelect(option)}
+                      >
+                        <span className={`w-4 h-4 rounded border flex-shrink-0 flex items-center justify-center ${
+                          selectedIds.has(option.id) ? "bg-primary border-primary" : "border-input"
+                        }`}>
+                          {selectedIds.has(option.id) && (
+                            <svg className="w-3 h-3 text-primary-foreground" viewBox="0 0 12 12" fill="none">
+                              <path d="M2 6L5 9L10 3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                            </svg>
+                          )}
+                        </span>
+                        <span className="truncate">{option.label}</span>
+                      </button>
+                    ))}
+                    {hasMore && (
+                      <div ref={sentinelRef} className="p-2 text-center text-xs text-muted-foreground">
+                        {isLoadingMore ? "加载更多..." : ""}
+                      </div>
+                    )}
+                  </>
+                )}
+              </div>
+              {isAdmin && (
+                <div className="border-t p-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="w-full h-7 text-xs"
+                    onClick={() => setShowCreateForm(true)}
+                  >
+                    新建记录
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </PopoverContent>
+      </Popover>
+    );
+  }
+
+  // Single-select mode
+  const currentOption = options.find((o) => o.id === value?.id);
+  const selectedLabel = currentOption?.label ?? value?.label;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <button
+            id={triggerId}
+            ref={triggerRef}
+            className="flex h-9 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 text-left"
+            disabled={disabled || !relationTableId}
+          />
+        }
+      >
+        {selectedLabel ? (
+          <span className="truncate">{selectedLabel}</span>
+        ) : (
+          <span className="text-muted-foreground">{placeholder}</span>
+        )}
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-[var(--trigger-width)] p-0" style={{ minWidth: 200 }}>
+        {showCreateForm ? (
+          <RelationQuickCreateForm
+            fields={requiredFields}
+            onSubmit={handleCreate}
+            onCancel={() => setShowCreateForm(false)}
+            isSubmitting={isCreating}
+          />
+        ) : (
+          <>
+            <div className="p-2 border-b">
+              <Input
+                placeholder="搜索..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="h-8"
+              />
+            </div>
+            <div className="max-h-60 overflow-auto">
+              {isLoading ? (
+                <div className="p-3 text-center text-sm text-muted-foreground">加载中...</div>
+              ) : options.length === 0 ? (
+                <div className="p-3 text-center text-sm text-muted-foreground">
+                  {search ? "无匹配结果" : "暂无记录"}
+                </div>
+              ) : (
+                <>
+                  {options.map((option) => (
+                    <button
+                      key={option.id}
+                      type="button"
+                      className={`w-full text-left px-3 py-1.5 text-sm hover:bg-muted truncate ${
+                        option.id === value?.id ? "bg-muted font-medium" : ""
+                      }`}
+                      onClick={() => handleSingleSelect(option)}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                  {hasMore && (
+                    <div ref={sentinelRef} className="p-2 text-center text-xs text-muted-foreground">
+                      {isLoadingMore ? "加载更多..." : ""}
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+            {isAdmin && (
+              <div className="border-t p-1">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="w-full h-7 text-xs"
+                  onClick={() => setShowCreateForm(true)}
+                >
+                  新建记录
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/src/hooks/use-infinite-scroll.ts
+++ b/src/hooks/use-infinite-scroll.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+
+/**
+ * Lightweight IntersectionObserver hook for infinite scroll.
+ * Attaches to a sentinel element at the bottom of a list.
+ * Fires `callback` when the sentinel becomes visible.
+ */
+export function useInfiniteScroll(
+  callback: () => void,
+  options?: {
+    threshold?: number;
+    rootMargin?: string;
+  }
+): { sentinelRef: React.RefCallback<HTMLElement> } {
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  const sentinelRef = useCallback(
+    (node: HTMLElement | null) => {
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+      }
+      if (!node) return;
+
+      observerRef.current = new IntersectionObserver(
+        ([entry]) => {
+          if (entry?.isIntersecting) {
+            callbackRef.current();
+          }
+        },
+        {
+          threshold: options?.threshold ?? 0.1,
+          rootMargin: options?.rootMargin ?? "100px",
+        }
+      );
+      observerRef.current.observe(node);
+    },
+    [options?.threshold, options?.rootMargin]
+  );
+
+  return { sentinelRef };
+}

--- a/src/hooks/use-relation-options.ts
+++ b/src/hooks/use-relation-options.ts
@@ -89,8 +89,10 @@ export function useRelationOptions({
   }, [buildUrl, relationTableId]);
 
   // ── Load more ──
+  const isLoadingMoreRef = useRef(false);
   const loadMore = useCallback(async () => {
-    if (isLoadingMore || !hasMore) return;
+    if (isLoadingMoreRef.current || !hasMore) return;
+    isLoadingMoreRef.current = true;
     setIsLoadingMore(true);
     const nextPage = page + 1;
     try {
@@ -104,8 +106,9 @@ export function useRelationOptions({
       setHasMore(data.hasMore ?? false);
       setPage(nextPage);
     } catch { /* ignore */ }
+    isLoadingMoreRef.current = false;
     setIsLoadingMore(false);
-  }, [isLoadingMore, hasMore, page, buildUrl]);
+  }, [hasMore, page, buildUrl]);
 
   // ── Infinite scroll sentinel ──
   const { sentinelRef } = useInfiniteScroll(loadMore);
@@ -166,8 +169,11 @@ export function useRelationOptions({
 
         setShowCreateForm(false);
         return newOption;
-      } catch { /* ignore */ }
-      return null;
+      } catch (error) {
+        throw error;
+      } finally {
+        setIsCreating(false);
+      }
     },
     [relationTableId, displayField, requiredFields, multiSelect]
   );

--- a/src/hooks/use-relation-options.ts
+++ b/src/hooks/use-relation-options.ts
@@ -1,0 +1,226 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useDebouncedValue } from "@/hooks/use-debounce";
+import { useInfiniteScroll } from "@/hooks/use-infinite-scroll";
+import type { DataFieldItem } from "@/types/data-table";
+import { FieldType } from "@/generated/prisma/enums";
+
+export interface RelationOption {
+  id: string;
+  label: string;
+}
+
+const SIMPLE_FIELD_TYPES = new Set([
+  "TEXT", "NUMBER", "DATE", "SELECT", "EMAIL", "PHONE", "BOOLEAN",
+]);
+
+interface UseRelationOptionsParams {
+  relationTableId: string;
+  displayField?: string;
+  pageSize?: number;
+  multiSelect?: boolean;
+}
+
+export function useRelationOptions({
+  relationTableId,
+  displayField,
+  pageSize = 50,
+  multiSelect = false,
+}: UseRelationOptionsParams) {
+  // ── Pagination state ──
+  const [options, setOptions] = useState<RelationOption[]>([]);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const fetchIdRef = useRef(0);
+
+  // ── Search state ──
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, 200);
+
+  // ── Create record state ──
+  const [isCreating, setIsCreating] = useState(false);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [requiredFields, setRequiredFields] = useState<DataFieldItem[]>([]);
+
+  // ── Multi-select state ──
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [selectedItems, setSelectedItems] = useState<RelationOption[]>([]);
+
+  // ── Build API URL ──
+  const buildUrl = useCallback(
+    (p: number) => {
+      const params = new URLSearchParams({
+        page: String(p),
+        pageSize: String(pageSize),
+      });
+      if (debouncedSearch) params.set("search", debouncedSearch);
+      if (displayField && displayField !== "id") params.set("displayField", displayField);
+      return `/api/data-tables/${relationTableId}/relation-options?${params}`;
+    },
+    [relationTableId, displayField, pageSize, debouncedSearch]
+  );
+
+  // ── Initial load & search reset ──
+  useEffect(() => {
+    if (!relationTableId) return;
+    const fetchId = ++fetchIdRef.current;
+    let cancelled = false;
+    async function fetchFirst() {
+      setIsLoading(true);
+      setOptions([]);
+      setPage(1);
+      try {
+        const res = await fetch(buildUrl(1));
+        if (!res.ok || cancelled) return;
+        const data = await res.json();
+        if (cancelled) return;
+        const newOptions = data.options ?? data;
+        setOptions(Array.isArray(newOptions) ? newOptions : []);
+        setHasMore(data.hasMore ?? false);
+        setPage(1);
+      } catch { /* ignore */ }
+      if (!cancelled) setIsLoading(false);
+    }
+    fetchFirst();
+    return () => { cancelled = true; };
+  }, [buildUrl, relationTableId]);
+
+  // ── Load more ──
+  const loadMore = useCallback(async () => {
+    if (isLoadingMore || !hasMore) return;
+    setIsLoadingMore(true);
+    const nextPage = page + 1;
+    try {
+      const res = await fetch(buildUrl(nextPage));
+      if (!res.ok) return;
+      const data = await res.json();
+      const newOptions = data.options ?? data;
+      if (Array.isArray(newOptions)) {
+        setOptions((prev) => [...prev, ...newOptions]);
+      }
+      setHasMore(data.hasMore ?? false);
+      setPage(nextPage);
+    } catch { /* ignore */ }
+    setIsLoadingMore(false);
+  }, [isLoadingMore, hasMore, page, buildUrl]);
+
+  // ── Infinite scroll sentinel ──
+  const { sentinelRef } = useInfiniteScroll(loadMore);
+
+  // ── Fetch required fields for quick create ──
+  useEffect(() => {
+    if (!relationTableId) return;
+    async function fetchFields() {
+      try {
+        const res = await fetch(`/api/data-tables/${relationTableId}/fields`);
+        if (!res.ok) return;
+        const fields: DataFieldItem[] = await res.json();
+        setRequiredFields(
+          fields.filter(
+            (f) =>
+              f.required &&
+              SIMPLE_FIELD_TYPES.has(f.type) &&
+              !f.key.startsWith("_")
+          )
+        );
+      } catch { /* ignore */ }
+    }
+    fetchFields();
+  }, [relationTableId]);
+
+  // ── Create record ──
+  const createRecord = useCallback(
+    async (data: Record<string, unknown>): Promise<RelationOption | null> => {
+      setIsCreating(true);
+      try {
+        const res = await fetch(`/api/data-tables/${relationTableId}/records`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ data }),
+        });
+        if (!res.ok) {
+          const err = await res.json();
+          throw new Error(err.error ?? "创建失败");
+        }
+        const record = await res.json();
+
+        // Build display label
+        let label = record.id;
+        if (displayField && record.data?.[displayField] != null) {
+          label = String(record.data[displayField]);
+        } else if (requiredFields.length > 0 && record.data?.[requiredFields[0].key] != null) {
+          label = String(record.data[requiredFields[0].key]);
+        }
+        const newOption: RelationOption = { id: record.id, label };
+
+        setOptions((prev) => [newOption, ...prev]);
+
+        // Auto-select
+        if (multiSelect) {
+          setSelectedIds((prev) => new Set(prev).add(newOption.id));
+          setSelectedItems((prev) => [...prev, newOption]);
+        }
+
+        setShowCreateForm(false);
+        return newOption;
+      } catch { /* ignore */ }
+      return null;
+    },
+    [relationTableId, displayField, requiredFields, multiSelect]
+  );
+
+  // ── Multi-select helpers ──
+  const toggleSelect = useCallback(
+    (id: string, label: string) => {
+      if (!multiSelect) return;
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        return next;
+      });
+      setSelectedItems((prev) => {
+        if (prev.some((i) => i.id === id)) return prev.filter((i) => i.id !== id);
+        return [...prev, { id, label }];
+      });
+    },
+    [multiSelect]
+  );
+
+  const removeSelect = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+    setSelectedItems((prev) => prev.filter((i) => i.id !== id));
+  }, []);
+
+  const clearSelections = useCallback(() => {
+    setSelectedIds(new Set());
+    setSelectedItems([]);
+  }, []);
+
+  return {
+    options,
+    isLoading,
+    isLoadingMore,
+    hasMore,
+    search,
+    setSearch,
+    sentinelRef,
+    selectedIds,
+    toggleSelect,
+    removeSelect,
+    clearSelections,
+    selectedItems,
+    createRecord,
+    isCreating,
+    showCreateForm,
+    setShowCreateForm,
+    requiredFields,
+  };
+}


### PR DESCRIPTION
## Summary
- 后端 relation-options API 添加分页支持（page/pageSize），向后兼容
- 新增 `useInfiniteScroll` hook：IntersectionObserver 无限滚动
- 新增 `useRelationOptions` hook：统一管理分页、搜索、创建记录、多选状态
- 新增 `RelationQuickCreateForm`：极简记录创建表单（仅必填简单字段，管理员权限）
- 新增 `RelationPreviewPopover`：悬停预览关联记录前 5 个字段
- 重构 `RelationSelect`：Popover 下拉替代 shadcn Select，支持无限滚动 + 新建记录
- 重构 `RelationCellEditor`：无限滚动 + 新建记录，保留 createPortal 定位
- 重构 `RelationTargetPicker`：新增多选模式（checkbox + 可删除 tag）
- 更新 `RelationSubtableEditor`：多基数场景支持批量选择目标记录

## 涉及文件
| 文件 | 改动 |
|------|------|
| `src/app/api/data-tables/[id]/relation-options/route.ts` | 分页信封响应 |
| `src/hooks/use-infinite-scroll.ts` | 新增 |
| `src/hooks/use-relation-options.ts` | 新增 |
| `src/components/data/relation-quick-create-form.tsx` | 新增 |
| `src/components/data/relation-preview-popover.tsx` | 新增 |
| `src/components/data/relation-select.tsx` | 重构 |
| `src/components/data/cell-editors/relation-cell-editor.tsx` | 重构 |
| `src/components/data/relation-target-picker.tsx` | 重构 + 多选 |
| `src/components/data/relation-subtable-editor.tsx` | 批量添加 |

## Test plan
- [ ] 类型检查通过 (`npx tsc --noEmit`)
- [ ] 构建通过 (`npm run build`)
- [ ] 关联选择器下拉列表支持滚动加载更多
- [ ] 下拉中点击"新建记录"填写表单，创建后自动选中
- [ ] 悬停关联 Badge 显示预览弹窗
- [ ] RELATION_SUBTABLE 多基数编辑器支持批量多选
- [ ] 不传 page 参数时 API 返回旧格式（向后兼容）

Closes #91