### PR TITLE
[Feature] 看板视图完善：拖拽移列 + 内联编辑 + 显示优化 (Issue #110)

### DIFF
--- a/src/components/data/record-table.tsx
+++ b/src/components/data/record-table.tsx
@@ -374,6 +374,7 @@ export function RecordTable({
             records={records}
             view={activeView}
             isAdmin={isAdmin}
+            tableId={tableId}
             onPatchRecord={handlePatchRecord}
             onOpenRecord={onOpenDetail ?? (() => {})}
           />

--- a/src/components/data/views/kanban/kanban-card.tsx
+++ b/src/components/data/views/kanban/kanban-card.tsx
@@ -1,37 +1,175 @@
 "use client";
 
+import { useState, useRef, useEffect, useCallback } from "react";
+import { useDraggable } from "@dnd-kit/react";
+import { MessageSquare } from "lucide-react";
 import type { DataFieldItem, DataRecordItem } from "@/types/data-table";
+import { FieldType } from "@/generated/prisma/enums";
+import { formatCellValue } from "@/lib/format-cell";
 
 interface KanbanCardProps {
   record: DataRecordItem;
   cardFields: DataFieldItem[];
   titleField: DataFieldItem;
+  commentCount: number;
   onOpenRecord: (recordId: string) => void;
+  onPatchRecord: (recordId: string, fieldKey: string, value: unknown) => Promise<void>;
 }
 
 export function KanbanCard({
   record,
   cardFields,
   titleField,
+  commentCount,
   onOpenRecord,
+  onPatchRecord,
 }: KanbanCardProps) {
+  const { ref, isDragging } = useDraggable({ id: record.id });
+  const [editingField, setEditingField] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState("");
+  const [isCommitting, setIsCommitting] = useState(false);
+  const inputRef = useRef<HTMLInputElement | HTMLSelectElement>(null);
+
+  useEffect(() => {
+    if (editingField && inputRef.current) {
+      inputRef.current.focus();
+      if (inputRef.current instanceof HTMLInputElement) {
+        inputRef.current.select();
+      }
+    }
+  }, [editingField]);
+
+  const commitEdit = useCallback(async () => {
+    if (!editingField || isCommitting) return;
+    const field = cardFields.find((f) => f.key === editingField) ?? titleField;
+    const currentValue = record.data[editingField];
+    const newValue = field.type === FieldType.NUMBER ? (editValue === "" ? null : Number(editValue)) : editValue;
+
+    setEditingField(null);
+    if (JSON.stringify(currentValue) === JSON.stringify(newValue)) return;
+
+    setIsCommitting(true);
+    try {
+      await onPatchRecord(record.id, editingField, newValue);
+    } catch {
+      console.error("保存失败");
+    } finally {
+      setIsCommitting(false);
+    }
+  }, [editingField, editValue, record.id, record.data, cardFields, titleField, onPatchRecord, isCommitting]);
+
+  const handleDoubleClick = useCallback(
+    (e: React.MouseEvent, fieldKey: string) => {
+      e.stopPropagation();
+      const value = record.data[fieldKey];
+      setEditValue(value == null ? "" : String(value));
+      setEditingField(fieldKey);
+    },
+    [record.data]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        commitEdit();
+      } else if (e.key === "Escape") {
+        setEditingField(null);
+      }
+    },
+    [commitEdit]
+  );
+
   const title = String(record.data[titleField.key] ?? "未命名记录");
 
   return (
     <div
-      className="w-full rounded-lg border bg-background p-3 text-left shadow-xs transition-colors hover:bg-accent cursor-pointer"
-      onClick={() => onOpenRecord(record.id)}
+      ref={ref}
+      className={`w-full rounded-lg border bg-background p-3 text-left shadow-xs transition-colors hover:bg-accent cursor-grab active:cursor-grabbing ${
+        isDragging ? "opacity-40" : ""
+      }`}
+      onClick={() => {
+        if (!editingField) onOpenRecord(record.id);
+      }}
     >
-      <div className="text-sm font-medium">{title}</div>
+      {editingField === titleField.key ? (
+        <input
+          ref={inputRef as React.RefObject<HTMLInputElement>}
+          className="text-sm font-medium w-full rounded border px-1 py-0.5 bg-background outline-none focus:ring-1 focus:ring-primary"
+          value={editValue}
+          onChange={(e) => setEditValue(e.target.value)}
+          onBlur={commitEdit}
+          onKeyDown={handleKeyDown}
+          onClick={(e) => e.stopPropagation()}
+        />
+      ) : (
+        <div className="flex items-start justify-between gap-2">
+          <div
+            className="text-sm font-medium"
+            onDoubleClick={(e) => handleDoubleClick(e, titleField.key)}
+          >
+            {title}
+          </div>
+          {commentCount > 0 && (
+            <span className="flex shrink-0 items-center gap-0.5 rounded-full bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+              <MessageSquare className="h-3 w-3" />
+              {commentCount}
+            </span>
+          )}
+        </div>
+      )}
       <div className="mt-2 space-y-1">
         {cardFields
           .filter((field) => field.key !== titleField.key)
-          .map((field) => (
-            <div key={field.id} className="text-xs text-muted-foreground">
-              <span className="mr-1">{field.label}:</span>
-              <span>{String(record.data[field.key] ?? "-")}</span>
-            </div>
-          ))}
+          .map((field) => {
+            const value = record.data[field.key];
+            const isEditing = editingField === field.key;
+
+            return (
+              <div key={field.id} className="text-xs text-muted-foreground flex items-center gap-1 flex-wrap">
+                <span className="shrink-0">{field.label}:</span>
+                {isEditing ? (
+                  field.type === FieldType.SELECT ? (
+                    <select
+                      ref={inputRef as React.RefObject<HTMLSelectElement>}
+                      className="text-xs rounded border px-1 py-0 bg-background outline-none focus:ring-1 focus:ring-primary"
+                      value={editValue}
+                      onChange={(e) => {
+                        const newValue = e.target.value;
+                        setEditingField(null);
+                        if (record.data[field.key] !== newValue) {
+                          onPatchRecord(record.id, field.key, newValue);
+                        }
+                      }}
+                      onBlur={() => setEditingField(null)}
+                      onKeyDown={handleKeyDown}
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {(field.options as string[])?.map((opt) => (
+                        <option key={opt} value={opt}>
+                          {opt}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <input
+                      ref={inputRef as React.RefObject<HTMLInputElement>}
+                      className="text-xs flex-1 min-w-0 rounded border px-1 py-0 bg-background outline-none focus:ring-1 focus:ring-primary"
+                      value={editValue}
+                      onChange={(e) => setEditValue(e.target.value)}
+                      onBlur={commitEdit}
+                      onKeyDown={handleKeyDown}
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                  )
+                ) : (
+                  <span onDoubleClick={(e) => handleDoubleClick(e, field.key)}>
+                    {formatCellValue(field, value)}
+                  </span>
+                )}
+              </div>
+            );
+          })}
       </div>
     </div>
   );

--- a/src/components/data/views/kanban/kanban-card.tsx
+++ b/src/components/data/views/kanban/kanban-card.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useDraggable } from "@dnd-kit/react";
 import { MessageSquare } from "lucide-react";
+import { toast } from "sonner";
 import type { DataFieldItem, DataRecordItem } from "@/types/data-table";
 import { FieldType } from "@/generated/prisma/enums";
 import { formatCellValue } from "@/lib/format-cell";
@@ -52,7 +53,7 @@ export function KanbanCard({
     try {
       await onPatchRecord(record.id, editingField, newValue);
     } catch {
-      console.error("保存失败");
+      toast.error("保存失败");
     } finally {
       setIsCommitting(false);
     }
@@ -138,7 +139,9 @@ export function KanbanCard({
                         const newValue = e.target.value;
                         setEditingField(null);
                         if (record.data[field.key] !== newValue) {
-                          onPatchRecord(record.id, field.key, newValue);
+                          onPatchRecord(record.id, field.key, newValue).catch(() => {
+                            toast.error("保存失败");
+                          });
                         }
                       }}
                       onBlur={() => setEditingField(null)}

--- a/src/components/data/views/kanban/kanban-column.tsx
+++ b/src/components/data/views/kanban/kanban-column.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useDroppable } from "@dnd-kit/react";
 import type { DataFieldItem, DataRecordItem } from "@/types/data-table";
 import { KanbanCard } from "./kanban-card";
 
@@ -8,7 +9,9 @@ interface KanbanColumnProps {
   records: DataRecordItem[];
   cardFields: DataFieldItem[];
   titleField: DataFieldItem;
+  commentCounts: Record<string, number>;
   onOpenRecord: (recordId: string) => void;
+  onPatchRecord: (recordId: string, fieldKey: string, value: unknown) => Promise<void>;
 }
 
 export function KanbanColumn({
@@ -16,10 +19,19 @@ export function KanbanColumn({
   records,
   cardFields,
   titleField,
+  commentCounts,
   onOpenRecord,
+  onPatchRecord,
 }: KanbanColumnProps) {
+  const { ref, isDropTarget } = useDroppable({ id: label });
+
   return (
-    <section className="min-w-[280px] flex-1 rounded-xl border bg-muted/30 p-3">
+    <section
+      ref={ref}
+      className={`min-w-[280px] flex-1 rounded-xl border bg-muted/30 p-3 transition-colors ${
+        isDropTarget ? "border-primary/50 bg-primary/5" : ""
+      }`}
+    >
       <div className="mb-3 flex items-center justify-between">
         <h3 className="text-sm font-semibold">{label}</h3>
         <span className="rounded-full bg-background px-2 py-0.5 text-xs text-muted-foreground">
@@ -33,7 +45,9 @@ export function KanbanColumn({
             record={record}
             cardFields={cardFields}
             titleField={titleField}
+            commentCount={commentCounts[record.id] ?? 0}
             onOpenRecord={onOpenRecord}
+            onPatchRecord={onPatchRecord}
           />
         ))}
       </div>

--- a/src/components/data/views/kanban/kanban-view.tsx
+++ b/src/components/data/views/kanban/kanban-view.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState, useCallback, useEffect } from "react";
 import { DragDropProvider, DragOverlay } from "@dnd-kit/react";
+import { toast } from "sonner";
 import type { DataFieldItem, DataRecordItem, DataViewItem } from "@/types/data-table";
 import { FieldType } from "@/generated/prisma/enums";
 import { KanbanColumn } from "./kanban-column";
@@ -126,7 +127,9 @@ export function KanbanView({
       if (!record || !groupField) return;
       if (record.data[groupField.key] === newValue) return;
 
-      onPatchRecord(recordId, groupField.key, newValue);
+      onPatchRecord(recordId, groupField.key, newValue).catch(() => {
+        toast.error("移动失败");
+      });
     },
     [records, groupField, onPatchRecord]
   );

--- a/src/components/data/views/kanban/kanban-view.tsx
+++ b/src/components/data/views/kanban/kanban-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, useCallback, useEffect } from "react";
+import { DragDropProvider, DragOverlay } from "@dnd-kit/react";
 import type { DataFieldItem, DataRecordItem, DataViewItem } from "@/types/data-table";
 import { FieldType } from "@/generated/prisma/enums";
 import { KanbanColumn } from "./kanban-column";
@@ -10,6 +11,7 @@ interface KanbanViewProps {
   records: DataRecordItem[];
   view: DataViewItem;
   isAdmin: boolean;
+  tableId: string;
   onPatchRecord: (recordId: string, fieldKey: string, value: unknown) => Promise<void>;
   onOpenRecord: (recordId: string) => void;
 }
@@ -37,17 +39,26 @@ function resolveTitleField(fields: DataFieldItem[]): DataFieldItem {
   );
 }
 
+interface DragEvent {
+  operation: {
+    source: { id: string | number } | null;
+    target: { id: string | number } | null;
+  };
+  canceled: boolean;
+}
+
 export function KanbanView({
   fields,
   records,
   view,
+  tableId,
   onPatchRecord,
   onOpenRecord,
 }: KanbanViewProps) {
   const groupField = resolveGroupField(view, fields);
-
-  // Early return placeholder - we'll render this after hooks
   const [shouldReturn, setShouldReturn] = useState(false);
+  const [activeRecordId, setActiveRecordId] = useState<string | null>(null);
+  const [commentCounts, setCommentCounts] = useState<Record<string, number>>({});
 
   const cardFieldKeys = Array.isArray(view.viewOptions.cardFields)
     ? view.viewOptions.cardFields.filter((key): key is string => typeof key === "string")
@@ -74,9 +85,53 @@ export function KanbanView({
     return groups;
   }, [records, groupField]);
 
-  // Check if we need to show the error message
+  const recordIdsKey = records.map((r) => r.id).join(",");
+  useEffect(() => {
+    if (!tableId || recordIdsKey.length === 0) return;
+    const ids = recordIdsKey.split(",");
+    fetch(`/api/data-tables/${tableId}/records/${ids[0]}/comments?ids=${ids.join(",")}`)
+      .then((res) => (res.ok ? res.json() : {}))
+      .then((data: Record<string, number>) => setCommentCounts(data))
+      .catch(() => {});
+  }, [tableId, recordIdsKey]);
+
+  const activeRecord = activeRecordId
+    ? records.find((r) => r.id === activeRecordId) ?? null
+    : null;
+
+  const effectiveCardFields = cardFields.length > 0 ? cardFields : fields;
+
+  const handleDragStart = useCallback(
+    (event: { operation: { source: { id: string | number } | null } }) => {
+      const sourceId = event.operation.source?.id;
+      if (sourceId) setActiveRecordId(String(sourceId));
+    },
+    []
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEvent) => {
+      setActiveRecordId(null);
+      if (event.canceled) return;
+
+      const sourceId = event.operation.source?.id;
+      const targetId = event.operation.target?.id;
+      if (!sourceId || !targetId) return;
+
+      const recordId = String(sourceId);
+      const targetGroup = String(targetId);
+      const newValue = targetGroup === "无值" ? "" : targetGroup;
+
+      const record = records.find((r) => r.id === recordId);
+      if (!record || !groupField) return;
+      if (record.data[groupField.key] === newValue) return;
+
+      onPatchRecord(recordId, groupField.key, newValue);
+    },
+    [records, groupField, onPatchRecord]
+  );
+
   if (!groupField && !shouldReturn) {
-    // This is a workaround for ESLint rules-of-hooks
     setShouldReturn(true);
   }
 
@@ -90,17 +145,37 @@ export function KanbanView({
   }
 
   return (
-    <div className="flex gap-4 overflow-x-auto pb-2">
-      {[...groupedRecords.entries()].map(([label, columnRecords]) => (
-        <KanbanColumn
-          key={label}
-          label={label}
-          records={columnRecords}
-          cardFields={cardFields.length > 0 ? cardFields : fields}
-          titleField={titleField}
-          onOpenRecord={onOpenRecord}
-        />
-      ))}
-    </div>
+    <DragDropProvider onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+      <div className="flex gap-4 overflow-x-auto pb-2">
+        {[...groupedRecords.entries()].map(([label, columnRecords]) => (
+          <KanbanColumn
+            key={label}
+            label={label}
+            records={columnRecords}
+            cardFields={effectiveCardFields}
+            titleField={titleField}
+            commentCounts={commentCounts}
+            onOpenRecord={onOpenRecord}
+            onPatchRecord={onPatchRecord}
+          />
+        ))}
+      </div>
+      <DragOverlay>
+        {activeRecord && (
+          <div className="w-[280px] rounded-lg border bg-background p-3 shadow-lg opacity-80">
+            <div className="text-sm font-medium">
+              {String(activeRecord.data[titleField.key] ?? "未命名记录")}
+            </div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              {effectiveCardFields
+                .filter((f) => f.key !== titleField.key)
+                .slice(0, 2)
+                .map((f) => String(activeRecord.data[f.key] ?? "-"))
+                .join(" · ")}
+            </div>
+          </div>
+        )}
+      </DragOverlay>
+    </DragDropProvider>
   );
 }


### PR DESCRIPTION
## Summary
- 使用 @dnd-kit/react 实现看板卡片跨列拖拽，通过 PATCH API 更新记录的 SELECT 分组字段值
- 双击卡片字段进入内联编辑模式，支持 TEXT（输入框）和 SELECT（下拉选择自动提交）
- 使用 `formatCellValue` 渲染带颜色的 SELECT 徽章，替代纯文本显示
- 显示评论数量角标（MessageSquare 图标 + 计数），通过批量查询 API 获取
- 拖拽时显示 DragOverlay 预览卡片，目标列添加高亮边框反馈

## 修改文件
| 文件 | 改动 |
|------|------|
| `kanban-view.tsx` | 包裹 DragDropProvider，添加拖拽处理、评论计数、DragOverlay |
| `kanban-column.tsx` | 添加 useDroppable 成为放置目标，传递 props |
| `kanban-card.tsx` | 添加 useDraggable、内联编辑状态、formatCellValue、评论角标 |
| `record-table.tsx` | 传递 tableId 给 KanbanView |

## Test plan
- [x] 创建含 SELECT 字段的测试表和看板视图
- [x] 拖拽卡片从一列到另一列，验证 SELECT 字段值正确更新
- [x] 双击 TEXT 字段进入输入框编辑，Enter 提交、Escape 取消
- [x] 双击 SELECT 字段显示下拉选择，选择后自动提交
- [x] SELECT 字段值以带颜色的徽章显示
- [x] 类型检查通过（`npx tsc --noEmit`）

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)