### PR TITLE
[Feature] 展开记录详情面板支持左右箭头切换上/下一条记录

### DIFF
--- a/src/components/data/record-detail-drawer.tsx
+++ b/src/components/data/record-detail-drawer.tsx
@@ -191,8 +191,8 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
       }
     };
 
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
   }, [open, recordIds, onNavigate, handleNavigate]);
 
   return (

--- a/src/components/data/record-detail-drawer.tsx
+++ b/src/components/data/record-detail-drawer.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
-import { Pencil, Trash2, History } from "lucide-react";
+import { Pencil, Trash2, History, ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
@@ -28,6 +28,8 @@ export interface RecordDetailDrawerProps {
   isAdmin: boolean;
   onEdit?: () => void;
   onDelete?: (recordId: string) => void;
+  recordIds?: string[];
+  onNavigate?: (recordId: string) => void;
 }
 
 function formatDateTime(value: string | Date): string {
@@ -41,8 +43,12 @@ function formatChangeValue(value: unknown): string {
 }
 
 export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
-  const { open, onOpenChange, recordId, tableId, fields, isAdmin, onDelete } =
+  const { open, onOpenChange, recordId, tableId, fields, isAdmin, onDelete, recordIds, onNavigate } =
     props;
+
+  const currentIndex = recordId && recordIds ? recordIds.indexOf(recordId) : -1;
+  const hasPrev = currentIndex > 0;
+  const hasNext = recordIds ? currentIndex < recordIds.length - 1 : false;
 
   const [record, setRecord] = useState<DataRecordItem | null>(null);
   const [loading, setLoading] = useState(false);
@@ -164,6 +170,31 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
     onOpenChange(false);
   };
 
+  const handleNavigate = useCallback((direction: -1 | 1) => {
+    if (!recordIds || !onNavigate || currentIndex < 0) return;
+    const nextIndex = currentIndex + direction;
+    if (nextIndex < 0 || nextIndex >= recordIds.length) return;
+    onNavigate(recordIds[nextIndex]);
+  }, [recordIds, onNavigate, currentIndex]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    if (!open || !recordIds || !onNavigate) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        handleNavigate(-1);
+      } else if (e.key === "ArrowRight") {
+        e.preventDefault();
+        handleNavigate(1);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, recordIds, onNavigate, handleNavigate]);
+
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent side="right" className="sm:max-w-md overflow-y-auto">
@@ -178,7 +209,34 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
         ) : (
           <div className="space-y-4">
             <SheetHeader className="border-b">
-              <SheetTitle className="text-lg">记录详情</SheetTitle>
+              <div className="flex items-center justify-between">
+                <SheetTitle className="text-lg">记录详情</SheetTitle>
+                {recordIds && recordIds.length > 0 && currentIndex >= 0 && (
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 w-7 p-0"
+                      disabled={!hasPrev}
+                      onClick={() => handleNavigate(-1)}
+                    >
+                      <ChevronLeft className="h-4 w-4" />
+                    </Button>
+                    <span className="text-xs text-muted-foreground tabular-nums min-w-[3rem] text-center">
+                      {currentIndex + 1} / {recordIds.length}
+                    </span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 w-7 p-0"
+                      disabled={!hasNext}
+                      onClick={() => handleNavigate(1)}
+                    >
+                      <ChevronRight className="h-4 w-4" />
+                    </Button>
+                  </div>
+                )}
+              </div>
             </SheetHeader>
 
             <Tabs value={activeTab} onValueChange={setActiveTab}>

--- a/src/components/data/record-table.tsx
+++ b/src/components/data/record-table.tsx
@@ -41,6 +41,7 @@ interface RecordTableProps {
   fields: DataFieldItem[];
   isAdmin: boolean;
   onOpenDetail?: (recordId: string) => void;
+  onRecordIdsChange?: (ids: string[]) => void;
 }
 
 // ─── Fallback view when no saved view is selected ────────────────────────────
@@ -70,6 +71,7 @@ export function RecordTable({
   fields,
   isAdmin,
   onOpenDetail,
+  onRecordIdsChange,
 }: RecordTableProps) {
   const router = useRouter();
   const [viewType, setViewType] = useState<ViewType>("GRID");
@@ -103,6 +105,13 @@ export function RecordTable({
     switchView,
     refresh,
   } = useTableData({ tableId, fields });
+
+  // Sync record IDs to parent for drawer navigation
+  useEffect(() => {
+    if (onRecordIdsChange) {
+      onRecordIdsChange(records.map((r: { id: string }) => r.id));
+    }
+  }, [records, onRecordIdsChange]);
 
   const activeView = useMemo(() => {
     const base = currentView ?? buildFallbackView(tableId, fields);

--- a/src/components/data/table-detail-content.tsx
+++ b/src/components/data/table-detail-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -24,6 +24,7 @@ interface TableDetailContentProps {
 export function TableDetailContent({ tableId, table, isAdmin }: TableDetailContentProps) {
   const [detailRecordId, setDetailRecordId] = useState<string | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
+  const recordIdsRef = useRef<string[]>([]);
 
   // AI Sheet state
   const [aiOpen, setAiOpen] = useState(false);
@@ -187,6 +188,7 @@ export function TableDetailContent({ tableId, table, isAdmin }: TableDetailConte
           setDetailRecordId(recordId);
           setDetailOpen(true);
         }}
+        onRecordIdsChange={(ids) => { recordIdsRef.current = ids; }}
       />
 
       {/* Record Detail Drawer */}
@@ -202,6 +204,8 @@ export function TableDetailContent({ tableId, table, isAdmin }: TableDetailConte
         tableId={tableId}
         fields={table.fields}
         isAdmin={isAdmin}
+        recordIds={recordIdsRef.current}
+        onNavigate={(id) => setDetailRecordId(id)}
       />
 
       {/* AI Assistant Sheet */}


### PR DESCRIPTION
## Summary
- 在 RecordDetailDrawer 中添加 ArrowLeft/ArrowRight 键盘导航
- 头部显示当前位置指示（如 `3 / 42`）和左右箭头按钮
- 通过 recordIds + onNavigate props 实现记录间无缝切换
- RecordTable 暴露 onRecordIdsChange 回调同步当前记录 ID 列表

## Test plan
- [ ] 打开数据表，点击任意记录的「查看详情」
- [ ] 按左右箭头键切换上/下一条记录
- [ ] 验证位置指示器正确显示（如 `3 / 42`）
- [ ] 验证首条记录禁用左箭头，末条记录禁用右箭头
- [ ] 点击箭头按钮验证也能切换

Closes #97