### PR TITLE
[Feature] 日历视图 (Issue #113)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -301,6 +301,7 @@ enum ViewType {
   GALLERY
   TIMELINE
   FORM
+  CALENDAR
 }
 
 enum RelationCardinality {

--- a/src/components/data/record-table.tsx
+++ b/src/components/data/record-table.tsx
@@ -419,6 +419,7 @@ export function RecordTable({
             onPatchRecord={handlePatchRecord}
             onOpenRecord={onOpenDetail ?? (() => {})}
             onRecordCreated={refresh}
+            onViewOptionsChange={setViewOptions}
           />
         );
       default:

--- a/src/components/data/record-table.tsx
+++ b/src/components/data/record-table.tsx
@@ -32,6 +32,7 @@ import { GridView } from "@/components/data/views/grid-view";
 import { KanbanView } from "@/components/data/views/kanban/kanban-view";
 import { GalleryView } from "@/components/data/views/gallery/gallery-view";
 import { TimelineView } from "@/components/data/views/timeline/timeline-view";
+import { CalendarView } from "@/components/data/views/calendar/calendar-view";
 import { FormView } from "@/components/data/views/form/form-view";
 import { ActivityStream } from "@/components/data/activity-stream";
 import { OnlinePresenceBar } from "@/components/data/online-presence-bar";
@@ -405,6 +406,19 @@ export function RecordTable({
             view={activeView}
             onViewOptionsChange={setViewOptions}
             tableId={tableId}
+          />
+        );
+      case "CALENDAR":
+        return (
+          <CalendarView
+            fields={fields}
+            records={records}
+            view={activeView}
+            isAdmin={isAdmin}
+            tableId={tableId}
+            onPatchRecord={handlePatchRecord}
+            onOpenRecord={onOpenDetail ?? (() => {})}
+            onRecordCreated={refresh}
           />
         );
       default:

--- a/src/components/data/view-switcher.tsx
+++ b/src/components/data/view-switcher.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/tooltip";
 import type { ViewType } from "@/types/data-table";
 import {
+  CalendarDays,
   ClipboardList,
   Columns3,
   GalleryHorizontal,
@@ -50,6 +51,11 @@ const VIEW_ITEMS: Array<{
     type: "FORM",
     label: "表单",
     Icon: ClipboardList,
+  },
+  {
+    type: "CALENDAR",
+    label: "日历",
+    Icon: CalendarDays,
   },
 ];
 

--- a/src/components/data/views/calendar/calendar-view.tsx
+++ b/src/components/data/views/calendar/calendar-view.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useMemo, useState, useCallback } from "react";
-import { DragDropProvider, DragOverlay } from "@dnd-kit/react";
+import { useMemo, useState, useCallback, useRef } from "react";
+import { DragDropProvider, DragOverlay, useDraggable, useDroppable } from "@dnd-kit/react";
 import { ChevronLeft, ChevronRight, Settings2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
 import type { DataFieldItem, DataRecordItem, DataViewItem } from "@/types/data-table";
 import { FieldType } from "@/generated/prisma/enums";
 
@@ -16,6 +17,7 @@ interface CalendarViewProps {
   onPatchRecord: (recordId: string, fieldKey: string, value: unknown) => Promise<void>;
   onOpenRecord: (recordId: string) => void;
   onRecordCreated?: () => void;
+  onViewOptionsChange?: (options: Record<string, unknown>) => void;
 }
 
 function asFieldKey(val: unknown): string | null {
@@ -44,6 +46,14 @@ interface CalendarEvent {
   endDate: Date;
 }
 
+interface DragEvent {
+  operation: {
+    source: { id: string | number } | null;
+    target: { id: string | number } | null;
+  };
+  canceled: boolean;
+}
+
 export function CalendarView({
   fields,
   records,
@@ -53,10 +63,12 @@ export function CalendarView({
   onPatchRecord,
   onOpenRecord,
   onRecordCreated,
+  onViewOptionsChange,
 }: CalendarViewProps) {
   const [currentDate, setCurrentDate] = useState(() => new Date());
   const [showConfig, setShowConfig] = useState(false);
   const [activeEventId, setActiveEventId] = useState<string | null>(null);
+  const creatingRef = useRef(false);
 
   const dateField = asFieldKey(view.viewOptions.startDateField);
   const endDateField = asFieldKey(view.viewOptions.endDateField);
@@ -74,7 +86,14 @@ export function CalendarView({
 
   const isConfigured = !!dateField && !!labelField;
 
-  // Build calendar events
+  const handleOptionChange = useCallback(
+    (key: string, value: string | null) => {
+      if (!onViewOptionsChange) return;
+      onViewOptionsChange({ ...view.viewOptions, [key]: value });
+    },
+    [onViewOptionsChange, view.viewOptions]
+  );
+
   const events = useMemo<CalendarEvent[]>(() => {
     if (!isConfigured) return [];
     return records
@@ -92,20 +111,18 @@ export function CalendarView({
       .filter((e): e is CalendarEvent => e !== null);
   }, [records, dateField, endDateField, labelField, isConfigured]);
 
-  // Calendar grid calculation
   const year = currentDate.getFullYear();
   const month = currentDate.getMonth();
 
   const calendarDays = useMemo(() => {
     const firstDay = new Date(year, month, 1);
     const lastDay = new Date(year, month + 1, 0);
-    const startDow = (firstDay.getDay() + 6) % 7; // Monday = 0
+    const startDow = (firstDay.getDay() + 6) % 7;
     const totalDays = lastDay.getDate();
     const days: Date[] = [];
     for (let i = 1 - startDow; i <= totalDays; i++) {
       days.push(new Date(year, month, i));
     }
-    // Pad to full weeks
     while (days.length % 7 !== 0) {
       const d = days[days.length - 1];
       days.push(new Date(year, month, d.getDate() + 1));
@@ -118,11 +135,13 @@ export function CalendarView({
     for (const event of events) {
       const start = new Date(event.startDate.getFullYear(), event.startDate.getMonth(), event.startDate.getDate());
       const end = new Date(event.endDate.getFullYear(), event.endDate.getMonth(), event.endDate.getDate());
-      for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
-        const key = toLocalDateString(d);
+      let cur = new Date(start);
+      while (cur <= end) {
+        const key = toLocalDateString(cur);
         const list = map.get(key) ?? [];
         list.push(event);
         map.set(key, list);
+        cur = new Date(cur.getFullYear(), cur.getMonth(), cur.getDate() + 1);
       }
     }
     return map;
@@ -152,33 +171,57 @@ export function CalendarView({
   );
 
   const handleDragEnd = useCallback(
-    (event: { operation: { source: { id: string | number } | null; target: { id: string | number } | null }; canceled: boolean }) => {
+    (event: DragEvent) => {
       setActiveEventId(null);
       if (event.canceled || !dateField) return;
       const sourceId = String(event.operation.source?.id ?? "");
       const targetDate = String(event.operation.target?.id ?? "");
       if (!sourceId || !targetDate) return;
-      onPatchRecord(sourceId, dateField, targetDate).catch(() => {});
+      onPatchRecord(sourceId, dateField, targetDate).catch(() => {
+        toast.error("移动失败");
+      });
     },
     [dateField, onPatchRecord]
   );
 
   const handleDayClick = useCallback(
     async (dateStr: string) => {
-      if (!isAdmin || !dateField) return;
+      if (!isAdmin || !dateField || creatingRef.current) return;
+      creatingRef.current = true;
       try {
         const res = await fetch(`/api/data-tables/${tableId}/records`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ data: { [dateField]: dateStr } }),
         });
-        if (res.ok) onRecordCreated?.();
-      } catch {}
+        if (res.ok) {
+          onRecordCreated?.();
+        } else {
+          const data = await res.json().catch(() => ({}));
+          toast.error(data.error ?? "创建失败");
+        }
+      } catch {
+        toast.error("创建失败");
+      } finally {
+        creatingRef.current = false;
+      }
     },
     [isAdmin, dateField, tableId, onRecordCreated]
   );
 
   const today = toLocalDateString(new Date());
+
+  const configPanel = showConfig ? (
+    <ConfigPanel
+      dateFields={dateFields}
+      textFields={textFields}
+      startDateField={dateField}
+      endDateField={endDateField}
+      labelField={labelField}
+      onChange={handleOptionChange}
+      onClose={() => setShowConfig(false)}
+    />
+  ) : null;
 
   if (!isConfigured) {
     return (
@@ -192,20 +235,7 @@ export function CalendarView({
             </Button>
           )}
         </div>
-        {showConfig && (
-          <ConfigPanel
-            fields={fields}
-            dateFields={dateFields}
-            textFields={textFields}
-            startDateField={dateField}
-            endDateField={endDateField}
-            labelField={labelField}
-            onChange={(key, value) => {
-              view.viewOptions[key] = value;
-            }}
-            onClose={() => setShowConfig(false)}
-          />
-        )}
+        {configPanel}
       </div>
     );
   }
@@ -238,24 +268,10 @@ export function CalendarView({
           </Button>
         </div>
 
-        {showConfig && (
-          <ConfigPanel
-            fields={fields}
-            dateFields={dateFields}
-            textFields={textFields}
-            startDateField={dateField}
-            endDateField={endDateField}
-            labelField={labelField}
-            onChange={(key, value) => {
-              view.viewOptions[key] = value;
-            }}
-            onClose={() => setShowConfig(false)}
-          />
-        )}
+        {configPanel}
 
         {/* Calendar grid */}
         <div className="flex-1 border rounded-md overflow-hidden">
-          {/* Weekday headers */}
           <div className="grid grid-cols-7 bg-muted/50">
             {WEEKDAYS.map((d) => (
               <div key={d} className="px-2 py-1.5 text-xs font-medium text-muted-foreground text-center border-b">
@@ -263,52 +279,19 @@ export function CalendarView({
               </div>
             ))}
           </div>
-          {/* Day cells */}
           <div className="grid grid-cols-7 flex-1">
-            {calendarDays.map((day, i) => {
-              const dateStr = toLocalDateString(day);
-              const isCurrentMonth = day.getMonth() === month;
-              const isToday = dateStr === today;
-              const dayEvents = eventsByDate.get(dateStr) ?? [];
-              const visibleEvents = dayEvents.slice(0, 3);
-              const hiddenCount = dayEvents.length - visibleEvents.length;
-
-              return (
-                <div
-                  key={i}
-                  data-drop-id={dateStr}
-                  className={`border-b border-r p-1 min-h-[80px] flex flex-col ${
-                    isCurrentMonth ? "bg-background" : "bg-muted/30"
-                  } ${isAdmin ? "cursor-pointer" : ""}`}
-                  onClick={() => handleDayClick(dateStr)}
-                >
-                  <div className={`text-xs mb-0.5 px-1 ${
-                    isToday ? "bg-primary text-primary-foreground rounded-full w-5 h-5 flex items-center justify-center font-bold" :
-                    !isCurrentMonth ? "text-muted-foreground/50" : "text-muted-foreground"
-                  }`}>
-                    {day.getDate()}
-                  </div>
-                  <div className="flex-1 space-y-0.5 overflow-hidden">
-                    {visibleEvents.map((ev) => (
-                      <CalendarEventCard
-                        key={ev.record.id}
-                        event={ev}
-                        isMultiDay={ev.startDate.getTime() !== ev.endDate.getTime()}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onOpenRecord(ev.record.id);
-                        }}
-                      />
-                    ))}
-                    {hiddenCount > 0 && (
-                      <div className="text-[10px] text-muted-foreground px-1">
-                        +{hiddenCount} 更多
-                      </div>
-                    )}
-                  </div>
-                </div>
-              );
-            })}
+            {calendarDays.map((day, i) => (
+              <CalendarDayCell
+                key={i}
+                day={day}
+                month={month}
+                today={today}
+                events={eventsByDate.get(toLocalDateString(day)) ?? []}
+                isAdmin={isAdmin}
+                onDayClick={handleDayClick}
+                onOpenRecord={onOpenRecord}
+              />
+            ))}
           </div>
         </div>
       </div>
@@ -323,7 +306,69 @@ export function CalendarView({
   );
 }
 
-// ── Event Card ──
+// ── Day Cell with dnd-kit droppable ──
+
+function CalendarDayCell({
+  day,
+  month,
+  today,
+  events,
+  isAdmin,
+  onDayClick,
+  onOpenRecord,
+}: {
+  day: Date;
+  month: number;
+  today: string;
+  events: CalendarEvent[];
+  isAdmin: boolean;
+  onDayClick: (dateStr: string) => void;
+  onOpenRecord: (recordId: string) => void;
+}) {
+  const dateStr = toLocalDateString(day);
+  const isCurrentMonth = day.getMonth() === month;
+  const isToday = dateStr === today;
+  const { ref: dropRef, isDropTarget } = useDroppable({ id: dateStr });
+  const visibleEvents = events.slice(0, 3);
+  const hiddenCount = events.length - visibleEvents.length;
+
+  return (
+    <div
+      ref={dropRef}
+      className={`border-b border-r p-1 min-h-[80px] flex flex-col ${
+        isCurrentMonth ? "bg-background" : "bg-muted/30"
+      } ${isDropTarget ? "bg-primary/5 border-primary/30" : ""} ${isAdmin ? "cursor-pointer" : ""}`}
+      onClick={() => onDayClick(dateStr)}
+    >
+      <div className={`text-xs mb-0.5 px-1 ${
+        isToday ? "bg-primary text-primary-foreground rounded-full w-5 h-5 flex items-center justify-center font-bold" :
+        !isCurrentMonth ? "text-muted-foreground/50" : "text-muted-foreground"
+      }`}>
+        {day.getDate()}
+      </div>
+      <div className="flex-1 space-y-0.5 overflow-hidden">
+        {visibleEvents.map((ev) => (
+          <CalendarEventCard
+            key={ev.record.id}
+            event={ev}
+            isMultiDay={ev.startDate.getTime() !== ev.endDate.getTime()}
+            onClick={(e) => {
+              e.stopPropagation();
+              onOpenRecord(ev.record.id);
+            }}
+          />
+        ))}
+        {hiddenCount > 0 && (
+          <div className="text-[10px] text-muted-foreground px-1">
+            +{hiddenCount} 更多
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Event Card with dnd-kit draggable ──
 
 function CalendarEventCard({
   event,
@@ -334,15 +379,14 @@ function CalendarEventCard({
   isMultiDay: boolean;
   onClick: (e: React.MouseEvent) => void;
 }) {
-  // Use native draggable since dnd-kit useDraggable needs hook rules
+  const { ref, isDragging } = useDraggable({ id: event.record.id });
+
   return (
     <div
-      draggable
-      onDragStart={(e) => {
-        e.dataTransfer.setData("text/plain", event.record.id);
-        e.dataTransfer.effectAllowed = "move";
-      }}
-      className="rounded px-1 py-0.5 text-[11px] truncate cursor-grab active:cursor-grabbing bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
+      ref={ref}
+      className={`rounded px-1 py-0.5 text-[11px] truncate cursor-grab active:cursor-grabbing bg-primary/10 text-primary hover:bg-primary/20 transition-colors ${
+        isDragging ? "opacity-40" : ""
+      }`}
       onClick={onClick}
       title={isMultiDay ? `${event.label} (${toLocalDateString(event.startDate)} - ${toLocalDateString(event.endDate)})` : event.label}
     >
@@ -362,7 +406,6 @@ function ConfigPanel({
   onChange,
   onClose,
 }: {
-  fields: DataFieldItem[];
   dateFields: DataFieldItem[];
   textFields: DataFieldItem[];
   startDateField: string | null;

--- a/src/components/data/views/calendar/calendar-view.tsx
+++ b/src/components/data/views/calendar/calendar-view.tsx
@@ -1,0 +1,425 @@
+"use client";
+
+import { useMemo, useState, useCallback } from "react";
+import { DragDropProvider, DragOverlay } from "@dnd-kit/react";
+import { ChevronLeft, ChevronRight, Settings2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { DataFieldItem, DataRecordItem, DataViewItem } from "@/types/data-table";
+import { FieldType } from "@/generated/prisma/enums";
+
+interface CalendarViewProps {
+  fields: DataFieldItem[];
+  records: DataRecordItem[];
+  view: DataViewItem;
+  isAdmin: boolean;
+  tableId: string;
+  onPatchRecord: (recordId: string, fieldKey: string, value: unknown) => Promise<void>;
+  onOpenRecord: (recordId: string) => void;
+  onRecordCreated?: () => void;
+}
+
+function asFieldKey(val: unknown): string | null {
+  return typeof val === "string" && val.length > 0 ? val : null;
+}
+
+function toDateValue(raw: unknown): Date | null {
+  if (typeof raw !== "string" || raw.length === 0) return null;
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function toLocalDateString(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+const WEEKDAYS = ["一", "二", "三", "四", "五", "六", "日"];
+
+interface CalendarEvent {
+  record: DataRecordItem;
+  label: string;
+  startDate: Date;
+  endDate: Date;
+}
+
+export function CalendarView({
+  fields,
+  records,
+  view,
+  tableId,
+  isAdmin,
+  onPatchRecord,
+  onOpenRecord,
+  onRecordCreated,
+}: CalendarViewProps) {
+  const [currentDate, setCurrentDate] = useState(() => new Date());
+  const [showConfig, setShowConfig] = useState(false);
+  const [activeEventId, setActiveEventId] = useState<string | null>(null);
+
+  const dateField = asFieldKey(view.viewOptions.startDateField);
+  const endDateField = asFieldKey(view.viewOptions.endDateField);
+  const labelField = asFieldKey(view.viewOptions.labelField);
+
+  const dateFields = useMemo(
+    () => fields.filter((f) => f.type === FieldType.DATE),
+    [fields]
+  );
+
+  const textFields = useMemo(
+    () => fields.filter((f) => f.type === FieldType.TEXT || f.type === FieldType.NUMBER),
+    [fields]
+  );
+
+  const isConfigured = !!dateField && !!labelField;
+
+  // Build calendar events
+  const events = useMemo<CalendarEvent[]>(() => {
+    if (!isConfigured) return [];
+    return records
+      .map((record) => {
+        const startDate = toDateValue(record.data[dateField!]);
+        if (!startDate) return null;
+        const endValue = endDateField ? toDateValue(record.data[endDateField]) : null;
+        return {
+          record,
+          label: String(record.data[labelField!] ?? record.id),
+          startDate,
+          endDate: endValue ?? startDate,
+        };
+      })
+      .filter((e): e is CalendarEvent => e !== null);
+  }, [records, dateField, endDateField, labelField, isConfigured]);
+
+  // Calendar grid calculation
+  const year = currentDate.getFullYear();
+  const month = currentDate.getMonth();
+
+  const calendarDays = useMemo(() => {
+    const firstDay = new Date(year, month, 1);
+    const lastDay = new Date(year, month + 1, 0);
+    const startDow = (firstDay.getDay() + 6) % 7; // Monday = 0
+    const totalDays = lastDay.getDate();
+    const days: Date[] = [];
+    for (let i = 1 - startDow; i <= totalDays; i++) {
+      days.push(new Date(year, month, i));
+    }
+    // Pad to full weeks
+    while (days.length % 7 !== 0) {
+      const d = days[days.length - 1];
+      days.push(new Date(year, month, d.getDate() + 1));
+    }
+    return days;
+  }, [year, month]);
+
+  const eventsByDate = useMemo(() => {
+    const map = new Map<string, CalendarEvent[]>();
+    for (const event of events) {
+      const start = new Date(event.startDate.getFullYear(), event.startDate.getMonth(), event.startDate.getDate());
+      const end = new Date(event.endDate.getFullYear(), event.endDate.getMonth(), event.endDate.getDate());
+      for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+        const key = toLocalDateString(d);
+        const list = map.get(key) ?? [];
+        list.push(event);
+        map.set(key, list);
+      }
+    }
+    return map;
+  }, [events]);
+
+  const activeEvent = activeEventId
+    ? events.find((e) => e.record.id === activeEventId) ?? null
+    : null;
+
+  const handlePrevMonth = useCallback(() => {
+    setCurrentDate((d) => new Date(d.getFullYear(), d.getMonth() - 1, 1));
+  }, []);
+
+  const handleNextMonth = useCallback(() => {
+    setCurrentDate((d) => new Date(d.getFullYear(), d.getMonth() + 1, 1));
+  }, []);
+
+  const handleToday = useCallback(() => {
+    setCurrentDate(new Date());
+  }, []);
+
+  const handleDragStart = useCallback(
+    (event: { operation: { source: { id: string | number } | null } }) => {
+      setActiveEventId(String(event.operation.source?.id ?? ""));
+    },
+    []
+  );
+
+  const handleDragEnd = useCallback(
+    (event: { operation: { source: { id: string | number } | null; target: { id: string | number } | null }; canceled: boolean }) => {
+      setActiveEventId(null);
+      if (event.canceled || !dateField) return;
+      const sourceId = String(event.operation.source?.id ?? "");
+      const targetDate = String(event.operation.target?.id ?? "");
+      if (!sourceId || !targetDate) return;
+      onPatchRecord(sourceId, dateField, targetDate).catch(() => {});
+    },
+    [dateField, onPatchRecord]
+  );
+
+  const handleDayClick = useCallback(
+    async (dateStr: string) => {
+      if (!isAdmin || !dateField) return;
+      try {
+        const res = await fetch(`/api/data-tables/${tableId}/records`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ data: { [dateField]: dateStr } }),
+        });
+        if (res.ok) onRecordCreated?.();
+      } catch {}
+    },
+    [isAdmin, dateField, tableId, onRecordCreated]
+  );
+
+  const today = toLocalDateString(new Date());
+
+  if (!isConfigured) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-8">
+        <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+          <p className="mb-3">日历视图需要配置日期字段和标题字段</p>
+          {!showConfig && (
+            <Button variant="outline" size="sm" onClick={() => setShowConfig(true)}>
+              <Settings2 className="h-4 w-4 mr-1" />
+              去配置
+            </Button>
+          )}
+        </div>
+        {showConfig && (
+          <ConfigPanel
+            fields={fields}
+            dateFields={dateFields}
+            textFields={textFields}
+            startDateField={dateField}
+            endDateField={endDateField}
+            labelField={labelField}
+            onChange={(key, value) => {
+              view.viewOptions[key] = value;
+            }}
+            onClose={() => setShowConfig(false)}
+          />
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <DragDropProvider onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+      <div className="flex flex-col flex-1 min-h-0">
+        {/* Toolbar */}
+        <div className="flex items-center gap-2 mb-3">
+          <Button variant="outline" size="icon-sm" onClick={handlePrevMonth}>
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <span className="text-sm font-medium min-w-[120px] text-center">
+            {year} 年 {month + 1} 月
+          </span>
+          <Button variant="outline" size="icon-sm" onClick={handleNextMonth}>
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+          <Button variant="ghost" size="sm" onClick={handleToday}>
+            今天
+          </Button>
+          <div className="flex-1" />
+          <Button
+            variant={showConfig ? "secondary" : "outline"}
+            size="sm"
+            onClick={() => setShowConfig(!showConfig)}
+          >
+            <Settings2 className="h-4 w-4 mr-1" />
+            配置
+          </Button>
+        </div>
+
+        {showConfig && (
+          <ConfigPanel
+            fields={fields}
+            dateFields={dateFields}
+            textFields={textFields}
+            startDateField={dateField}
+            endDateField={endDateField}
+            labelField={labelField}
+            onChange={(key, value) => {
+              view.viewOptions[key] = value;
+            }}
+            onClose={() => setShowConfig(false)}
+          />
+        )}
+
+        {/* Calendar grid */}
+        <div className="flex-1 border rounded-md overflow-hidden">
+          {/* Weekday headers */}
+          <div className="grid grid-cols-7 bg-muted/50">
+            {WEEKDAYS.map((d) => (
+              <div key={d} className="px-2 py-1.5 text-xs font-medium text-muted-foreground text-center border-b">
+                {d}
+              </div>
+            ))}
+          </div>
+          {/* Day cells */}
+          <div className="grid grid-cols-7 flex-1">
+            {calendarDays.map((day, i) => {
+              const dateStr = toLocalDateString(day);
+              const isCurrentMonth = day.getMonth() === month;
+              const isToday = dateStr === today;
+              const dayEvents = eventsByDate.get(dateStr) ?? [];
+              const visibleEvents = dayEvents.slice(0, 3);
+              const hiddenCount = dayEvents.length - visibleEvents.length;
+
+              return (
+                <div
+                  key={i}
+                  data-drop-id={dateStr}
+                  className={`border-b border-r p-1 min-h-[80px] flex flex-col ${
+                    isCurrentMonth ? "bg-background" : "bg-muted/30"
+                  } ${isAdmin ? "cursor-pointer" : ""}`}
+                  onClick={() => handleDayClick(dateStr)}
+                >
+                  <div className={`text-xs mb-0.5 px-1 ${
+                    isToday ? "bg-primary text-primary-foreground rounded-full w-5 h-5 flex items-center justify-center font-bold" :
+                    !isCurrentMonth ? "text-muted-foreground/50" : "text-muted-foreground"
+                  }`}>
+                    {day.getDate()}
+                  </div>
+                  <div className="flex-1 space-y-0.5 overflow-hidden">
+                    {visibleEvents.map((ev) => (
+                      <CalendarEventCard
+                        key={ev.record.id}
+                        event={ev}
+                        isMultiDay={ev.startDate.getTime() !== ev.endDate.getTime()}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onOpenRecord(ev.record.id);
+                        }}
+                      />
+                    ))}
+                    {hiddenCount > 0 && (
+                      <div className="text-[10px] text-muted-foreground px-1">
+                        +{hiddenCount} 更多
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+      <DragOverlay>
+        {activeEvent && (
+          <div className="rounded bg-primary/90 text-primary-foreground px-2 py-0.5 text-xs shadow-lg opacity-80">
+            {activeEvent.label}
+          </div>
+        )}
+      </DragOverlay>
+    </DragDropProvider>
+  );
+}
+
+// ── Event Card ──
+
+function CalendarEventCard({
+  event,
+  isMultiDay,
+  onClick,
+}: {
+  event: CalendarEvent;
+  isMultiDay: boolean;
+  onClick: (e: React.MouseEvent) => void;
+}) {
+  // Use native draggable since dnd-kit useDraggable needs hook rules
+  return (
+    <div
+      draggable
+      onDragStart={(e) => {
+        e.dataTransfer.setData("text/plain", event.record.id);
+        e.dataTransfer.effectAllowed = "move";
+      }}
+      className="rounded px-1 py-0.5 text-[11px] truncate cursor-grab active:cursor-grabbing bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
+      onClick={onClick}
+      title={isMultiDay ? `${event.label} (${toLocalDateString(event.startDate)} - ${toLocalDateString(event.endDate)})` : event.label}
+    >
+      {isMultiDay && "📅 "}{event.label}
+    </div>
+  );
+}
+
+// ── Config Panel ──
+
+function ConfigPanel({
+  dateFields,
+  textFields,
+  startDateField,
+  endDateField,
+  labelField,
+  onChange,
+  onClose,
+}: {
+  fields: DataFieldItem[];
+  dateFields: DataFieldItem[];
+  textFields: DataFieldItem[];
+  startDateField: string | null;
+  endDateField: string | null;
+  labelField: string | null;
+  onChange: (key: string, value: string | null) => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="border rounded-md p-4 mb-3 bg-muted/30 space-y-3">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium">日历视图配置</span>
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          关闭
+        </Button>
+      </div>
+      <div className="grid grid-cols-3 gap-3">
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">日期字段 *</label>
+          <select
+            value={startDateField ?? ""}
+            onChange={(e) => onChange("startDateField", e.target.value || null)}
+            className="w-full h-8 rounded-md border bg-background px-2 text-sm"
+          >
+            <option value="">选择日期字段</option>
+            {dateFields.map((f) => (
+              <option key={f.key} value={f.key}>{f.label}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">标题字段 *</label>
+          <select
+            value={labelField ?? ""}
+            onChange={(e) => onChange("labelField", e.target.value || null)}
+            className="w-full h-8 rounded-md border bg-background px-2 text-sm"
+          >
+            <option value="">选择标题字段</option>
+            {textFields.map((f) => (
+              <option key={f.key} value={f.key}>{f.label}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">结束日期字段</label>
+          <select
+            value={endDateField ?? ""}
+            onChange={(e) => onChange("endDateField", e.target.value || null)}
+            className="w-full h-8 rounded-md border bg-background px-2 text-sm"
+          >
+            <option value="">无</option>
+            {dateFields.map((f) => (
+              <option key={f.key} value={f.key}>{f.label}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- 新增 CalendarView 月视图组件，记录按日期字段分布在日历网格中
- 上/下月导航 + 跳转到今天按钮
- 点击记录卡片打开详情抽屉，点击空白日期新建记录（日期预填）
- 跨天事件支持（配置结束日期字段）
- 配置面板：选择日期字段、标题字段、结束日期字段
- 原生 HTML5 拖拽支持将记录拖到另一天更新日期

## 修改文件
| 文件 | 改动 |
|------|------|
| `prisma/schema.prisma` | ViewType 枚举添加 CALENDAR |
| `view-switcher.tsx` | 添加日历图标按钮 |
| `calendar-view.tsx` | 新增日历视图完整实现 |
| `record-table.tsx` | 添加 CalendarView 渲染分支 |

## Test plan
- [ ] 切换到日历视图，配置日期和标题字段
- [ ] 月视图正确渲染，记录显示在对应日期
- [ ] 上/下月导航正常，跳转到今天正常
- [ ] 点击记录卡片打开详情
- [ ] 点击空白日期新建记录（管理员）
- [ ] 类型检查通过

Closes #113