### PR TITLE
[Feature] 关联字段选择器优化：内联搜索 + 快捷新建 (Issue #112)

### DIFF
--- a/src/components/data/cell-editors/relation-cell-editor.tsx
+++ b/src/components/data/cell-editors/relation-cell-editor.tsx
@@ -5,16 +5,20 @@ import { createPortal } from "react-dom";
 import { useSession } from "next-auth/react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Check, X } from "lucide-react";
 import { toast } from "sonner";
 import { useRelationOptions } from "@/hooks/use-relation-options";
 import { RelationQuickCreateForm } from "@/components/data/relation-quick-create-form";
 
 interface RelationCellEditorProps {
-  value: string | { id: string; display?: string } | null;
-  onCommit: (value: string | { id: string; display: string } | null) => void;
+  value: string | { id: string; display?: string } | Array<{ id: string; display?: string }> | null;
+  onCommit: (value: string | { id: string; display: string } | Array<{ id: string; display: string }> | null) => void;
   onCancel: () => void;
   relationTableId?: string;
   displayField?: string;
+  multiSelect?: boolean;
+  onOpenRecord?: (recordId: string) => void;
 }
 
 export function RelationCellEditor({
@@ -23,6 +27,8 @@ export function RelationCellEditor({
   onCancel,
   relationTableId,
   displayField,
+  multiSelect = false,
+  onOpenRecord,
 }: RelationCellEditorProps) {
   const { data: session } = useSession();
   const isAdmin = session?.user?.role === "ADMIN";
@@ -41,6 +47,10 @@ export function RelationCellEditor({
     search,
     setSearch,
     sentinelRef,
+    selectedIds: hookSelectedIds,
+    toggleSelect,
+    removeSelect,
+    selectedItems,
     createRecord,
     isCreating,
     showCreateForm,
@@ -49,6 +59,7 @@ export function RelationCellEditor({
   } = useRelationOptions({
     relationTableId: relationTableId ?? "",
     displayField,
+    multiSelect,
   });
 
   const updatePosition = () => {
@@ -64,7 +75,6 @@ export function RelationCellEditor({
     setMounted(true);
   }, []);
 
-  // Close dropdown on outside click
   useEffect(() => {
     if (!isOpen) return;
     function handleClickOutside(e: MouseEvent) {
@@ -85,21 +95,29 @@ export function RelationCellEditor({
     [options]
   );
 
-  const currentLabel = useMemo(() => {
-    if (!value) return null;
-    if (typeof value === "object") return (value as { display?: string }).display;
-    return optionMap.get(value)?.label ?? value;
-  }, [value, optionMap]);
-
-  const rawId = useMemo(() => {
-    if (!value) return null;
-    if (typeof value === "object" && "id" in (value as object)) {
-      return (value as { id: string }).id;
-    }
-    return String(value);
+  // Parse initial value(s) into a consistent format
+  const initialIds = useMemo(() => {
+    if (!value) return [] as string[];
+    if (Array.isArray(value)) return value.map((v) => typeof v === "object" && "id" in v ? v.id : String(v));
+    if (typeof value === "object") return [(value as { id: string }).id];
+    return [String(value)];
   }, [value]);
 
-  function handleSelect(id: string, label: string) {
+  // For single-select: track the current raw ID
+  const rawId = useMemo(() => {
+    if (multiSelect) return null;
+    return initialIds[0] ?? null;
+  }, [multiSelect, initialIds]);
+
+  const currentLabel = useMemo(() => {
+    if (!rawId) return null;
+    if (typeof value === "object" && !Array.isArray(value) && value !== null) {
+      return (value as { display?: string }).display;
+    }
+    return optionMap.get(rawId)?.label ?? rawId;
+  }, [rawId, value, optionMap]);
+
+  function handleSingleSelect(id: string, label: string) {
     committedRef.current = true;
     onCommit({ id, display: label });
   }
@@ -109,12 +127,25 @@ export function RelationCellEditor({
     onCommit(null);
   }
 
+  function handleMultiCommit() {
+    committedRef.current = true;
+    if (selectedItems.length === 0) {
+      onCommit(null);
+    } else {
+      onCommit(selectedItems.map((item) => ({ id: item.id, display: item.label })));
+    }
+  }
+
   async function handleCreate(data: Record<string, unknown>) {
     try {
       const newOption = await createRecord(data);
       if (newOption) {
-        committedRef.current = true;
-        onCommit({ id: newOption.id, display: newOption.label });
+        if (multiSelect) {
+          // Auto-selected by hook, just update UI
+        } else {
+          committedRef.current = true;
+          onCommit({ id: newOption.id, display: newOption.label });
+        }
       }
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "创建失败");
@@ -126,7 +157,7 @@ export function RelationCellEditor({
     return (
       <Input
         value={rawId ?? ""}
-        onChange={(e) => {}}
+        onChange={() => {}}
         onKeyDown={(e) => {
           if (e.key === "Escape") { e.preventDefault(); onCancel(); }
         }}
@@ -138,6 +169,132 @@ export function RelationCellEditor({
     );
   }
 
+  // ── Multi-select mode ──
+  if (multiSelect) {
+    const dropdown = isOpen && dropdownPos ? createPortal(
+      <div
+        id="relation-dropdown-portal"
+        style={{
+          position: "fixed",
+          top: dropdownPos.top,
+          left: dropdownPos.left,
+          zIndex: 9999,
+        }}
+        className="w-72 bg-background border rounded-md shadow-lg"
+      >
+        {showCreateForm ? (
+          <RelationQuickCreateForm
+            fields={requiredFields}
+            onSubmit={handleCreate}
+            onCancel={() => setShowCreateForm(false)}
+            isSubmitting={isCreating}
+          />
+        ) : (
+          <>
+            <div className="max-h-52 overflow-auto">
+              {isLoading ? (
+                <div className="p-3 text-center text-sm text-muted-foreground">加载中...</div>
+              ) : options.length === 0 ? (
+                <div className="p-3 text-center text-sm text-muted-foreground">
+                  {search ? "无匹配结果" : "暂无记录"}
+                </div>
+              ) : (
+                <>
+                  {options.map((option) => {
+                    const isSelected = hookSelectedIds.has(option.id);
+                    return (
+                      <button
+                        key={option.id}
+                        type="button"
+                        className={`w-full text-left px-3 py-1.5 text-sm hover:bg-muted flex items-center gap-2 ${
+                          isSelected ? "bg-muted/50" : ""
+                        }`}
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          toggleSelect(option.id, option.label);
+                        }}
+                      >
+                        <span className={`w-4 h-4 shrink-0 rounded border flex items-center justify-center ${
+                          isSelected ? "bg-primary border-primary text-primary-foreground" : "border-muted-foreground/30"
+                        }`}>
+                          {isSelected && <Check className="h-3 w-3" />}
+                        </span>
+                        <span className="truncate">{option.label}</span>
+                      </button>
+                    );
+                  })}
+                  {hasMore && (
+                    <div ref={sentinelRef} className="p-2 text-center text-xs text-muted-foreground">
+                      {isLoadingMore ? "加载更多..." : ""}
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+            <div className="border-t p-1 flex gap-1">
+              {isAdmin && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="flex-1 h-7 text-xs"
+                  onMouseDown={(e) => { e.preventDefault(); setShowCreateForm(true); }}
+                >
+                  + 新建记录
+                </Button>
+              )}
+              <Button
+                variant="ghost"
+                size="sm"
+                className="flex-1 h-7 text-xs"
+                onMouseDown={(e) => { e.preventDefault(); handleMultiCommit(); }}
+              >
+                确认
+              </Button>
+            </div>
+          </>
+        )}
+      </div>,
+      document.body
+    ) : null;
+
+    return (
+      <div ref={containerRef} className="relative flex items-center gap-1 flex-wrap min-h-8 p-0.5">
+        {selectedItems.length > 0 ? selectedItems.map((item) => (
+          <Badge key={item.id} variant="secondary" className="gap-0.5 text-xs pr-0.5">
+            {item.label}
+            <button
+              className="ml-0.5 rounded-full hover:bg-muted-foreground/20 p-0.5"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                removeSelect(item.id);
+              }}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </Badge>
+        )) : null}
+        <input
+          ref={inputRef}
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              e.preventDefault();
+              committedRef.current = true;
+              onCancel();
+            }
+          }}
+          onFocus={updatePosition}
+          className="min-w-[80px] flex-1 text-sm outline-none bg-transparent border-none h-6 px-1"
+          placeholder={selectedItems.length > 0 ? "搜索..." : "搜索关联记录..."}
+        />
+        {mounted && dropdown}
+      </div>
+    );
+  }
+
+  // ── Single-select mode ──
   const dropdown = isOpen && dropdownPos ? createPortal(
     <div
       id="relation-dropdown-portal"
@@ -171,15 +328,32 @@ export function RelationCellEditor({
                   <button
                     key={option.id}
                     type="button"
-                    className={`w-full text-left px-3 py-1.5 text-sm hover:bg-muted truncate ${
+                    className={`w-full text-left px-3 py-1.5 text-sm hover:bg-muted flex items-center gap-2 ${
                       option.id === rawId ? "bg-muted font-medium" : ""
                     }`}
                     onMouseDown={(e) => {
                       e.preventDefault();
-                      handleSelect(option.id, option.label);
+                      handleSingleSelect(option.id, option.label);
                     }}
                   >
-                    {option.label}
+                    {onOpenRecord && option.id === rawId && (
+                      <span
+                        className="text-blue-600 hover:underline shrink-0"
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          onOpenRecord(option.id);
+                          committedRef.current = true;
+                          onCancel();
+                        }}
+                        title="查看详情"
+                      >
+                        {option.label}
+                      </span>
+                    )}
+                    {(!onOpenRecord || option.id !== rawId) && (
+                      <span className="truncate">{option.label}</span>
+                    )}
                   </button>
                 ))}
                 {hasMore && (

--- a/src/components/data/cell-editors/relation-cell-editor.tsx
+++ b/src/components/data/cell-editors/relation-cell-editor.tsx
@@ -39,6 +39,21 @@ export function RelationCellEditor({
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
+  // Build initial selected items from value prop (for multi-select initialization)
+  const parsedInitialItems = useMemo(() => {
+    if (!multiSelect || !value) return undefined;
+    if (Array.isArray(value)) {
+      return value
+        .filter((v): v is { id: string; display?: string } => typeof v === "object" && "id" in v)
+        .map((v) => ({ id: v.id, label: v.display ?? v.id }));
+    }
+    if (typeof value === "object" && "id" in value) {
+      const v = value as { id: string; display?: string };
+      return [{ id: v.id, label: v.display ?? v.id }];
+    }
+    return undefined;
+  }, [multiSelect, value]);
+
   const {
     options,
     isLoading,
@@ -60,6 +75,7 @@ export function RelationCellEditor({
     relationTableId: relationTableId ?? "",
     displayField,
     multiSelect,
+    initialSelectedItems: parsedInitialItems,
   });
 
   const updatePosition = () => {

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -1379,23 +1379,53 @@ export function GridView({
           );
         }
         case FieldType.RELATION: {
+          const isMulti = field.relationCardinality === "MULTIPLE";
+          if (isMulti) {
+            const multiValue = Array.isArray(originalValue)
+              ? originalValue as Array<{ id: string; display?: string }>
+              : originalValue && typeof originalValue === "object"
+                ? [originalValue as { id: string; display?: string }]
+                : [];
+            return (
+              <RelationCellEditor
+                value={multiValue}
+                onCommit={async (v) => {
+                  if (!v) {
+                    await commitEdit(null);
+                    onUpdateRecordField(record.id, field.key, null);
+                  } else if (Array.isArray(v)) {
+                    const apiValue = v.map((item) => item.id);
+                    await commitEdit(apiValue);
+                    onUpdateRecordField(record.id, field.key, v);
+                  } else {
+                    const apiValue = (v as { id: string }).id;
+                    await commitEdit(apiValue);
+                    onUpdateRecordField(record.id, field.key, v as { id: string; display: string });
+                  }
+                }}
+                onCancel={cancelEdit}
+                relationTableId={field.relationTo}
+                displayField={field.displayField}
+                multiSelect
+              />
+            );
+          }
           const relValue = originalValue as { id?: string; display?: string } | string | null;
           const relId = relValue && typeof relValue === "object" ? relValue.id ?? null : typeof relValue === "string" ? relValue : null;
           return (
             <RelationCellEditor
               value={relId}
               onCommit={async (v) => {
-                // Extract raw ID for API
-                const apiValue = v && typeof v === "object" ? v.id : v;
+                const apiValue = v && typeof v === "object" && !Array.isArray(v) ? v.id : v;
                 await commitEdit(apiValue);
-                // Override local state with resolved {id, display} object
-                if (v && typeof v === "object") {
+                if (v && typeof v === "object" && !Array.isArray(v)) {
                   onUpdateRecordField(record.id, field.key, v);
                 }
               }}
               onCancel={cancelEdit}
               relationTableId={field.relationTo}
               displayField={field.displayField}
+              onOpenRecord={onOpenDetail}
             />
           );
         }

--- a/src/hooks/use-relation-options.ts
+++ b/src/hooks/use-relation-options.ts
@@ -20,6 +20,7 @@ interface UseRelationOptionsParams {
   displayField?: string;
   pageSize?: number;
   multiSelect?: boolean;
+  initialSelectedItems?: RelationOption[];
 }
 
 export function useRelationOptions({
@@ -27,6 +28,7 @@ export function useRelationOptions({
   displayField,
   pageSize = 50,
   multiSelect = false,
+  initialSelectedItems,
 }: UseRelationOptionsParams) {
   // ── Pagination state ──
   const [options, setOptions] = useState<RelationOption[]>([]);
@@ -46,8 +48,12 @@ export function useRelationOptions({
   const [requiredFields, setRequiredFields] = useState<DataFieldItem[]>([]);
 
   // ── Multi-select state ──
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [selectedItems, setSelectedItems] = useState<RelationOption[]>([]);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(
+    () => new Set(initialSelectedItems?.map((i) => i.id) ?? [])
+  );
+  const [selectedItems, setSelectedItems] = useState<RelationOption[]>(
+    () => initialSelectedItems ?? []
+  );
 
   // ── Build API URL ──
   const buildUrl = useCallback(

--- a/src/lib/format-cell.tsx
+++ b/src/lib/format-cell.tsx
@@ -136,6 +136,26 @@ export function formatCellValue(
     case FieldType.PHONE:
       return <span className="font-mono">{String(value)}</span>;
     case FieldType.RELATION: {
+      if (Array.isArray(value)) {
+        const items = value.filter(
+          (v): v is Record<string, unknown> => v != null && typeof v === "object"
+        );
+        if (items.length === 0) return <span className="text-zinc-400">-</span>;
+        const visibleItems = items.slice(0, 3);
+        const hiddenCount = items.length - visibleItems.length;
+        return (
+          <div className="flex flex-wrap gap-1">
+            {visibleItems.map((item, i) => (
+              <Badge key={i} variant="outline" className="text-xs">
+                {String(item.display ?? item.displayValue ?? item.id ?? "-")}
+              </Badge>
+            ))}
+            {hiddenCount > 0 && (
+              <Badge variant="secondary" className="text-xs">+{hiddenCount}</Badge>
+            )}
+          </div>
+        );
+      }
       const obj = value as Record<string, unknown> | null;
       const displayValue =
         obj?.display ?? obj?.displayValue ?? value;


### PR DESCRIPTION
## Summary
- RelationCellEditor 支持多选模式（relationCardinality=MULTIPLE），显示勾选列表 + badge 标签 + 移除按钮
- 单选模式新增 onOpenRecord 回调，可从选择器内展开关联记录详情
- formatCellValue 支持数组 RELATION 值，显示多个 badge + 溢出计数
- grid-view 根据 relationCardinality 自动切换单选/多选编辑器

## 修改文件
| 文件 | 改动 |
|------|------|
| `cell-editors/relation-cell-editor.tsx` | 新增 multiSelect 模式，badge 显示，单选 onOpenRecord |
| `format-cell.tsx` | RELATION 类型支持数组值渲染多个 badge |
| `grid-view.tsx` | 传递 relationCardinality/multiSelect/onOpenRecord |

## Test plan
- [ ] 单选 RELATION 字段双击编辑，搜索选择正常
- [ ] 多选 RELATION 字段双击编辑，勾选列表和 badge 显示正常
- [ ] 多选 badge 点击 × 可移除关联
- [ ] 点击"新建记录"可快捷新建并自动关联
- [ ] 类型检查通过

Closes #112