### PR TITLE
[Fix] 记录详情页关联字段显示 ID 改为显示值

### DIFF
--- a/src/app/api/data-tables/[id]/records/[recordId]/route.ts
+++ b/src/app/api/data-tables/[id]/records/[recordId]/route.ts
@@ -16,7 +16,7 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
     return NextResponse.json({ error: "未授权" }, { status: 401 });
   }
 
-  const { recordId } = await params;
+  const { id: tableId, recordId } = await params;
   const result = await getRecord(recordId);
 
   if (!result.success) {
@@ -29,7 +29,45 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
     );
   }
 
-  return NextResponse.json(result.data);
+  const record = result.data;
+
+  // Resolve RELATION fields to {id, display} format (same as listRecords)
+  const table = await db.dataTable.findUnique({
+    where: { id: tableId },
+    include: { fields: { where: { type: "RELATION" } } },
+  });
+
+  if (table) {
+    const relationFields = table.fields.filter(
+      (f) => f.relationTo && f.displayField
+    );
+    const relIds = relationFields
+      .map((f) => record.data[f.key])
+      .filter((v): v is string => typeof v === "string" && !!v);
+
+    if (relIds.length > 0) {
+      const related = await db.dataRecord.findMany({
+        where: { id: { in: relIds } },
+      });
+      const relatedMap = new Map(
+        related.map((r) => [r.id, r.data as Record<string, unknown>])
+      );
+      for (const field of relationFields) {
+        const relId = record.data[field.key];
+        if (typeof relId === "string" && relId) {
+          const data = relatedMap.get(relId);
+          if (data) {
+            record.data[field.key] = {
+              id: relId,
+              display: data[field.displayField!] ?? relId,
+            };
+          }
+        }
+      }
+    }
+  }
+
+  return NextResponse.json(record);
 }
 
 export async function PUT(request: NextRequest, { params }: RouteParams) {


### PR DESCRIPTION
## Summary
- 记录详情页（GET /records/[recordId]）关联字段返回原始 ID，导致详情抽屉显示 ID 而非可读名称
- 在 API GET handler 中添加 RELATION 字段解析逻辑，与 `listRecords()` 保持一致，将 ID 转换为 `{id, display}` 格式
- `formatCellValue` 已能正确处理该格式，无需前端修改

## Test plan
- [x] 类型检查通过
- [x] 浏览器测试：Grid 视图关联字段显示名称
- [x] 浏览器测试：详情抽屉关联字段显示名称（非 ID）
- [ ] 测试无关联值的记录仍正常显示 "-"

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)