### PR TITLE
[Feature] 用户在线状态 + 单元格编辑锁定 (Issue #98 Phase 2)

### DIFF
--- a/src/app/api/data-tables/[id]/realtime/cursor/route.ts
+++ b/src/app/api/data-tables/[id]/realtime/cursor/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest } from "next/server";
+import { auth } from "@/lib/auth";
+import { broadcastToTable } from "@/lib/services/realtime-notify.service";
+import { getUserColor } from "@/lib/services/presence.service";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const session = await auth();
+  if (!session?.user) {
+    return Response.json({ error: "未授权" }, { status: 401 });
+  }
+
+  const { id: tableId } = await params;
+  const userId = session.user.id;
+  const userName = session.user.name ?? "";
+
+  try {
+    const body = await request.json();
+    const { recordId, fieldKey } = body as { recordId: string; fieldKey: string };
+
+    if (!recordId || !fieldKey) {
+      return Response.json({ error: "参数缺失" }, { status: 400 });
+    }
+
+    broadcastToTable(tableId, {
+      type: "cursor_moved",
+      tableId,
+      userId,
+      userName,
+      recordId,
+      fieldKey,
+      color: getUserColor(userId),
+    });
+
+    return Response.json({ success: true });
+  } catch {
+    return Response.json({ error: "请求失败" }, { status: 500 });
+  }
+}

--- a/src/app/api/data-tables/[id]/realtime/lock/route.ts
+++ b/src/app/api/data-tables/[id]/realtime/lock/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest } from "next/server";
+import { auth } from "@/lib/auth";
+import { acquireLock, releaseLock } from "@/lib/services/presence.service";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const session = await auth();
+  if (!session?.user) {
+    return Response.json({ error: "未授权" }, { status: 401 });
+  }
+
+  const { id: tableId } = await params;
+  const userId = session.user.id;
+  const userName = session.user.name ?? "";
+
+  try {
+    const body = await request.json();
+    const { action, recordId, fieldKey } = body as {
+      action: "acquire" | "release";
+      recordId: string;
+      fieldKey: string;
+    };
+
+    if (!recordId || !fieldKey || !action) {
+      return Response.json({ error: "参数缺失" }, { status: 400 });
+    }
+
+    if (action === "acquire") {
+      const result = acquireLock(tableId, recordId, fieldKey, userId, userName);
+      if (!result.acquired) {
+        return Response.json({ acquired: false, lockedBy: result.lockedBy });
+      }
+      return Response.json({ acquired: true });
+    }
+
+    if (action === "release") {
+      releaseLock(tableId, recordId, fieldKey, userId);
+      return Response.json({ released: true });
+    }
+
+    return Response.json({ error: "无效操作" }, { status: 400 });
+  } catch {
+    return Response.json({ error: "请求失败" }, { status: 500 });
+  }
+}

--- a/src/app/api/data-tables/[id]/realtime/route.ts
+++ b/src/app/api/data-tables/[id]/realtime/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { getToken } from "next-auth/jwt";
 import { subscribeToTable } from "@/lib/services/realtime-notify.service";
+import { joinPresence, leavePresence, getOnlineUsers, getLocksForTable } from "@/lib/services/presence.service";
 import type { RealtimeEvent } from "@/types/realtime";
 
 interface RouteParams {
@@ -14,15 +15,29 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   }
 
   const { id: tableId } = await params;
-  const userId = (token as { sub?: string })?.sub ?? "";
+  const userId = (token as { sub?: string }).sub ?? "";
+  const userName = (token as { name?: string }).name ?? "";
 
   const encoder = new TextEncoder();
 
   const stream = new ReadableStream({
     start(controller) {
+      // Join presence and notify others
+      joinPresence(tableId, userId, userName);
+
+      // Send initial connected message
       controller.enqueue(
         encoder.encode(
           `data: ${JSON.stringify({ type: "connected", tableId, userId })}\n\n`
+        )
+      );
+
+      // Send presence snapshot so the new client knows who's online
+      const snapshotUsers = getOnlineUsers(tableId);
+      const snapshotLocks = getLocksForTable(tableId);
+      controller.enqueue(
+        encoder.encode(
+          `data: ${JSON.stringify({ type: "presence_snapshot", tableId, users: snapshotUsers, locks: snapshotLocks })}\n\n`
         )
       );
 
@@ -49,6 +64,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       }, 30000);
 
       request.signal.addEventListener("abort", () => {
+        leavePresence(tableId, userId);
         unsubscribe();
         clearInterval(heartbeat);
         try {

--- a/src/components/data/online-presence-bar.tsx
+++ b/src/components/data/online-presence-bar.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import type { OnlineUser } from "@/types/realtime";
+import { UserAvatarStack } from "@/components/data/user-avatar";
+
+interface OnlinePresenceBarProps {
+  users: OnlineUser[];
+}
+
+export function OnlinePresenceBar({ users }: OnlinePresenceBarProps) {
+  if (users.length === 0) return null;
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <UserAvatarStack users={users} size="sm" />
+      <span className="text-xs text-muted-foreground">
+        {users.length} 人在线
+      </span>
+    </div>
+  );
+}

--- a/src/components/data/record-table.tsx
+++ b/src/components/data/record-table.tsx
@@ -117,6 +117,7 @@ export function RecordTable({
     getLockOwner,
     broadcastCursor,
     myColor,
+    onLockLost,
   } = useTableData({ tableId, fields });
 
   // Sync record IDs to parent for drawer navigation
@@ -361,6 +362,7 @@ export function RecordTable({
             releaseCellLock={releaseCellLock}
             broadcastCursor={broadcastCursor}
             myColor={myColor}
+            onLockLost={onLockLost}
           />
         );
       case "KANBAN":

--- a/src/components/data/record-table.tsx
+++ b/src/components/data/record-table.tsx
@@ -34,6 +34,7 @@ import { GalleryView } from "@/components/data/views/gallery/gallery-view";
 import { TimelineView } from "@/components/data/views/timeline/timeline-view";
 import { FormView } from "@/components/data/views/form/form-view";
 import { ActivityStream } from "@/components/data/activity-stream";
+import { OnlinePresenceBar } from "@/components/data/online-presence-bar";
 
 // ─── Props ──────────────────────────────────────────────────────────────────
 
@@ -108,6 +109,14 @@ export function RecordTable({
     refresh,
     isConnected,
     activityFeed,
+    onlineUsers,
+    cellLocks,
+    acquireCellLock,
+    releaseCellLock,
+    isCellLockedByOther,
+    getLockOwner,
+    broadcastCursor,
+    myColor,
   } = useTableData({ tableId, fields });
 
   // Sync record IDs to parent for drawer navigation
@@ -345,6 +354,13 @@ export function RecordTable({
             onOpenFieldsConfig={handleOpenFieldsConfig}
             rowHeight={rowHeight}
             onFetchRelatedFields={handleFetchRelatedFields}
+            cellLocks={cellLocks}
+            isCellLockedByOther={isCellLockedByOther}
+            getLockOwner={getLockOwner}
+            acquireCellLock={acquireCellLock}
+            releaseCellLock={releaseCellLock}
+            broadcastCursor={broadcastCursor}
+            myColor={myColor}
           />
         );
       case "KANBAN":
@@ -520,6 +536,7 @@ export function RecordTable({
               </Button>
             </Link>
           )}
+          <OnlinePresenceBar users={onlineUsers} />
           <Button
             variant={showActivity ? "secondary" : "outline"}
             size="sm"

--- a/src/components/data/user-avatar.tsx
+++ b/src/components/data/user-avatar.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+interface UserAvatarProps {
+  name: string;
+  color?: string;
+  size?: "sm" | "md";
+  className?: string;
+}
+
+export function UserAvatar({ name, color, size = "sm", className = "" }: UserAvatarProps) {
+  const initial = (name || "?").charAt(0).toUpperCase();
+  const sizeClass = size === "sm" ? "size-6 text-xs" : "size-8 text-sm";
+  const bg = color ?? "#6B7280";
+
+  return (
+    <div
+      className={`rounded-full flex items-center justify-center text-white font-medium shrink-0 ${sizeClass} ${className}`}
+      style={{ backgroundColor: bg }}
+      title={name}
+    >
+      {initial}
+    </div>
+  );
+}
+
+interface UserAvatarStackProps {
+  users: Array<{ userName: string; color: string }>;
+  max?: number;
+  size?: "sm" | "md";
+}
+
+export function UserAvatarStack({ users, max = 4, size = "sm" }: UserAvatarStackProps) {
+  const visible = users.slice(0, max);
+  const remaining = users.length - max;
+
+  return (
+    <div className="flex items-center -space-x-1.5">
+      {visible.map((user, i) => (
+        <UserAvatar key={i} name={user.userName} color={user.color} size={size} className="ring-1 ring-background" />
+      ))}
+      {remaining > 0 && (
+        <div className={`rounded-full flex items-center justify-center bg-muted text-muted-foreground font-medium ring-1 ring-background ${size === "sm" ? "size-6 text-xs" : "size-8 text-sm"}`}>
+          +{remaining}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -94,10 +94,11 @@ interface GridViewProps {
   cellLocks?: Map<string, { recordId: string; fieldKey: string; lockedById: string; lockedByName: string; color: string }>;
   isCellLockedByOther?: (recordId: string, fieldKey: string) => boolean;
   getLockOwner?: (recordId: string, fieldKey: string) => { userId: string; userName: string } | null;
-  acquireCellLock?: (recordId: string, fieldKey: string) => Promise<boolean>;
+  acquireCellLock?: (recordId: string, fieldKey: string) => Promise<{ acquired: boolean; lockedBy?: { userId: string; userName: string } }>;
   releaseCellLock?: (recordId: string, fieldKey: string) => Promise<void>;
   broadcastCursor?: (recordId: string, fieldKey: string) => void;
   myColor?: string;
+  onLockLost?: (callback: (recordId: string, fieldKey: string) => void) => () => void;
 }
 
 // ─── Grouping helpers ───────────────────────────────────────────────────────
@@ -282,6 +283,7 @@ export function GridView({
   releaseCellLock,
   broadcastCursor,
   myColor,
+  onLockLost,
 }: GridViewProps) {
   const frozenFieldCountValue = frozenFieldCount ?? 0;
 
@@ -704,8 +706,25 @@ export function GridView({
   );
 
   const handleRichEditClose = useCallback(() => {
+    if (richEditCell) {
+      releaseCellLock?.(richEditCell.recordId, richEditCell.fieldKey);
+    }
     setRichEditCell(null);
-  }, []);
+  }, [richEditCell, releaseCellLock]);
+
+  useEffect(() => {
+    if (!onLockLost) return;
+    return onLockLost((recordId, fieldKey) => {
+      if (editingCell?.recordId === recordId && editingCell?.fieldKey === fieldKey) {
+        cancelEdit();
+        toast.warning("编辑锁已过期，请重新编辑");
+      }
+      if (richEditCell?.recordId === recordId && richEditCell?.fieldKey === fieldKey) {
+        setRichEditCell(null);
+        toast.warning("编辑锁已过期，请重新编辑");
+      }
+    });
+  }, [onLockLost, editingCell, richEditCell, cancelEdit]);
 
   // ── Fill handle (drag-fill) ──────────────────────────────────────────────
   const [fillRange, setFillRange] = useState<{ startRow: number; startCol: number; endRow: number; endCol: number } | null>(null);
@@ -1404,7 +1423,22 @@ export function GridView({
             className="cursor-pointer w-full h-full"
             onClick={(e) => {
               e.stopPropagation();
-              setRichEditCell({ recordId: record.id, fieldKey: field.key, value: record.data[field.key] });
+              if (isCellLockedByOther?.(record.id, field.key)) {
+                const owner = getLockOwner?.(record.id, field.key);
+                toast.error(`该单元格正在被 ${owner?.userName ?? "其他用户"} 编辑`);
+                return;
+              }
+              if (acquireCellLock) {
+                acquireCellLock(record.id, field.key).then((result) => {
+                  if (!result.acquired) {
+                    toast.error(`该单元格正在被 ${result.lockedBy?.userName ?? "其他用户"} 编辑`);
+                    return;
+                  }
+                  setRichEditCell({ recordId: record.id, fieldKey: field.key, value: record.data[field.key] });
+                });
+              } else {
+                setRichEditCell({ recordId: record.id, fieldKey: field.key, value: record.data[field.key] });
+              }
             }}
           >
             <RichTextPreview value={record.data[field.key]} />

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -90,6 +90,14 @@ interface GridViewProps {
   onColumnAggregationsChange?: (aggregations: Record<string, AggregateType>) => void;
   rowHeight?: number;
   onFetchRelatedFields?: (tableId: string) => Promise<DataFieldItem[]>;
+  // ── Realtime collaboration ──
+  cellLocks?: Map<string, { recordId: string; fieldKey: string; lockedById: string; lockedByName: string; color: string }>;
+  isCellLockedByOther?: (recordId: string, fieldKey: string) => boolean;
+  getLockOwner?: (recordId: string, fieldKey: string) => { userId: string; userName: string } | null;
+  acquireCellLock?: (recordId: string, fieldKey: string) => Promise<boolean>;
+  releaseCellLock?: (recordId: string, fieldKey: string) => Promise<void>;
+  broadcastCursor?: (recordId: string, fieldKey: string) => void;
+  myColor?: string;
 }
 
 // ─── Grouping helpers ───────────────────────────────────────────────────────
@@ -267,6 +275,13 @@ export function GridView({
   onColumnAggregationsChange,
   rowHeight,
   onFetchRelatedFields,
+  cellLocks,
+  isCellLockedByOther,
+  getLockOwner,
+  acquireCellLock,
+  releaseCellLock,
+  broadcastCursor,
+  myColor,
 }: GridViewProps) {
   const frozenFieldCountValue = frozenFieldCount ?? 0;
 
@@ -664,7 +679,14 @@ export function GridView({
   );
 
   const { editingCell, startEditing, commitEdit, cancelEdit } =
-    useInlineEdit({ tableId, onCommit: handleCommitWithUndo });
+    useInlineEdit({
+      tableId,
+      onCommit: handleCommitWithUndo,
+      isCellLockedByOther,
+      getLockOwner,
+      acquireCellLock,
+      releaseCellLock,
+    });
 
   // Rich text popup editor state
   const [richEditCell, setRichEditCell] = useState<{
@@ -1480,6 +1502,9 @@ export function GridView({
             const isEditing =
               editingCell?.recordId === record.id &&
               editingCell?.fieldKey === field.key;
+            const lockKey = `${record.id}:${field.key}`;
+            const lockInfo = cellLocks?.get(lockKey);
+            const isLockedByOther = !!lockInfo;
             const mergedStyle: React.CSSProperties = {
               ...(frozenTdStyle ?? {}),
               ...(cellStyle ?? {}),
@@ -1492,7 +1517,6 @@ export function GridView({
                 style={Object.keys(mergedStyle).length > 0 ? mergedStyle : undefined}
                 className={cn(
                   "align-middle border-r border-neutral-400", rhClasses.td,
-                  // Only apply overflow-hidden when NOT editing a field with a dropdown (RELATION)
                   !(isEditing && field.type === FieldType.RELATION) && "overflow-hidden",
                   (rowHeight ?? 40) < 56 && "whitespace-nowrap",
                   rhClasses.text,
@@ -1502,7 +1526,8 @@ export function GridView({
                     "frozen-last-col relative",
                   isActive && "outline outline-2 outline-primary outline-offset-[-2px] relative",
                   isInRange && !isActive && "bg-primary/20 outline outline-1 outline-offset-[-1px] outline-primary/40",
-                  isFillTarget && "bg-primary/15"
+                  isFillTarget && "bg-primary/15",
+                  isLockedByOther && "bg-amber-50/60"
                 )}
                 onClick={(e) => handleCellClick(flatRowIndex, fieldIndex, e)}
                 onDoubleClick={() => {
@@ -1520,7 +1545,20 @@ export function GridView({
                 }}
                 onContextMenu={(e) => captureCell(e, record.id, field.key, flatRowIndex, fieldIndex)}
               >
-                {renderCell(field, record)}
+                {isLockedByOther && lockInfo ? (
+                  <div className="flex items-center gap-1 text-xs text-amber-700">
+                    <div
+                      className="size-4 rounded-full flex items-center justify-center text-white text-[10px] font-medium shrink-0"
+                      style={{ backgroundColor: lockInfo.color }}
+                      title={lockInfo.lockedByName}
+                    >
+                      {lockInfo.lockedByName.charAt(0).toUpperCase()}
+                    </div>
+                    <span className="truncate">{lockInfo.lockedByName} 编辑中</span>
+                  </div>
+                ) : (
+                  renderCell(field, record)
+                )}
                 {isActive && !READONLY_FIELD_TYPES.includes(field.type) && !editingCell && (
                   <div
                     className="absolute bottom-0 right-0 w-2 h-2 bg-primary cursor-crosshair z-10"

--- a/src/hooks/use-inline-edit.ts
+++ b/src/hooks/use-inline-edit.ts
@@ -13,7 +13,7 @@ export interface UseInlineEditOptions {
   onCommit: (recordId: string, fieldKey: string, value: unknown) => Promise<void>;
   isCellLockedByOther?: (recordId: string, fieldKey: string) => boolean;
   getLockOwner?: (recordId: string, fieldKey: string) => { userId: string; userName: string } | null;
-  acquireCellLock?: (recordId: string, fieldKey: string) => Promise<boolean>;
+  acquireCellLock?: (recordId: string, fieldKey: string) => Promise<{ acquired: boolean; lockedBy?: { userId: string; userName: string } }>;
   releaseCellLock?: (recordId: string, fieldKey: string) => Promise<void>;
 }
 
@@ -47,9 +47,9 @@ export function useInlineEdit({
       return;
     }
     if (acquireCellLock) {
-      acquireCellLock(recordId, fieldKey).then((acquired) => {
-        if (!acquired) {
-          toast.error("获取编辑锁失败，请稍后重试");
+      acquireCellLock(recordId, fieldKey).then((result) => {
+        if (!result.acquired) {
+          toast.error(`该单元格正在被 ${result.lockedBy?.userName ?? "其他用户"} 编辑`);
           return;
         }
         setEditingCell({ recordId, fieldKey });
@@ -73,10 +73,10 @@ export function useInlineEdit({
             ? null
             : prev
         );
-        releaseCellLock?.(currentCell.recordId, currentCell.fieldKey);
       } catch (error) {
         console.error("内联编辑保存失败:", error);
       } finally {
+        await releaseCellLock?.(currentCell.recordId, currentCell.fieldKey);
         isCommittingRef.current = false;
         setIsCommitting(false);
       }
@@ -85,10 +85,11 @@ export function useInlineEdit({
   );
 
   const cancelEdit = useCallback(() => {
-    if (editingCell) {
-      releaseCellLock?.(editingCell.recordId, editingCell.fieldKey);
-    }
+    const cell = editingCell;
     setEditingCell(null);
+    if (cell) {
+      releaseCellLock?.(cell.recordId, cell.fieldKey);
+    }
   }, [editingCell, releaseCellLock]);
 
   return {

--- a/src/hooks/use-inline-edit.ts
+++ b/src/hooks/use-inline-edit.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef } from "react";
+import { toast } from "sonner";
 
 export interface EditingCell {
   recordId: string;
@@ -10,6 +11,10 @@ export interface EditingCell {
 export interface UseInlineEditOptions {
   tableId: string;
   onCommit: (recordId: string, fieldKey: string, value: unknown) => Promise<void>;
+  isCellLockedByOther?: (recordId: string, fieldKey: string) => boolean;
+  getLockOwner?: (recordId: string, fieldKey: string) => { userId: string; userName: string } | null;
+  acquireCellLock?: (recordId: string, fieldKey: string) => Promise<boolean>;
+  releaseCellLock?: (recordId: string, fieldKey: string) => Promise<void>;
 }
 
 export interface UseInlineEditReturn {
@@ -23,18 +28,36 @@ export interface UseInlineEditReturn {
 export function useInlineEdit({
   tableId: _tableId,
   onCommit,
+  isCellLockedByOther,
+  getLockOwner,
+  acquireCellLock,
+  releaseCellLock,
 }: UseInlineEditOptions): UseInlineEditReturn {
   const [editingCell, setEditingCell] = useState<EditingCell | null>(null);
   const [isCommitting, setIsCommitting] = useState(false);
   const onCommitRef = useRef(onCommit);
   onCommitRef.current = onCommit;
 
-  // Ref guard prevents double-commits from stale closures (e.g. onBlur during navigation)
   const isCommittingRef = useRef(false);
 
   const startEditing = useCallback((recordId: string, fieldKey: string) => {
+    if (isCellLockedByOther?.(recordId, fieldKey)) {
+      const owner = getLockOwner?.(recordId, fieldKey);
+      toast.error(`该单元格正在被 ${owner?.userName ?? "其他用户"} 编辑`);
+      return;
+    }
+    if (acquireCellLock) {
+      acquireCellLock(recordId, fieldKey).then((acquired) => {
+        if (!acquired) {
+          toast.error("获取编辑锁失败，请稍后重试");
+          return;
+        }
+        setEditingCell({ recordId, fieldKey });
+      });
+      return;
+    }
     setEditingCell({ recordId, fieldKey });
-  }, []);
+  }, [isCellLockedByOther, getLockOwner, acquireCellLock]);
 
   const commitEdit = useCallback(
     async (value: unknown) => {
@@ -45,26 +68,28 @@ export function useInlineEdit({
       setIsCommitting(true);
       try {
         await onCommitRef.current(currentCell.recordId, currentCell.fieldKey, value);
-        // Only clear if editingCell hasn't been changed by navigation
         setEditingCell((prev) =>
           prev?.recordId === currentCell.recordId && prev?.fieldKey === currentCell.fieldKey
             ? null
             : prev
         );
+        releaseCellLock?.(currentCell.recordId, currentCell.fieldKey);
       } catch (error) {
         console.error("内联编辑保存失败:", error);
-        // Keep editing on error so user can retry
       } finally {
         isCommittingRef.current = false;
         setIsCommitting(false);
       }
     },
-    [editingCell]
+    [editingCell, releaseCellLock]
   );
 
   const cancelEdit = useCallback(() => {
+    if (editingCell) {
+      releaseCellLock?.(editingCell.recordId, editingCell.fieldKey);
+    }
     setEditingCell(null);
-  }, []);
+  }, [editingCell, releaseCellLock]);
 
   return {
     editingCell,

--- a/src/hooks/use-realtime-table.ts
+++ b/src/hooks/use-realtime-table.ts
@@ -2,7 +2,8 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useSession } from "next-auth/react";
-import type { RealtimeEvent, ActivityEntry } from "@/types/realtime";
+import type { RealtimeEvent, ActivityEntry, OnlineUser, CellLock } from "@/types/realtime";
+import { getUserColor } from "@/types/realtime";
 
 interface UseRealtimeTableOptions {
   tableId: string;
@@ -14,6 +15,14 @@ interface UseRealtimeTableOptions {
 interface UseRealtimeTableReturn {
   isConnected: boolean;
   activityFeed: ActivityEntry[];
+  onlineUsers: OnlineUser[];
+  cellLocks: Map<string, CellLock>;
+  acquireCellLock: (recordId: string, fieldKey: string) => Promise<boolean>;
+  releaseCellLock: (recordId: string, fieldKey: string) => Promise<void>;
+  isCellLockedByOther: (recordId: string, fieldKey: string) => boolean;
+  getLockOwner: (recordId: string, fieldKey: string) => { userId: string; userName: string } | null;
+  broadcastCursor: (recordId: string, fieldKey: string) => void;
+  myColor: string;
 }
 
 const MAX_ACTIVITY = 50;
@@ -26,8 +35,12 @@ export function useRealtimeTable({
 }: UseRealtimeTableOptions): UseRealtimeTableReturn {
   const { data: session } = useSession();
   const currentUserId = session?.user?.id ?? "";
+  const myColor = getUserColor(currentUserId);
+
   const [isConnected, setIsConnected] = useState(false);
   const [activityFeed, setActivityFeed] = useState<ActivityEntry[]>([]);
+  const [onlineUsers, setOnlineUsers] = useState<OnlineUser[]>([]);
+  const [cellLocks, setCellLocks] = useState<Map<string, CellLock>>(new Map());
 
   const callbacksRef = useRef({ onUpdateRecordField, onRefresh });
   callbacksRef.current = { onUpdateRecordField, onRefresh };
@@ -54,9 +67,80 @@ export function useRealtimeTable({
 
         if (event.type === "connected" || event.type === "heartbeat") return;
 
-        const rtEvent = event as RealtimeEvent;
+        // ── Presence snapshot ──
+        if (event.type === "presence_snapshot") {
+          const snap = event;
+          setOnlineUsers(snap.users.filter((u) => u.userId !== currentUserId));
+          const lockMap = new Map<string, CellLock>();
+          for (const lock of snap.locks) {
+            if (lock.lockedById !== currentUserId) {
+              lockMap.set(`${lock.recordId}:${lock.fieldKey}`, lock);
+            }
+          }
+          setCellLocks(lockMap);
+          return;
+        }
 
-        // Self-suppression: skip events from current user
+        // ── User joined ──
+        if (event.type === "user_joined") {
+          if (event.userId === currentUserId) return;
+          setOnlineUsers((prev) => {
+            if (prev.some((u) => u.userId === event.userId)) return prev;
+            return [...prev, { userId: event.userId, userName: event.userName, color: event.color }];
+          });
+          return;
+        }
+
+        // ── User left ──
+        if (event.type === "user_left") {
+          setOnlineUsers((prev) => prev.filter((u) => u.userId !== event.userId));
+          // Release any locks from this user
+          setCellLocks((prev) => {
+            const next = new Map(prev);
+            for (const [key, lock] of next) {
+              if (lock.lockedById === event.userId) {
+                next.delete(key);
+              }
+            }
+            return next;
+          });
+          return;
+        }
+
+        // ── Cell locked ──
+        if (event.type === "cell_locked") {
+          if (event.lockedById === currentUserId) return;
+          setCellLocks((prev) => {
+            const next = new Map(prev);
+            next.set(`${event.recordId}:${event.fieldKey}`, {
+              recordId: event.recordId,
+              fieldKey: event.fieldKey,
+              lockedById: event.lockedById,
+              lockedByName: event.lockedByName,
+              color: event.color,
+            });
+            return next;
+          });
+          return;
+        }
+
+        // ── Cell unlocked ──
+        if (event.type === "cell_unlocked") {
+          setCellLocks((prev) => {
+            const next = new Map(prev);
+            next.delete(`${event.recordId}:${event.fieldKey}`);
+            return next;
+          });
+          return;
+        }
+
+        // ── Cursor moved (no state needed, consumed by overlay) ──
+        if (event.type === "cursor_moved") return;
+
+        // ── Data change events ──
+        const rtEvent = event as RealtimeEvent;
+        if (rtEvent.type !== "record_updated" && rtEvent.type !== "record_created" && rtEvent.type !== "record_deleted") return;
+
         const eventUserId =
           rtEvent.type === "record_updated" ? rtEvent.changedById :
           rtEvent.type === "record_created" ? rtEvent.createdById :
@@ -64,7 +148,6 @@ export function useRealtimeTable({
 
         if (eventUserId === currentUserId) return;
 
-        // Apply changes
         if (rtEvent.type === "record_updated") {
           callbacksRef.current.onUpdateRecordField(
             rtEvent.recordId,
@@ -101,8 +184,57 @@ export function useRealtimeTable({
     return () => {
       es.close();
       setIsConnected(false);
+      setOnlineUsers([]);
+      setCellLocks(new Map());
     };
   }, [tableId, enabled, currentUserId, addActivity]);
 
-  return { isConnected, activityFeed };
+  const acquireCellLock = useCallback(async (recordId: string, fieldKey: string): Promise<boolean> => {
+    const res = await fetch(`/api/data-tables/${tableId}/realtime/lock`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "acquire", recordId, fieldKey }),
+    });
+    const data = await res.json();
+    return data.acquired === true;
+  }, [tableId]);
+
+  const releaseCellLock = useCallback(async (recordId: string, fieldKey: string): Promise<void> => {
+    await fetch(`/api/data-tables/${tableId}/realtime/lock`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "release", recordId, fieldKey }),
+    });
+  }, [tableId]);
+
+  const isCellLockedByOther = useCallback((recordId: string, fieldKey: string): boolean => {
+    return cellLocks.has(`${recordId}:${fieldKey}`);
+  }, [cellLocks]);
+
+  const getLockOwner = useCallback((recordId: string, fieldKey: string): { userId: string; userName: string } | null => {
+    const lock = cellLocks.get(`${recordId}:${fieldKey}`);
+    if (!lock) return null;
+    return { userId: lock.lockedById, userName: lock.lockedByName };
+  }, [cellLocks]);
+
+  const broadcastCursor = useCallback((recordId: string, fieldKey: string): void => {
+    void fetch(`/api/data-tables/${tableId}/realtime/cursor`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ recordId, fieldKey }),
+    });
+  }, [tableId]);
+
+  return {
+    isConnected,
+    activityFeed,
+    onlineUsers,
+    cellLocks,
+    acquireCellLock,
+    releaseCellLock,
+    isCellLockedByOther,
+    getLockOwner,
+    broadcastCursor,
+    myColor,
+  };
 }

--- a/src/hooks/use-realtime-table.ts
+++ b/src/hooks/use-realtime-table.ts
@@ -17,12 +17,13 @@ interface UseRealtimeTableReturn {
   activityFeed: ActivityEntry[];
   onlineUsers: OnlineUser[];
   cellLocks: Map<string, CellLock>;
-  acquireCellLock: (recordId: string, fieldKey: string) => Promise<boolean>;
+  acquireCellLock: (recordId: string, fieldKey: string) => Promise<{ acquired: boolean; lockedBy?: { userId: string; userName: string } }>;
   releaseCellLock: (recordId: string, fieldKey: string) => Promise<void>;
   isCellLockedByOther: (recordId: string, fieldKey: string) => boolean;
   getLockOwner: (recordId: string, fieldKey: string) => { userId: string; userName: string } | null;
   broadcastCursor: (recordId: string, fieldKey: string) => void;
   myColor: string;
+  onLockLost: (callback: (recordId: string, fieldKey: string) => void) => () => void;
 }
 
 const MAX_ACTIVITY = 50;
@@ -44,6 +45,8 @@ export function useRealtimeTable({
 
   const callbacksRef = useRef({ onUpdateRecordField, onRefresh });
   callbacksRef.current = { onUpdateRecordField, onRefresh };
+
+  const lockLostCallbacksRef = useRef(new Set<(recordId: string, fieldKey: string) => void>());
 
   const addActivity = useCallback((entry: ActivityEntry) => {
     setActivityFeed((prev) => {
@@ -126,6 +129,11 @@ export function useRealtimeTable({
 
         // ── Cell unlocked ──
         if (event.type === "cell_unlocked") {
+          if (event.unlockedById === currentUserId) {
+            for (const cb of lockLostCallbacksRef.current) {
+              cb(event.recordId, event.fieldKey);
+            }
+          }
           setCellLocks((prev) => {
             const next = new Map(prev);
             next.delete(`${event.recordId}:${event.fieldKey}`);
@@ -189,14 +197,16 @@ export function useRealtimeTable({
     };
   }, [tableId, enabled, currentUserId, addActivity]);
 
-  const acquireCellLock = useCallback(async (recordId: string, fieldKey: string): Promise<boolean> => {
+  const acquireCellLock = useCallback(async (recordId: string, fieldKey: string): Promise<{ acquired: boolean; lockedBy?: { userId: string; userName: string } }> => {
     const res = await fetch(`/api/data-tables/${tableId}/realtime/lock`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ action: "acquire", recordId, fieldKey }),
     });
     const data = await res.json();
-    return data.acquired === true;
+    if (data.acquired) return { acquired: true };
+    if (data.lockedBy) return { acquired: false, lockedBy: { userId: data.lockedBy.lockedById, userName: data.lockedBy.lockedByName } };
+    return { acquired: false };
   }, [tableId]);
 
   const releaseCellLock = useCallback(async (recordId: string, fieldKey: string): Promise<void> => {
@@ -225,6 +235,11 @@ export function useRealtimeTable({
     });
   }, [tableId]);
 
+  const onLockLost = useCallback((callback: (recordId: string, fieldKey: string) => void) => {
+    lockLostCallbacksRef.current.add(callback);
+    return () => { lockLostCallbacksRef.current.delete(callback); };
+  }, []);
+
   return {
     isConnected,
     activityFeed,
@@ -236,5 +251,6 @@ export function useRealtimeTable({
     getLockOwner,
     broadcastCursor,
     myColor,
+    onLockLost,
   };
 }

--- a/src/hooks/use-table-data.ts
+++ b/src/hooks/use-table-data.ts
@@ -51,6 +51,14 @@ export interface UseTableDataReturn {
   refresh: () => void;
   isConnected: boolean;
   activityFeed: import("@/types/realtime").ActivityEntry[];
+  onlineUsers: import("@/types/realtime").OnlineUser[];
+  cellLocks: Map<string, import("@/types/realtime").CellLock>;
+  acquireCellLock: (recordId: string, fieldKey: string) => Promise<boolean>;
+  releaseCellLock: (recordId: string, fieldKey: string) => Promise<void>;
+  isCellLockedByOther: (recordId: string, fieldKey: string) => boolean;
+  getLockOwner: (recordId: string, fieldKey: string) => { userId: string; userName: string } | null;
+  broadcastCursor: (recordId: string, fieldKey: string) => void;
+  myColor: string;
 }
 
 function buildTablePath(tableId: string, params: URLSearchParams): string {
@@ -232,7 +240,18 @@ export function useTableData({
     []
   );
 
-  const { isConnected, activityFeed } = useRealtimeTable({
+  const {
+    isConnected,
+    activityFeed,
+    onlineUsers,
+    cellLocks,
+    acquireCellLock,
+    releaseCellLock,
+    isCellLockedByOther,
+    getLockOwner,
+    broadcastCursor,
+    myColor,
+  } = useRealtimeTable({
     tableId,
     onUpdateRecordField: updateRecordField,
     onRefresh: refresh,
@@ -533,5 +552,13 @@ export function useTableData({
     refresh,
     isConnected,
     activityFeed,
+    onlineUsers,
+    cellLocks,
+    acquireCellLock,
+    releaseCellLock,
+    isCellLockedByOther,
+    getLockOwner,
+    broadcastCursor,
+    myColor,
   };
 }

--- a/src/hooks/use-table-data.ts
+++ b/src/hooks/use-table-data.ts
@@ -53,12 +53,13 @@ export interface UseTableDataReturn {
   activityFeed: import("@/types/realtime").ActivityEntry[];
   onlineUsers: import("@/types/realtime").OnlineUser[];
   cellLocks: Map<string, import("@/types/realtime").CellLock>;
-  acquireCellLock: (recordId: string, fieldKey: string) => Promise<boolean>;
+  acquireCellLock: (recordId: string, fieldKey: string) => Promise<{ acquired: boolean; lockedBy?: { userId: string; userName: string } }>;
   releaseCellLock: (recordId: string, fieldKey: string) => Promise<void>;
   isCellLockedByOther: (recordId: string, fieldKey: string) => boolean;
   getLockOwner: (recordId: string, fieldKey: string) => { userId: string; userName: string } | null;
   broadcastCursor: (recordId: string, fieldKey: string) => void;
   myColor: string;
+  onLockLost: (callback: (recordId: string, fieldKey: string) => void) => () => void;
 }
 
 function buildTablePath(tableId: string, params: URLSearchParams): string {
@@ -251,6 +252,7 @@ export function useTableData({
     getLockOwner,
     broadcastCursor,
     myColor,
+    onLockLost,
   } = useRealtimeTable({
     tableId,
     onUpdateRecordField: updateRecordField,
@@ -560,5 +562,6 @@ export function useTableData({
     getLockOwner,
     broadcastCursor,
     myColor,
+    onLockLost,
   };
 }

--- a/src/lib/services/presence.service.ts
+++ b/src/lib/services/presence.service.ts
@@ -1,0 +1,133 @@
+import { broadcastToTable } from "@/lib/services/realtime-notify.service";
+import type { OnlineUser, CellLock } from "@/types/realtime";
+import { getUserColor } from "@/types/realtime";
+
+interface PresenceEntry {
+  userName: string;
+  color: string;
+  joinedAt: number;
+}
+
+interface LockEntry {
+  recordId: string;
+  fieldKey: string;
+  lockedById: string;
+  lockedByName: string;
+  color: string;
+  lockedAt: number;
+}
+
+const presence = new Map<string, Map<string, PresenceEntry>>();
+const locks = new Map<string, Map<string, LockEntry>>();
+
+function getPresenceMap(tableId: string): Map<string, PresenceEntry> {
+  let map = presence.get(tableId);
+  if (!map) {
+    map = new Map();
+    presence.set(tableId, map);
+  }
+  return map;
+}
+
+function getLockMap(tableId: string): Map<string, LockEntry> {
+  let map = locks.get(tableId);
+  if (!map) {
+    map = new Map();
+    locks.set(tableId, map);
+  }
+  return map;
+}
+
+function lockKey(recordId: string, fieldKey: string): string {
+  return `${recordId}:${fieldKey}`;
+}
+
+export { getUserColor };
+
+export function joinPresence(tableId: string, userId: string, userName: string): OnlineUser {
+  const color = getUserColor(userId);
+  getPresenceMap(tableId).set(userId, { userName, color, joinedAt: Date.now() });
+  broadcastToTable(tableId, { type: "user_joined", tableId, userId, userName, color });
+  return { userId, userName, color };
+}
+
+export function leavePresence(tableId: string, userId: string): void {
+  getPresenceMap(tableId).delete(userId);
+  releaseAllLocksForUser(tableId, userId);
+  broadcastToTable(tableId, { type: "user_left", tableId, userId });
+}
+
+export function getOnlineUsers(tableId: string): OnlineUser[] {
+  const map = presence.get(tableId);
+  if (!map) return [];
+  return Array.from(map.entries()).map(([userId, entry]) => ({
+    userId,
+    userName: entry.userName,
+    color: entry.color,
+  }));
+}
+
+export function getLocksForTable(tableId: string): CellLock[] {
+  const map = locks.get(tableId);
+  if (!map) return [];
+  return Array.from(map.values()).map((entry) => ({
+    recordId: entry.recordId,
+    fieldKey: entry.fieldKey,
+    lockedById: entry.lockedById,
+    lockedByName: entry.lockedByName,
+    color: entry.color,
+  }));
+}
+
+export function acquireLock(
+  tableId: string,
+  recordId: string,
+  fieldKey: string,
+  userId: string,
+  userName: string
+): { acquired: boolean; lockedBy?: { userId: string; userName: string } } {
+  const key = lockKey(recordId, fieldKey);
+  const map = getLockMap(tableId);
+  const existing = map.get(key);
+  if (existing && existing.lockedById !== userId) {
+    return { acquired: false, lockedBy: { userId: existing.lockedById, userName: existing.lockedByName } };
+  }
+  const color = getUserColor(userId);
+  map.set(key, { recordId, fieldKey, lockedById: userId, lockedByName: userName, color, lockedAt: Date.now() });
+  broadcastToTable(tableId, { type: "cell_locked", tableId, recordId, fieldKey, lockedById: userId, lockedByName: userName, color });
+  return { acquired: true };
+}
+
+export function releaseLock(tableId: string, recordId: string, fieldKey: string, userId: string): void {
+  const key = lockKey(recordId, fieldKey);
+  const map = locks.get(tableId);
+  if (!map) return;
+  const entry = map.get(key);
+  if (!entry || entry.lockedById !== userId) return;
+  map.delete(key);
+  broadcastToTable(tableId, { type: "cell_unlocked", tableId, recordId, fieldKey, unlockedById: userId });
+}
+
+export function releaseAllLocksForUser(tableId: string, userId: string): void {
+  const map = locks.get(tableId);
+  if (!map) return;
+  for (const [key, entry] of map) {
+    if (entry.lockedById === userId) {
+      map.delete(key);
+      broadcastToTable(tableId, { type: "cell_unlocked", tableId, recordId: entry.recordId, fieldKey: entry.fieldKey, unlockedById: userId });
+    }
+  }
+}
+
+// Stale-lock reaper: remove locks older than 5 minutes
+setInterval(() => {
+  const cutoff = Date.now() - 5 * 60 * 1000;
+  for (const [tableId, map] of locks) {
+    for (const [key, entry] of map) {
+      if (entry.lockedAt < cutoff) {
+        map.delete(key);
+        broadcastToTable(tableId, { type: "cell_unlocked", tableId, recordId: entry.recordId, fieldKey: entry.fieldKey, unlockedById: entry.lockedById });
+      }
+    }
+  }
+}, 60_000);

--- a/src/lib/services/realtime-notify.service.ts
+++ b/src/lib/services/realtime-notify.service.ts
@@ -93,6 +93,15 @@ export function subscribeToTable(
   };
 }
 
+export function broadcastToTable(tableId: string, event: RealtimeEvent): void {
+  const tableListeners = listeners.get(tableId);
+  if (tableListeners) {
+    for (const fn of tableListeners) {
+      fn(event);
+    }
+  }
+}
+
 export function shutdownRealtimeNotify(): void {
   if (listenClient) {
     void listenClient.end();

--- a/src/types/realtime.ts
+++ b/src/types/realtime.ts
@@ -1,3 +1,5 @@
+// ── Data change events ──
+
 export interface RecordUpdatedEvent {
   type: "record_updated";
   tableId: string;
@@ -28,10 +30,99 @@ export interface RecordDeletedEvent {
   deletedAt: string;
 }
 
+// ── Presence events ──
+
+export interface UserJoinedEvent {
+  type: "user_joined";
+  tableId: string;
+  userId: string;
+  userName: string;
+  color: string;
+}
+
+export interface UserLeftEvent {
+  type: "user_left";
+  tableId: string;
+  userId: string;
+}
+
+export interface PresenceSnapshotEvent {
+  type: "presence_snapshot";
+  tableId: string;
+  users: Array<{ userId: string; userName: string; color: string }>;
+  locks: Array<{ recordId: string; fieldKey: string; lockedById: string; lockedByName: string; color: string }>;
+}
+
+// ── Cell lock events ──
+
+export interface CellLockedEvent {
+  type: "cell_locked";
+  tableId: string;
+  recordId: string;
+  fieldKey: string;
+  lockedById: string;
+  lockedByName: string;
+  color: string;
+}
+
+export interface CellUnlockedEvent {
+  type: "cell_unlocked";
+  tableId: string;
+  recordId: string;
+  fieldKey: string;
+  unlockedById: string;
+}
+
+// ── Cursor events ──
+
+export interface CursorMovedEvent {
+  type: "cursor_moved";
+  tableId: string;
+  userId: string;
+  userName: string;
+  recordId: string;
+  fieldKey: string;
+  color: string;
+}
+
+// ── Union ──
+
 export type RealtimeEvent =
   | RecordUpdatedEvent
   | RecordCreatedEvent
-  | RecordDeletedEvent;
+  | RecordDeletedEvent
+  | UserJoinedEvent
+  | UserLeftEvent
+  | PresenceSnapshotEvent
+  | CellLockedEvent
+  | CellUnlockedEvent
+  | CursorMovedEvent;
+
+// ── Client-side types ──
+
+const PALETTE = ["#3B82F6", "#EF4444", "#10B981", "#F59E0B", "#8B5CF6", "#EC4899", "#06B6D4", "#F97316"];
+
+export function getUserColor(userId: string): string {
+  let hash = 0;
+  for (let i = 0; i < userId.length; i++) {
+    hash = (hash * 31 + userId.charCodeAt(i)) | 0;
+  }
+  return PALETTE[Math.abs(hash) % PALETTE.length];
+}
+
+export interface OnlineUser {
+  userId: string;
+  userName: string;
+  color: string;
+}
+
+export interface CellLock {
+  recordId: string;
+  fieldKey: string;
+  lockedById: string;
+  lockedByName: string;
+  color: string;
+}
 
 export interface ActivityEntry {
   id: string;


### PR DESCRIPTION
## Summary
Phase 2 of real-time collaboration (Issue #98):
- 用户在线状态：内存注册表追踪在线用户，工具栏显示头像堆叠 + 在线人数
- 单元格编辑锁定：防止并发编辑同一单元格，已锁单元格显示头像 + "编辑中"指示器
- 光标位置广播 API（为 Phase 3 光标感知做准备）

## Changes
| 文件 | 说明 |
|------|------|
| `src/types/realtime.ts` | 新增 presence/lock/cursor 事件类型 + `getUserColor` |
| `src/lib/services/presence.service.ts` | 在线状态 + 锁定注册表（含 stale-lock 清理） |
| `src/lib/services/realtime-notify.service.ts` | 新增 `broadcastToTable` 直播函数 |
| `src/app/api/data-tables/[id]/realtime/route.ts` | SSE 连接时 join/leave + presence_snapshot |
| `src/app/api/data-tables/[id]/realtime/lock/route.ts` | 锁定 acquire/release API |
| `src/app/api/data-tables/[id]/realtime/cursor/route.ts` | 光标广播 API |
| `src/hooks/use-realtime-table.ts` | 处理新事件类型，导出 lock/presence 状态 |
| `src/hooks/use-table-data.ts` | 透传 lock/presence 到消费者 |
| `src/hooks/use-inline-edit.ts` | 编辑前检查锁，提交/取消后释放锁 |
| `src/components/data/user-avatar.tsx` | 头像组件 + 重叠堆叠 |
| `src/components/data/online-presence-bar.tsx` | 在线用户栏 |
| `src/components/data/record-table.tsx` | 工具栏集成在线用户栏 |
| `src/components/data/views/grid-view.tsx` | 锁定指示器（头像 + 编辑中 + 淡色背景） |

## Test plan
- [ ] 类型检查通过 `npx tsc --noEmit`
- [ ] 两个浏览器窗口登录不同用户，工具栏显示双方头像
- [ ] 用户 A 点击单元格编辑 → 用户 B 看到锁定指示器
- [ ] 用户 B 双击已锁单元格 → toast 提示"正在被 XX 编辑"
- [ ] 用户 A 完成编辑 → 锁定释放 → 用户 B 可编辑
- [ ] 用户 A 关闭页面 → 锁定自动释放 + 在线状态更新

Closes #98