### PR TITLE
[Feature] 为每种字段类型添加专属图标标识

### DIFF
--- a/src/components/data/column-header.tsx
+++ b/src/components/data/column-header.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/popover";
 import { ArrowDown, ArrowUp, Filter } from "lucide-react";
 import { FieldType } from "@/generated/prisma/enums";
+import { FieldTypeIcon } from "./field-type-icon";
 import type {
   DataFieldItem,
   FilterCondition,
@@ -270,6 +271,7 @@ export function ColumnHeader({
           <button className="flex items-center gap-1 text-sm font-medium hover:bg-muted/50 rounded px-1.5 py-0.5 transition-colors select-none min-w-0" />
         }
       >
+        <FieldTypeIcon type={field.type} />
         <span className="truncate">{field.label}</span>
         {sort && (
           <span className="shrink-0 text-primary">

--- a/src/components/data/field-config-form.tsx
+++ b/src/components/data/field-config-form.tsx
@@ -34,6 +34,7 @@ import type { RollupAggregateType, FilterCondition, FilterGroup } from "@/types/
 import type { DataFieldInput } from "@/validators/data-table";
 import { FormulaEditor } from "@/components/data/formula-editor";
 import { parseFormula, evaluateFormula, detectCircularRefs } from "@/lib/formula";
+import { FieldTypeIcon } from "./field-type-icon";
 
 interface FieldConfigFormProps {
   open: boolean;
@@ -721,7 +722,10 @@ export function FieldConfigForm({
                 <SelectContent>
                   {FIELD_TYPES.map((item) => (
                     <SelectItem key={item.value} value={item.value}>
-                      {item.label}
+                      <span className="inline-flex items-center gap-1.5">
+                        <FieldTypeIcon type={item.value} />
+                        {item.label}
+                      </span>
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/src/components/data/field-config-list.tsx
+++ b/src/components/data/field-config-list.tsx
@@ -17,6 +17,7 @@ import type { DataFieldItem, DataTableListItem } from "@/types/data-table";
 import { parseSelectOptions, SELECT_COLORS } from "@/types/data-table";
 import type { DataFieldInput } from "@/validators/data-table";
 import { FieldType } from "@/generated/prisma/enums";
+import { FieldTypeIcon } from "./field-type-icon";
 
 interface FieldConfigListProps {
   tableId: string;
@@ -304,7 +305,8 @@ export function FieldConfigList({
                   </TableCell>
                   <TableCell>{field.label}</TableCell>
                   <TableCell>
-                    <Badge variant="secondary">
+                    <Badge variant="secondary" className="gap-1">
+                      <FieldTypeIcon type={field.type} />
                       {FIELD_TYPE_LABELS[field.type]}
                     </Badge>
                   </TableCell>

--- a/src/components/data/field-type-icon.tsx
+++ b/src/components/data/field-type-icon.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import {
+  Type,
+  Hash,
+  Calendar,
+  ChevronDown,
+  ListChecks,
+  Mail,
+  Phone,
+  Paperclip,
+  Link2,
+  Table2,
+  Globe,
+  CheckSquare,
+  Clock,
+  UserCircle,
+  Calculator,
+  Search,
+  BarChart3,
+} from "lucide-react";
+import { FieldType } from "@/generated/prisma/enums";
+
+const ICON_MAP: Record<FieldType, React.ComponentType<{ className?: string }>> = {
+  [FieldType.TEXT]: Type,
+  [FieldType.NUMBER]: Hash,
+  [FieldType.DATE]: Calendar,
+  [FieldType.SELECT]: ChevronDown,
+  [FieldType.MULTISELECT]: ListChecks,
+  [FieldType.EMAIL]: Mail,
+  [FieldType.PHONE]: Phone,
+  [FieldType.FILE]: Paperclip,
+  [FieldType.RELATION]: Link2,
+  [FieldType.RELATION_SUBTABLE]: Table2,
+  [FieldType.URL]: Globe,
+  [FieldType.BOOLEAN]: CheckSquare,
+  [FieldType.AUTO_NUMBER]: Hash,
+  [FieldType.SYSTEM_TIMESTAMP]: Clock,
+  [FieldType.SYSTEM_USER]: UserCircle,
+  [FieldType.FORMULA]: Calculator,
+  [FieldType.COUNT]: Calculator,
+  [FieldType.LOOKUP]: Search,
+  [FieldType.ROLLUP]: BarChart3,
+};
+
+const COMPUTED_TYPES = new Set<FieldType>([
+  FieldType.FORMULA,
+  FieldType.COUNT,
+  FieldType.LOOKUP,
+  FieldType.ROLLUP,
+]);
+
+export function FieldTypeIcon({
+  type,
+  className = "h-3.5 w-3.5 text-muted-foreground",
+}: {
+  type: FieldType;
+  className?: string;
+}) {
+  const Icon = ICON_MAP[type];
+  if (!Icon) return null;
+  return <Icon className={className} />;
+}
+
+export function isComputedFieldType(type: FieldType): boolean {
+  return COMPUTED_TYPES.has(type);
+}

--- a/src/components/data/record-detail-drawer.tsx
+++ b/src/components/data/record-detail-drawer.tsx
@@ -17,6 +17,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { formatCellValue } from "@/lib/format-cell";
 import type { DataFieldItem, DataRecordItem } from "@/types/data-table";
 import type { ChangeHistoryEntry } from "@/lib/services/data-record-change-history.service";
+import { FieldTypeIcon } from "./field-type-icon";
 
 export interface RecordDetailDrawerProps {
   open: boolean;
@@ -215,7 +216,8 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
                 <div className="space-y-4">
                   {fields.map((field) => (
                     <div key={field.id} className="space-y-1.5">
-                      <div className="text-xs font-medium text-muted-foreground">
+                      <div className="flex items-center gap-1 text-xs font-medium text-muted-foreground">
+                        <FieldTypeIcon type={field.type} />
                         {field.label}
                       </div>
                       <div className="break-words text-sm">


### PR DESCRIPTION
## Summary
- 新增 `FieldTypeIcon` 共享组件和 `FIELD_TYPE_ICONS` 图标映射（lucide-react）
- 列头（column-header）字段名前显示类型图标
- 字段配置列表（field-config-list）Badge 中显示图标
- 字段配置表单（field-config-form）类型选择器中显示图标
- 记录详情抽屉（record-detail-drawer）字段标签旁显示图标
- 计算型字段（FORMULA/COUNT/LOOKUP/ROLLUP）使用差异化图标

## Test plan
- [ ] 打开数据表，验证列头显示字段类型图标
- [ ] 打开字段配置页面，验证列表和类型选择器中显示图标
- [ ] 打开记录详情抽屉，验证字段标签旁显示图标
- [ ] 验证各字段类型图标正确对应

Closes #100