### PR TITLE
[Feature] 实时数据同步 + 活动流 (Phase 1)

### DIFF
--- a/src/app/api/data-tables/[id]/activity/route.ts
+++ b/src/app/api/data-tables/[id]/activity/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: RouteParams
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "未授权" }, { status: 401 });
+  }
+
+  const { id: tableId } = await params;
+  const page = Math.max(1, Number(request.nextUrl.searchParams.get("page") ?? "1"));
+  const pageSize = Math.min(100, Math.max(1, Number(request.nextUrl.searchParams.get("pageSize") ?? "50")));
+
+  const [entries, total] = await Promise.all([
+    db.dataRecordChangeHistory.findMany({
+      where: { tableId },
+      orderBy: { changedAt: "desc" },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      include: {
+        changedBy: { select: { name: true } },
+      },
+    }),
+    db.dataRecordChangeHistory.count({ where: { tableId } }),
+  ]);
+
+  return NextResponse.json({
+    entries: entries.map((e) => ({
+      id: e.id,
+      recordId: e.recordId,
+      fieldKey: e.fieldKey,
+      fieldLabel: e.fieldLabel,
+      oldValue: e.oldValue,
+      newValue: e.newValue,
+      changedById: e.changedById,
+      changedByName: e.changedBy?.name ?? "",
+      changedAt: e.changedAt.toISOString(),
+    })),
+    total,
+    page,
+    pageSize,
+    totalPages: Math.ceil(total / pageSize),
+  });
+}

--- a/src/app/api/data-tables/[id]/realtime/route.ts
+++ b/src/app/api/data-tables/[id]/realtime/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest } from "next/server";
+import { getToken } from "next-auth/jwt";
+import { subscribeToTable } from "@/lib/services/realtime-notify.service";
+import type { RealtimeEvent } from "@/types/realtime";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  // Authenticate: try cookie-based first, then query param token
+  let token = await getToken({ req: request as never });
+  if (!token) {
+    const urlToken = request.nextUrl.searchParams.get("token");
+    if (!urlToken) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+  }
+
+  const { id: tableId } = await params;
+  const userId = (token as { sub?: string } | null)?.sub ?? "";
+
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(
+        encoder.encode(
+          `data: ${JSON.stringify({ type: "connected", tableId, userId })}\n\n`
+        )
+      );
+
+      const unsubscribe = subscribeToTable(tableId, (event: RealtimeEvent) => {
+        try {
+          controller.enqueue(
+            encoder.encode(`data: ${JSON.stringify(event)}\n\n`)
+          );
+        } catch {
+          // stream already closed
+        }
+      });
+
+      const heartbeat = setInterval(() => {
+        try {
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({ type: "heartbeat", ts: Date.now() })}\n\n`
+            )
+          );
+        } catch {
+          clearInterval(heartbeat);
+        }
+      }, 30000);
+
+      request.signal.addEventListener("abort", () => {
+        unsubscribe();
+        clearInterval(heartbeat);
+        try {
+          controller.close();
+        } catch {
+          // already closed
+        }
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/src/app/api/data-tables/[id]/realtime/route.ts
+++ b/src/app/api/data-tables/[id]/realtime/route.ts
@@ -8,17 +8,13 @@ interface RouteParams {
 }
 
 export async function GET(request: NextRequest, { params }: RouteParams) {
-  // Authenticate: try cookie-based first, then query param token
-  let token = await getToken({ req: request as never });
+  const token = await getToken({ req: request as never });
   if (!token) {
-    const urlToken = request.nextUrl.searchParams.get("token");
-    if (!urlToken) {
-      return new Response("Unauthorized", { status: 401 });
-    }
+    return new Response("Unauthorized", { status: 401 });
   }
 
   const { id: tableId } = await params;
-  const userId = (token as { sub?: string } | null)?.sub ?? "";
+  const userId = (token as { sub?: string })?.sub ?? "";
 
   const encoder = new TextEncoder();
 

--- a/src/app/api/data-tables/[id]/records/[recordId]/route.ts
+++ b/src/app/api/data-tables/[id]/records/[recordId]/route.ts
@@ -139,7 +139,7 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
     },
   });
 
-  const result = await deleteRecord(recordId);
+  const result = await deleteRecord(recordId, session.user.id);
 
   if (!result.success) {
     if (result.error.code === "NOT_FOUND") {

--- a/src/app/api/v1/data-tables/[id]/records/[recordId]/route.ts
+++ b/src/app/api/v1/data-tables/[id]/records/[recordId]/route.ts
@@ -71,7 +71,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     return apiErrorResponse("NOT_FOUND", "记录不存在或不属于该数据表", 404);
   }
 
-  const result = await deleteRecord(recordId);
+  const result = await deleteRecord(recordId, authResult.data.userId);
 
   if (!result.success) {
     if (result.error.code === "NOT_FOUND") {

--- a/src/components/data/activity-stream.tsx
+++ b/src/components/data/activity-stream.tsx
@@ -31,12 +31,6 @@ function formatTimeAgo(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString("zh-CN");
 }
 
-function formatValue(val: unknown): string {
-  if (val === null || val === undefined) return "(空)";
-  if (typeof val === "object") return JSON.stringify(val);
-  return String(val);
-}
-
 export function ActivityStream({ tableId, liveActivities }: ActivityStreamProps) {
   const [history, setHistory] = useState<HistoryEntry[]>([]);
   const [loading, setLoading] = useState(true);

--- a/src/components/data/activity-stream.tsx
+++ b/src/components/data/activity-stream.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Spinner } from "@/components/ui/spinner";
+import type { ActivityEntry } from "@/types/realtime";
+
+interface ActivityStreamProps {
+  tableId: string;
+  liveActivities: ActivityEntry[];
+}
+
+interface HistoryEntry {
+  id: string;
+  recordId: string;
+  fieldLabel: string;
+  oldValue: unknown;
+  newValue: unknown;
+  changedByName: string;
+  changedAt: string;
+}
+
+function formatTimeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return `${seconds}秒前`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}分钟前`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}小时前`;
+  return new Date(dateStr).toLocaleDateString("zh-CN");
+}
+
+function formatValue(val: unknown): string {
+  if (val === null || val === undefined) return "(空)";
+  if (typeof val === "object") return JSON.stringify(val);
+  return String(val);
+}
+
+export function ActivityStream({ tableId, liveActivities }: ActivityStreamProps) {
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch(`/api/data-tables/${tableId}/activity?pageSize=50`);
+        if (res.ok && !cancelled) {
+          const data = await res.json();
+          setHistory(data.entries ?? []);
+        }
+      } catch {
+        // ignore
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    void load();
+    return () => { cancelled = true; };
+  }, [tableId]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [liveActivities]);
+
+  return (
+    <div className="w-72 border-l flex flex-col">
+      <div className="p-3 border-b">
+        <h3 className="text-sm font-medium">活动动态</h3>
+      </div>
+      <ScrollArea className="flex-1">
+        <div className="p-3 space-y-3">
+          {/* Live activities (newest first) */}
+          {liveActivities.map((activity) => (
+            <div key={activity.id} className="flex gap-2 text-xs">
+              <div className="flex flex-col items-center">
+                <div className="w-2 h-2 rounded-full bg-blue-500 mt-1 shrink-0" />
+                <div className="w-px flex-1 bg-border" />
+              </div>
+              <div className="flex-1 pb-2">
+                <div className="text-muted-foreground">
+                  {activity.userName || "用户"}
+                  {activity.action === "updated" && ` 更新了 ${activity.fieldLabel ?? ""}`}
+                  {activity.action === "created" && " 创建了记录"}
+                  {activity.action === "deleted" && " 删除了记录"}
+                </div>
+                <div className="text-muted-foreground/60 mt-0.5">
+                  {formatTimeAgo(activity.timestamp)}
+                </div>
+              </div>
+            </div>
+          ))}
+
+          {/* History entries */}
+          {loading ? (
+            <div className="flex justify-center py-6">
+              <Spinner className="size-4" />
+            </div>
+          ) : (
+            history.map((entry) => (
+              <div key={entry.id} className="flex gap-2 text-xs">
+                <div className="flex flex-col items-center">
+                  <div className="w-2 h-2 rounded-full bg-zinc-300 mt-1 shrink-0" />
+                  <div className="w-px flex-1 bg-border" />
+                </div>
+                <div className="flex-1 pb-2">
+                  <div>
+                    <span className="font-medium">{entry.changedByName || "用户"}</span>
+                    {" 更新了 "}
+                    <span className="font-medium">{entry.fieldLabel}</span>
+                  </div>
+                  <div className="text-muted-foreground/60 mt-0.5">
+                    {formatTimeAgo(entry.changedAt)}
+                  </div>
+                </div>
+              </div>
+            ))
+          )}
+          <div ref={bottomRef} />
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/src/components/data/record-table.tsx
+++ b/src/components/data/record-table.tsx
@@ -11,7 +11,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { ArrowUpDown, Download, Plus, X } from "lucide-react";
+import { ArrowUpDown, Download, Plus, X, Activity } from "lucide-react";
 import type {
   DataFieldItem,
   DataViewItem,
@@ -33,6 +33,7 @@ import { KanbanView } from "@/components/data/views/kanban/kanban-view";
 import { GalleryView } from "@/components/data/views/gallery/gallery-view";
 import { TimelineView } from "@/components/data/views/timeline/timeline-view";
 import { FormView } from "@/components/data/views/form/form-view";
+import { ActivityStream } from "@/components/data/activity-stream";
 
 // ─── Props ──────────────────────────────────────────────────────────────────
 
@@ -78,6 +79,7 @@ export function RecordTable({
   const [saveDialogOpen, setSaveDialogOpen] = useState(false);
   const [quickFormatField, setQuickFormatField] = useState<string | undefined>();
   const [quickFormatValue, setQuickFormatValue] = useState<string | undefined>();
+  const [showActivity, setShowActivity] = useState(false);
   const {
     records,
     totalCount,
@@ -104,6 +106,8 @@ export function RecordTable({
     addRecord,
     switchView,
     refresh,
+    isConnected,
+    activityFeed,
   } = useTableData({ tableId, fields });
 
   // Sync record IDs to parent for drawer navigation
@@ -516,11 +520,29 @@ export function RecordTable({
               </Button>
             </Link>
           )}
+          <Button
+            variant={showActivity ? "secondary" : "outline"}
+            size="sm"
+            onClick={() => setShowActivity(!showActivity)}
+          >
+            <Activity className="h-4 w-4 mr-1" />
+            动态
+            {isConnected && (
+              <span className="ml-1 w-2 h-2 rounded-full bg-green-500 inline-block" />
+            )}
+          </Button>
         </div>
       </div>
 
-      {/* View content */}
-      {renderView()}
+      {/* View content + Activity panel */}
+      <div className="flex flex-1 min-h-0">
+        <div className="flex-1 min-w-0">
+          {renderView()}
+        </div>
+        {showActivity && (
+          <ActivityStream tableId={tableId} liveActivities={activityFeed} />
+        )}
+      </div>
 
       {/* Record count */}
       {!isLoading && (

--- a/src/hooks/use-realtime-table.ts
+++ b/src/hooks/use-realtime-table.ts
@@ -1,0 +1,117 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import { useSession } from "next-auth/react";
+import type { RealtimeEvent, ActivityEntry } from "@/types/realtime";
+
+interface UseRealtimeTableOptions {
+  tableId: string;
+  onUpdateRecordField: (recordId: string, fieldKey: string, value: unknown) => void;
+  onRefresh: () => void;
+  enabled?: boolean;
+}
+
+interface UseRealtimeTableReturn {
+  isConnected: boolean;
+  activityFeed: ActivityEntry[];
+}
+
+function getSessionToken(): string | null {
+  const match = document.cookie.match(/next-auth\.session-token=([^;]+)/);
+  return match ? match[1] : null;
+}
+
+const MAX_ACTIVITY = 50;
+
+export function useRealtimeTable({
+  tableId,
+  onUpdateRecordField,
+  onRefresh,
+  enabled = true,
+}: UseRealtimeTableOptions): UseRealtimeTableReturn {
+  const { data: session } = useSession();
+  const currentUserId = session?.user?.id ?? "";
+  const [isConnected, setIsConnected] = useState(false);
+  const [activityFeed, setActivityFeed] = useState<ActivityEntry[]>([]);
+
+  const callbacksRef = useRef({ onUpdateRecordField, onRefresh });
+  callbacksRef.current = { onUpdateRecordField, onRefresh };
+
+  const addActivity = useCallback((entry: ActivityEntry) => {
+    setActivityFeed((prev) => {
+      const next = [entry, ...prev];
+      return next.slice(0, MAX_ACTIVITY);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || !tableId) return;
+
+    const token = getSessionToken();
+    if (!token) return;
+
+    const url = `/api/data-tables/${tableId}/realtime?token=${encodeURIComponent(token)}`;
+    const es = new EventSource(url);
+
+    es.onopen = () => {
+      setIsConnected(true);
+    };
+
+    es.onmessage = (e) => {
+      try {
+        const event = JSON.parse(e.data) as RealtimeEvent | { type: "connected" | "heartbeat" };
+
+        if (event.type === "connected" || event.type === "heartbeat") return;
+
+        const rtEvent = event as RealtimeEvent;
+
+        // Self-suppression: skip events from current user
+        const eventUserId =
+          rtEvent.type === "record_updated" ? rtEvent.changedById :
+          rtEvent.type === "record_created" ? rtEvent.createdById :
+          rtEvent.deletedById;
+
+        if (eventUserId === currentUserId) return;
+
+        // Apply changes
+        if (rtEvent.type === "record_updated") {
+          callbacksRef.current.onUpdateRecordField(
+            rtEvent.recordId,
+            rtEvent.fieldKey,
+            rtEvent.value
+          );
+          addActivity({
+            id: `${rtEvent.recordId}-${rtEvent.fieldKey}-${rtEvent.changedAt}`,
+            userName: rtEvent.changedByName,
+            action: "updated",
+            fieldLabel: rtEvent.fieldLabel,
+            recordId: rtEvent.recordId,
+            timestamp: rtEvent.changedAt,
+          });
+        } else if (rtEvent.type === "record_created" || rtEvent.type === "record_deleted") {
+          callbacksRef.current.onRefresh();
+          addActivity({
+            id: `${rtEvent.type}-${rtEvent.recordId}-${Date.now()}`,
+            userName: rtEvent.type === "record_created" ? rtEvent.createdByName : rtEvent.deletedByName,
+            action: rtEvent.type === "record_created" ? "created" : "deleted",
+            recordId: rtEvent.recordId,
+            timestamp: rtEvent.type === "record_created" ? rtEvent.createdAt : rtEvent.deletedAt,
+          });
+        }
+      } catch {
+        // ignore malformed events
+      }
+    };
+
+    es.onerror = () => {
+      setIsConnected(false);
+    };
+
+    return () => {
+      es.close();
+      setIsConnected(false);
+    };
+  }, [tableId, enabled, currentUserId, addActivity]);
+
+  return { isConnected, activityFeed };
+}

--- a/src/hooks/use-realtime-table.ts
+++ b/src/hooks/use-realtime-table.ts
@@ -16,11 +16,6 @@ interface UseRealtimeTableReturn {
   activityFeed: ActivityEntry[];
 }
 
-function getSessionToken(): string | null {
-  const match = document.cookie.match(/next-auth\.session-token=([^;]+)/);
-  return match ? match[1] : null;
-}
-
 const MAX_ACTIVITY = 50;
 
 export function useRealtimeTable({
@@ -45,13 +40,9 @@ export function useRealtimeTable({
   }, []);
 
   useEffect(() => {
-    if (!enabled || !tableId) return;
+    if (!enabled || !tableId || !currentUserId) return;
 
-    const token = getSessionToken();
-    if (!token) return;
-
-    const url = `/api/data-tables/${tableId}/realtime?token=${encodeURIComponent(token)}`;
-    const es = new EventSource(url);
+    const es = new EventSource(`/api/data-tables/${tableId}/realtime`);
 
     es.onopen = () => {
       setIsConnected(true);

--- a/src/hooks/use-table-data.ts
+++ b/src/hooks/use-table-data.ts
@@ -14,6 +14,7 @@ import type {
   SortConfig,
 } from "@/types/data-table";
 import { useDebouncedCallback } from "@/hooks/use-debounce";
+import { useRealtimeTable } from "@/hooks/use-realtime-table";
 
 export interface UseTableDataOptions {
   tableId: string;
@@ -48,6 +49,8 @@ export interface UseTableDataReturn {
   updateRecordField: (recordId: string, fieldKey: string, value: unknown) => void;
   addRecord: (record: DataRecordItem) => void;
   refresh: () => void;
+  isConnected: boolean;
+  activityFeed: import("@/types/realtime").ActivityEntry[];
 }
 
 function buildTablePath(tableId: string, params: URLSearchParams): string {
@@ -228,6 +231,13 @@ export function useTableData({
     },
     []
   );
+
+  const { isConnected, activityFeed } = useRealtimeTable({
+    tableId,
+    onUpdateRecordField: updateRecordField,
+    onRefresh: refresh,
+    enabled: !!tableId,
+  });
 
   const setFilters = useCallback((nextFilters: FilterGroup[]) => {
     setFiltersState(nextFilters);
@@ -521,5 +531,7 @@ export function useTableData({
     updateRecordField,
     addRecord,
     refresh,
+    isConnected,
+    activityFeed,
   };
 }

--- a/src/lib/agent2/tool-executor.ts
+++ b/src/lib/agent2/tool-executor.ts
@@ -49,7 +49,8 @@ export async function executeToolAction(
       // Get tableId before deletion for cache invalidation
       const existingResult = await helpers.getRecord(toolInput.recordId as string);
       const result = await recordService.deleteRecord(
-        toolInput.recordId as string
+        toolInput.recordId as string,
+        userId
       );
       if (!result.success)
         return { success: false, error: result.error.message, errorDetails: result.error };

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -4,10 +4,13 @@ import { Pool } from "pg";
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
+  pgPool: Pool | undefined;
 };
 
+export const pool = globalForPrisma.pgPool ?? new Pool({ connectionString: process.env.DATABASE_URL });
+if (process.env.NODE_ENV !== "production") globalForPrisma.pgPool = pool;
+
 function createPrismaClient() {
-  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
   const adapter = new PrismaPg(pool);
   return new PrismaClient({ adapter });
 }

--- a/src/lib/services/data-record.service.ts
+++ b/src/lib/services/data-record.service.ts
@@ -1019,7 +1019,7 @@ export async function patchField(
     // Fetch updated record with relations
     const updatedRecord = await db.dataRecord.findUnique({
       where: { id: recordId },
-      include: { createdBy: { select: { name: true } } },
+      include: { createdBy: { select: { name: true } }, updatedBy: { select: { name: true } } },
     });
 
     if (!updatedRecord) {
@@ -1035,7 +1035,7 @@ export async function patchField(
       fieldLabel: field?.label ?? fieldKey,
       value,
       changedById: userId,
-      changedByName: mapped.createdByName ?? "",
+      changedByName: mapped.updatedByName ?? mapped.createdByName ?? "",
       changedAt: new Date().toISOString(),
     }).catch(() => {});
 
@@ -1072,6 +1072,12 @@ export async function deleteRecord(
       return { success: false, error: { code: "NOT_FOUND", message: "记录不存在" } };
     }
 
+    let deletedByName = "";
+    if (userId) {
+      const user = await db.user.findUnique({ where: { id: userId }, select: { name: true } });
+      deletedByName = user?.name ?? "";
+    }
+
     await db.$transaction(tx => doDeleteRecord(tx, id));
 
     void publishRealtimeEvent({
@@ -1079,7 +1085,7 @@ export async function deleteRecord(
       tableId: record.tableId,
       recordId: id,
       deletedById: userId ?? "",
-      deletedByName: "",
+      deletedByName,
       deletedAt: new Date().toISOString(),
     }).catch(() => {});
 

--- a/src/lib/services/data-record.service.ts
+++ b/src/lib/services/data-record.service.ts
@@ -13,6 +13,7 @@ import type {
 } from "@/types/data-table";
 import { normalizeFilters, parseFieldOptions, parseRelationFieldRef } from "@/types/data-table";
 import { evaluateFormula } from "@/lib/formula";
+import { publishRealtimeEvent } from "@/lib/services/realtime-notify.service";
 
 // Strip control characters (U+0000-U+001F except TAB/LF/CR) from string values
 const CONTROL_CHAR_RE = /[\x00-\x08\x0B\x0C\x0E-\x1F]/g;
@@ -779,7 +780,17 @@ export async function createRecord(
       };
     }
 
-    return { success: true, data: mapRecordToItem(record) };
+    const mapped = mapRecordToItem(record);
+    void publishRealtimeEvent({
+      type: "record_created",
+      tableId,
+      recordId: mapped.id,
+      createdById: userId,
+      createdByName: mapped.createdByName ?? "",
+      createdAt: new Date().toISOString(),
+    }).catch(() => {});
+
+    return { success: true, data: mapped };
   } catch (error) {
     const message = error instanceof Error ? error.message : "创建记录失败";
     return { success: false, error: { code: "CREATE_FAILED", message } };
@@ -1015,7 +1026,20 @@ export async function patchField(
       return { success: false, error: { code: "NOT_FOUND", message: "记录不存在" } };
     }
 
-    return { success: true, data: mapRecordToItem(updatedRecord) };
+    const mapped = mapRecordToItem(updatedRecord);
+    void publishRealtimeEvent({
+      type: "record_updated",
+      tableId: existingRecord.tableId,
+      recordId,
+      fieldKey,
+      fieldLabel: field?.label ?? fieldKey,
+      value,
+      changedById: userId,
+      changedByName: mapped.createdByName ?? "",
+      changedAt: new Date().toISOString(),
+    }).catch(() => {});
+
+    return { success: true, data: mapped };
   } catch (error) {
     const message = error instanceof Error ? error.message : "更新字段失败";
     return { success: false, error: { code: "PATCH_FAILED", message } };
@@ -1038,7 +1062,10 @@ async function doDeleteRecord(
   await tx.dataRecord.delete({ where: { id } });
 }
 
-export async function deleteRecord(id: string): Promise<ServiceResult<null>> {
+export async function deleteRecord(
+  id: string,
+  userId?: string
+): Promise<ServiceResult<null>> {
   try {
     const record = await db.dataRecord.findUnique({ where: { id } });
     if (!record) {
@@ -1046,6 +1073,16 @@ export async function deleteRecord(id: string): Promise<ServiceResult<null>> {
     }
 
     await db.$transaction(tx => doDeleteRecord(tx, id));
+
+    void publishRealtimeEvent({
+      type: "record_deleted",
+      tableId: record.tableId,
+      recordId: id,
+      deletedById: userId ?? "",
+      deletedByName: "",
+      deletedAt: new Date().toISOString(),
+    }).catch(() => {});
+
     return { success: true, data: null };
   } catch (error) {
     const message = error instanceof Error ? error.message : "删除记录失败";

--- a/src/lib/services/realtime-notify.service.ts
+++ b/src/lib/services/realtime-notify.service.ts
@@ -1,0 +1,91 @@
+import { Client } from "pg";
+import { pool } from "@/lib/db";
+import type { RealtimeEvent } from "@/types/realtime";
+
+type RealtimeListener = (event: RealtimeEvent) => void;
+
+const CHANNEL = "table_changes";
+const listeners = new Map<string, Set<RealtimeListener>>();
+let listenClient: Client | null = null;
+let initPromise: Promise<void> | null = null;
+
+async function ensureListening(): Promise<void> {
+  if (listenClient) return;
+
+  if (initPromise) {
+    await initPromise;
+    return;
+  }
+
+  initPromise = (async () => {
+    const client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+    await client.query(`LISTEN ${CHANNEL}`);
+
+    client.on("notification", (msg) => {
+      if (!msg.payload) return;
+      try {
+        const event = JSON.parse(msg.payload) as RealtimeEvent;
+        const tableListeners = listeners.get(event.tableId);
+        if (tableListeners) {
+          for (const fn of tableListeners) {
+            fn(event);
+          }
+        }
+      } catch {
+        // ignore malformed payloads
+      }
+    });
+
+    client.on("error", () => {
+      listenClient = null;
+      initPromise = null;
+    });
+
+    client.on("end", () => {
+      listenClient = null;
+      initPromise = null;
+    });
+
+    listenClient = client;
+  })();
+
+  await initPromise;
+}
+
+export async function publishRealtimeEvent(event: RealtimeEvent): Promise<void> {
+  const payload = JSON.stringify(event);
+  await pool.query(`SELECT pg_notify($1, $2)`, [CHANNEL, payload]);
+}
+
+export function subscribeToTable(
+  tableId: string,
+  listener: RealtimeListener
+): () => void {
+  if (!listeners.has(tableId)) {
+    listeners.set(tableId, new Set());
+  }
+  listeners.get(tableId)!.add(listener);
+
+  // Lazy-init LISTEN connection on first subscription
+  void ensureListening();
+
+  return () => {
+    const tableListeners = listeners.get(tableId);
+    if (tableListeners) {
+      tableListeners.delete(listener);
+      if (tableListeners.size === 0) {
+        listeners.delete(tableId);
+      }
+    }
+  };
+}
+
+export function shutdownRealtimeNotify(): void {
+  if (listenClient) {
+    void listenClient.end();
+    listenClient = null;
+    initPromise = null;
+  }
+  listeners.clear();
+}

--- a/src/lib/services/realtime-notify.service.ts
+++ b/src/lib/services/realtime-notify.service.ts
@@ -8,6 +8,16 @@ const CHANNEL = "table_changes";
 const listeners = new Map<string, Set<RealtimeListener>>();
 let listenClient: Client | null = null;
 let initPromise: Promise<void> | null = null;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+function scheduleReconnect(): void {
+  if (reconnectTimer) return;
+  if (listeners.size === 0) return;
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    void ensureListening();
+  }, 3000);
+}
 
 async function ensureListening(): Promise<void> {
   if (listenClient) return;
@@ -40,11 +50,13 @@ async function ensureListening(): Promise<void> {
     client.on("error", () => {
       listenClient = null;
       initPromise = null;
+      scheduleReconnect();
     });
 
     client.on("end", () => {
       listenClient = null;
       initPromise = null;
+      scheduleReconnect();
     });
 
     listenClient = client;

--- a/src/types/realtime.ts
+++ b/src/types/realtime.ts
@@ -1,0 +1,45 @@
+export interface RecordUpdatedEvent {
+  type: "record_updated";
+  tableId: string;
+  recordId: string;
+  fieldKey: string;
+  fieldLabel: string;
+  value: unknown;
+  changedById: string;
+  changedByName: string;
+  changedAt: string;
+}
+
+export interface RecordCreatedEvent {
+  type: "record_created";
+  tableId: string;
+  recordId: string;
+  createdById: string;
+  createdByName: string;
+  createdAt: string;
+}
+
+export interface RecordDeletedEvent {
+  type: "record_deleted";
+  tableId: string;
+  recordId: string;
+  deletedById: string;
+  deletedByName: string;
+  deletedAt: string;
+}
+
+export type RealtimeEvent =
+  | RecordUpdatedEvent
+  | RecordCreatedEvent
+  | RecordDeletedEvent;
+
+export interface ActivityEntry {
+  id: string;
+  userName: string;
+  action: "updated" | "created" | "deleted";
+  fieldLabel?: string;
+  oldValue?: unknown;
+  newValue?: unknown;
+  recordId: string;
+  timestamp: string;
+}


### PR DESCRIPTION
## Summary
- 基于 SSE + PostgreSQL LISTEN/NOTIFY 实现多人实时协作
- 新增 `realtime-notify` 服务管理 PG LISTEN 连接和内存监听器
- 新增 SSE 端点 `/api/data-tables/[id]/realtime` 供客户端订阅
- 在 `patchField`/`createRecord`/`deleteRecord` 后通过 `pg_notify` 发布变更
- 新增 `use-realtime-table` Hook 处理 SSE 事件、自我抑制、活动流
- 集成到 `use-table-data`，其他用户的编辑实时反映到本地状态
- 新增活动流 REST 端点和 `ActivityStream` 侧边面板
- "动态"按钮显示 SSE 连接状态（绿点指示）

## Test plan
- [ ] 打开两个浏览器窗口登录不同用户，编辑同一数据表
- [ ] User A 编辑单元格 → User B 实时看到变化
- [ ] User A 新建/删除记录 → User B 表格自动刷新
- [ ] 活动流面板显示操作历史
- [ ] 类型检查通过：`npx tsc --noEmit`

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)