### PR TITLE
[Feature] 全局搜索 Cmd+K 跨表搜索记录

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+
+const SEARCHABLE_FIELD_TYPES = new Set([
+  "TEXT", "EMAIL", "SELECT", "PHONE", "URL",
+]);
+
+export async function GET(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "未授权" }, { status: 401 });
+  }
+
+  const q = request.nextUrl.searchParams.get("q")?.trim();
+  if (!q || q.length < 1) {
+    return NextResponse.json({ results: [] });
+  }
+
+  const limit = Math.min(parseInt(request.nextUrl.searchParams.get("limit") ?? "5", 10), 20);
+
+  // Fetch all tables with their fields
+  const tables = await db.dataTable.findMany({
+    include: { fields: true },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  const results: Array<{
+    tableId: string;
+    tableName: string;
+    tableIcon: string | null;
+    records: Array<{
+      id: string;
+      data: Record<string, unknown>;
+      matchedFields: string[];
+    }>;
+    totalMatches: number;
+  }> = [];
+
+  for (const table of tables) {
+    const searchFields = table.fields
+      .filter((f) => SEARCHABLE_FIELD_TYPES.has(f.type))
+      .map((f) => f.key);
+
+    if (searchFields.length === 0) continue;
+
+    const orConditions = searchFields.map((fieldKey) => ({
+      data: { path: [fieldKey], string_contains: q },
+    }));
+
+    const matchingRecords = await db.dataRecord.findMany({
+      where: {
+        tableId: table.id,
+        OR: orConditions,
+      },
+      take: limit + 1,
+      orderBy: { updatedAt: "desc" },
+    });
+
+    if (matchingRecords.length === 0) continue;
+
+    const records = matchingRecords.slice(0, limit).map((record) => {
+      const data = record.data as Record<string, unknown>;
+      const matchedFields = searchFields.filter((key) => {
+        const val = data[key];
+        return typeof val === "string" && val.toLowerCase().includes(q.toLowerCase());
+      });
+      return { id: record.id, data, matchedFields };
+    });
+
+    results.push({
+      tableId: table.id,
+      tableName: table.name,
+      tableIcon: table.icon,
+      records,
+      totalMatches: matchingRecords.length > limit ? matchingRecords.length : records.length,
+    });
+
+    if (results.length >= 10) break;
+  }
+
+  return NextResponse.json({ results });
+}

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,83 +1,34 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
-import { db } from "@/lib/db";
-
-const SEARCHABLE_FIELD_TYPES = new Set([
-  "TEXT", "EMAIL", "SELECT", "PHONE", "URL",
-]);
+import { globalSearch } from "@/lib/services/search.service";
 
 export async function GET(request: NextRequest) {
   const session = await auth();
   if (!session?.user?.id) {
-    return NextResponse.json({ error: "未授权" }, { status: 401 });
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "未登录" } },
+      { status: 401 }
+    );
   }
 
   const q = request.nextUrl.searchParams.get("q")?.trim();
-  if (!q || q.length < 1) {
-    return NextResponse.json({ results: [] });
+  if (!q) {
+    return NextResponse.json({ success: true, data: [] });
   }
 
-  const limit = Math.min(parseInt(request.nextUrl.searchParams.get("limit") ?? "5", 10), 20);
+  const limit = Math.min(
+    Math.max(parseInt(request.nextUrl.searchParams.get("limit") ?? "5", 10) || 5, 1),
+    20
+  );
 
-  // Fetch all tables with their fields
-  const tables = await db.dataTable.findMany({
-    include: { fields: true },
-    orderBy: { updatedAt: "desc" },
-  });
+  const result = await globalSearch(q, limit);
 
-  const results: Array<{
-    tableId: string;
-    tableName: string;
-    tableIcon: string | null;
-    records: Array<{
-      id: string;
-      data: Record<string, unknown>;
-      matchedFields: string[];
-    }>;
-    totalMatches: number;
-  }> = [];
-
-  for (const table of tables) {
-    const searchFields = table.fields
-      .filter((f) => SEARCHABLE_FIELD_TYPES.has(f.type))
-      .map((f) => f.key);
-
-    if (searchFields.length === 0) continue;
-
-    const orConditions = searchFields.map((fieldKey) => ({
-      data: { path: [fieldKey], string_contains: q },
-    }));
-
-    const matchingRecords = await db.dataRecord.findMany({
-      where: {
-        tableId: table.id,
-        OR: orConditions,
-      },
-      take: limit + 1,
-      orderBy: { updatedAt: "desc" },
-    });
-
-    if (matchingRecords.length === 0) continue;
-
-    const records = matchingRecords.slice(0, limit).map((record) => {
-      const data = record.data as Record<string, unknown>;
-      const matchedFields = searchFields.filter((key) => {
-        const val = data[key];
-        return typeof val === "string" && val.toLowerCase().includes(q.toLowerCase());
-      });
-      return { id: record.id, data, matchedFields };
-    });
-
-    results.push({
-      tableId: table.id,
-      tableName: table.name,
-      tableIcon: table.icon,
-      records,
-      totalMatches: matchingRecords.length > limit ? matchingRecords.length : records.length,
-    });
-
-    if (results.length >= 10) break;
+  if (!result.success) {
+    return NextResponse.json(
+      { error: { code: result.error.code, message: result.error.message } },
+      { status: 500 }
+    );
   }
 
-  return NextResponse.json({ results });
+  return NextResponse.json({ success: true, data: result.data });
 }

--- a/src/components/data/global-search-dialog.tsx
+++ b/src/components/data/global-search-dialog.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Search, Table2, X } from "lucide-react";
+
+interface SearchResult {
+  tableId: string;
+  tableName: string;
+  tableIcon: string | null;
+  records: Array<{
+    id: string;
+    data: Record<string, unknown>;
+    matchedFields: string[];
+  }>;
+  totalMatches: number;
+}
+
+interface FlattenedItem {
+  type: "record";
+  tableId: string;
+  tableName: string;
+  tableIcon: string | null;
+  recordId: string;
+  data: Record<string, unknown>;
+  matchedFields: string[];
+}
+
+export function GlobalSearchDialog({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  // Flatten results for keyboard navigation
+  const flatItems: FlattenedItem[] = results.flatMap((table) =>
+    table.records.map((record) => ({
+      type: "record" as const,
+      tableId: table.tableId,
+      tableName: table.tableName,
+      tableIcon: table.tableIcon,
+      recordId: record.id,
+      data: record.data,
+      matchedFields: record.matchedFields,
+    }))
+  );
+
+  const doSearch = useCallback(async (q: string) => {
+    if (!q.trim()) {
+      setResults([]);
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`);
+      if (res.ok) {
+        const data = await res.json();
+        setResults(data.results ?? []);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setResults([]);
+      setSelectedIndex(0);
+      return;
+    }
+    // Auto-focus input when dialog opens
+    setTimeout(() => inputRef.current?.focus(), 50);
+  }, [open]);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      doSearch(query);
+      setSelectedIndex(0);
+    }, 300);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query, doSearch]);
+
+  const handleSelect = useCallback(
+    (item: FlattenedItem) => {
+      router.push(`/data/${item.tableId}?recordId=${item.recordId}`);
+      onClose();
+    },
+    [router, onClose]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedIndex((i) => Math.min(i + 1, flatItems.length - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedIndex((i) => Math.max(i - 1, 0));
+      } else if (e.key === "Enter" && flatItems.length > 0) {
+        e.preventDefault();
+        handleSelect(flatItems[selectedIndex]);
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    },
+    [flatItems, selectedIndex, handleSelect, onClose]
+  );
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Dialog */}
+      <div className="relative w-full max-w-lg bg-background border rounded-xl shadow-2xl overflow-hidden">
+        {/* Search input */}
+        <div className="flex items-center gap-3 px-4 border-b">
+          <Search className="h-4 w-4 text-muted-foreground shrink-0" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="搜索记录、表名..."
+            className="flex-1 h-12 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          />
+          {query && (
+            <button
+              onClick={() => setQuery("")}
+              className="text-muted-foreground hover:text-foreground"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
+          <kbd className="hidden sm:inline-flex items-center rounded border bg-muted px-1.5 py-0.5 text-[10px] font-mono text-muted-foreground">
+            ESC
+          </kbd>
+        </div>
+
+        {/* Results */}
+        <div className="max-h-[400px] overflow-y-auto">
+          {isLoading && (
+            <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+              搜索中...
+            </div>
+          )}
+
+          {!isLoading && query && flatItems.length === 0 && (
+            <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+              未找到匹配结果
+            </div>
+          )}
+
+          {!isLoading &&
+            !query && (
+              <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+                输入关键词开始搜索
+              </div>
+            )}
+
+          {results.map((table) => {
+            if (table.records.length === 0) return null;
+            return (
+              <div key={table.tableId}>
+                <div className="flex items-center gap-2 px-4 pt-3 pb-1">
+                  {table.tableIcon ? (
+                    <span className="text-sm">{table.tableIcon}</span>
+                  ) : (
+                    <Table2 className="h-3.5 w-3.5 text-muted-foreground" />
+                  )}
+                  <span className="text-xs font-medium text-muted-foreground">
+                    {table.tableName}
+                  </span>
+                  {table.totalMatches > table.records.length && (
+                    <span className="text-[10px] text-muted-foreground">
+                      ({table.records.length}/{table.totalMatches})
+                    </span>
+                  )}
+                </div>
+                {table.records.map((record) => {
+                  const flatIdx = flatItems.findIndex(
+                    (f) => f.recordId === record.id && f.tableId === table.tableId
+                  );
+                  const isSelected = flatIdx === selectedIndex;
+                  const label = getRecordLabel(record.data, record.matchedFields);
+
+                  return (
+                    <button
+                      key={record.id}
+                      className={`w-full text-left px-4 py-2 flex items-center gap-3 text-sm transition-colors ${
+                        isSelected ? "bg-accent text-accent-foreground" : "hover:bg-accent/50"
+                      }`}
+                      onClick={() =>
+                        handleSelect({
+                          type: "record",
+                          tableId: table.tableId,
+                          tableName: table.tableName,
+                          tableIcon: table.tableIcon,
+                          recordId: record.id,
+                          data: record.data,
+                          matchedFields: record.matchedFields,
+                        })
+                      }
+                      onMouseEnter={() => setSelectedIndex(flatIdx)}
+                    >
+                      <span className="flex-1 truncate">
+                        <span className="font-medium">{label}</span>
+                        {record.matchedFields.length > 0 && (
+                          <span className="ml-2 text-muted-foreground text-xs">
+                            {record.matchedFields.join(", ")}
+                          </span>
+                        )}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Footer */}
+        <div className="border-t px-4 py-2 flex items-center gap-4 text-[10px] text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <kbd className="rounded border bg-muted px-1">↑</kbd>
+            <kbd className="rounded border bg-muted px-1">↓</kbd>
+            导航
+          </span>
+          <span className="flex items-center gap-1">
+            <kbd className="rounded border bg-muted px-1">↵</kbd>
+            打开
+          </span>
+          <span className="flex items-center gap-1">
+            <kbd className="rounded border bg-muted px-1">esc</kbd>
+            关闭
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function getRecordLabel(
+  data: Record<string, unknown>,
+  matchedFields: string[]
+): string {
+  // Prefer the first matched field value as label
+  for (const key of matchedFields) {
+    const val = data[key];
+    if (typeof val === "string" && val.trim()) return val;
+  }
+  // Fallback: first string field
+  for (const val of Object.values(data)) {
+    if (typeof val === "string" && val.trim()) return val;
+  }
+  return "未命名记录";
+}

--- a/src/components/data/global-search-dialog.tsx
+++ b/src/components/data/global-search-dialog.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Search, Table2, X } from "lucide-react";
+import { toast } from "sonner";
 
 interface SearchResult {
   tableId: string;
@@ -13,7 +14,7 @@ interface SearchResult {
     data: Record<string, unknown>;
     matchedFields: string[];
   }>;
-  totalMatches: number;
+  hasMore: boolean;
 }
 
 interface FlattenedItem {
@@ -41,7 +42,6 @@ export function GlobalSearchDialog({
   const inputRef = useRef<HTMLInputElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
-  // Flatten results for keyboard navigation
   const flatItems: FlattenedItem[] = results.flatMap((table) =>
     table.records.map((record) => ({
       type: "record" as const,
@@ -63,11 +63,15 @@ export function GlobalSearchDialog({
     try {
       const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`);
       if (res.ok) {
-        const data = await res.json();
-        setResults(data.results ?? []);
+        const json = await res.json();
+        setResults(json.data ?? []);
+      } else {
+        toast.error("搜索失败");
+        setResults([]);
       }
     } catch {
-      // ignore
+      toast.error("搜索失败，请检查网络连接");
+      setResults([]);
     } finally {
       setIsLoading(false);
     }
@@ -80,7 +84,6 @@ export function GlobalSearchDialog({
       setSelectedIndex(0);
       return;
     }
-    // Auto-focus input when dialog opens
     setTimeout(() => inputRef.current?.focus(), 50);
   }, [open]);
 
@@ -126,15 +129,12 @@ export function GlobalSearchDialog({
 
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]">
-      {/* Backdrop */}
       <div
         className="absolute inset-0 bg-black/50 backdrop-blur-sm"
         onClick={onClose}
       />
 
-      {/* Dialog */}
       <div className="relative w-full max-w-lg bg-background border rounded-xl shadow-2xl overflow-hidden">
-        {/* Search input */}
         <div className="flex items-center gap-3 px-4 border-b">
           <Search className="h-4 w-4 text-muted-foreground shrink-0" />
           <input
@@ -159,7 +159,6 @@ export function GlobalSearchDialog({
           </kbd>
         </div>
 
-        {/* Results */}
         <div className="max-h-[400px] overflow-y-auto">
           {isLoading && (
             <div className="px-4 py-8 text-center text-sm text-muted-foreground">
@@ -173,12 +172,11 @@ export function GlobalSearchDialog({
             </div>
           )}
 
-          {!isLoading &&
-            !query && (
-              <div className="px-4 py-8 text-center text-sm text-muted-foreground">
-                输入关键词开始搜索
-              </div>
-            )}
+          {!isLoading && !query && (
+            <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+              输入关键词开始搜索
+            </div>
+          )}
 
           {results.map((table) => {
             if (table.records.length === 0) return null;
@@ -193,9 +191,9 @@ export function GlobalSearchDialog({
                   <span className="text-xs font-medium text-muted-foreground">
                     {table.tableName}
                   </span>
-                  {table.totalMatches > table.records.length && (
+                  {table.hasMore && (
                     <span className="text-[10px] text-muted-foreground">
-                      ({table.records.length}/{table.totalMatches})
+                      更多结果...
                     </span>
                   )}
                 </div>
@@ -241,7 +239,6 @@ export function GlobalSearchDialog({
           })}
         </div>
 
-        {/* Footer */}
         <div className="border-t px-4 py-2 flex items-center gap-4 text-[10px] text-muted-foreground">
           <span className="flex items-center gap-1">
             <kbd className="rounded border bg-muted px-1">↑</kbd>
@@ -266,12 +263,10 @@ function getRecordLabel(
   data: Record<string, unknown>,
   matchedFields: string[]
 ): string {
-  // Prefer the first matched field value as label
   for (const key of matchedFields) {
     const val = data[key];
     if (typeof val === "string" && val.trim()) return val;
   }
-  // Fallback: first string field
   for (const val of Object.values(data)) {
     if (typeof val === "string" && val.trim()) return val;
   }

--- a/src/components/data/table-detail-content.tsx
+++ b/src/components/data/table-detail-content.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -22,9 +23,19 @@ interface TableDetailContentProps {
 }
 
 export function TableDetailContent({ tableId, table, isAdmin }: TableDetailContentProps) {
+  const searchParams = useSearchParams();
   const [detailRecordId, setDetailRecordId] = useState<string | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
   const recordIdsRef = useRef<string[]>([]);
+
+  // Auto-open record detail from search params
+  useEffect(() => {
+    const rid = searchParams.get("recordId");
+    if (rid) {
+      setDetailRecordId(rid);
+      setDetailOpen(true);
+    }
+  }, [searchParams]);
 
   // AI Sheet state
   const [aiOpen, setAiOpen] = useState(false);

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,9 +1,12 @@
 "use client";
 
+import { useCallback, useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
+import { Search } from "lucide-react";
 import { MobileNav } from "@/components/layout/mobile-nav";
 import { NotificationBell } from "@/components/layout/notification-bell";
 import { ThemeToggle } from "@/components/layout/theme-toggle";
+import { GlobalSearchDialog } from "@/components/data/global-search-dialog";
 
 const routeTitles: Record<string, string> = {
   "/": "仪表盘",
@@ -17,20 +20,45 @@ const routeTitles: Record<string, string> = {
 
 export function Header() {
   const pathname = usePathname();
+  const [searchOpen, setSearchOpen] = useState(false);
 
   const title = routeTitles[pathname] ?? "IDRL填表系统";
 
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+      e.preventDefault();
+      setSearchOpen((v) => !v);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
   return (
-    <header className="sticky top-0 z-30 flex h-14 items-center gap-2 sm:gap-4 border-b bg-background px-3 sm:px-6">
-      {/* Mobile navigation */}
-      <MobileNav />
+    <>
+      <header className="sticky top-0 z-30 flex h-14 items-center gap-2 sm:gap-4 border-b bg-background px-3 sm:px-6">
+        {/* Mobile navigation */}
+        <MobileNav />
 
-      <div className="flex flex-1 items-center min-w-0">
-        <h1 className="text-base sm:text-lg font-semibold truncate">{title}</h1>
-      </div>
+        <div className="flex flex-1 items-center min-w-0">
+          <h1 className="text-base sm:text-lg font-semibold truncate">{title}</h1>
+        </div>
 
-      <ThemeToggle />
-      <NotificationBell />
-    </header>
+        <button
+          onClick={() => setSearchOpen(true)}
+          className="hidden sm:flex items-center gap-2 h-8 px-3 rounded-md border bg-muted/50 text-sm text-muted-foreground hover:bg-muted transition-colors"
+        >
+          <Search className="h-3.5 w-3.5" />
+          <span>搜索...</span>
+          <kbd className="rounded border bg-background px-1 py-0.5 text-[10px] font-mono">⌘K</kbd>
+        </button>
+
+        <ThemeToggle />
+        <NotificationBell />
+      </header>
+      <GlobalSearchDialog open={searchOpen} onClose={() => setSearchOpen(false)} />
+    </>
   );
 }

--- a/src/lib/services/search.service.ts
+++ b/src/lib/services/search.service.ts
@@ -1,0 +1,81 @@
+import { db } from "@/lib/db";
+import type { ServiceResult } from "@/types/data-table";
+
+const SEARCHABLE_FIELD_TYPES = new Set([
+  "TEXT", "EMAIL", "SELECT", "PHONE", "URL", "MULTISELECT",
+]);
+
+export interface SearchResultItem {
+  id: string;
+  data: Record<string, unknown>;
+  matchedFields: string[];
+}
+
+export interface SearchTableResult {
+  tableId: string;
+  tableName: string;
+  tableIcon: string | null;
+  records: SearchResultItem[];
+  hasMore: boolean;
+}
+
+export async function globalSearch(
+  query: string,
+  limit: number = 5
+): Promise<ServiceResult<SearchTableResult[]>> {
+  try {
+    const tables = await db.dataTable.findMany({
+      include: { fields: true },
+      orderBy: { updatedAt: "desc" },
+    });
+
+    const results: SearchTableResult[] = [];
+
+    for (const table of tables) {
+      const searchFields = table.fields
+        .filter((f) => SEARCHABLE_FIELD_TYPES.has(f.type))
+        .map((f) => f.key);
+
+      if (searchFields.length === 0) continue;
+
+      const orConditions = searchFields.map((fieldKey) => ({
+        data: { path: [fieldKey], string_contains: query },
+      }));
+
+      const matchingRecords = await db.dataRecord.findMany({
+        where: { tableId: table.id, OR: orConditions },
+        take: limit + 1,
+        orderBy: { updatedAt: "desc" },
+      });
+
+      if (matchingRecords.length === 0) continue;
+
+      const hasMore = matchingRecords.length > limit;
+      const records = matchingRecords.slice(0, limit).map((record) => {
+        const data = record.data as Record<string, unknown>;
+        const matchedFields = searchFields.filter((key) => {
+          const val = data[key];
+          return typeof val === "string" && val.toLowerCase().includes(query.toLowerCase());
+        });
+        return { id: record.id, data, matchedFields };
+      });
+
+      results.push({
+        tableId: table.id,
+        tableName: table.name,
+        tableIcon: table.icon,
+        records,
+        hasMore,
+      });
+
+      if (results.length >= 10) break;
+    }
+
+    return { success: true, data: results };
+  } catch (error) {
+    return {
+      success: false,
+      error: { code: "SEARCH_ERROR", message: error instanceof Error ? error.message : "搜索失败" },
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- 新增 `GET /api/search?q=` 全局搜索 API，跨所有数据表搜索 TEXT/EMAIL/SELECT/PHONE/URL 类型字段
- 新增 `GlobalSearchDialog` 弹窗组件，支持即时搜索、结果按表分组、键盘导航
- Header 注册 Cmd/Ctrl+K 快捷键，点击搜索栏打开弹窗
- 搜索结果点击后跳转到对应表页并自动打开记录详情抽屉

## Test plan
- [ ] Cmd+K / Ctrl+K 打开搜索弹窗
- [ ] 输入关键词即时返回跨表结果
- [ ] 结果按表分组显示，显示匹配字段名
- [ ] 上下箭头键盘导航，Enter 跳转
- [ ] ESC 关闭弹窗
- [ ] 跳转后自动打开记录详情

Closes #114