### PR TITLE
[Feature] 撤销/重做系统增强：记录操作 + 视图配置撤销

### DIFF
--- a/src/components/data/record-table.tsx
+++ b/src/components/data/record-table.tsx
@@ -106,6 +106,7 @@ export function RecordTable({
     deletingIds,
     updateRecordField,
     addRecord,
+    removeRecord,
     switchView,
     refresh,
     isConnected,
@@ -340,6 +341,7 @@ export function RecordTable({
             onRefresh={refresh}
             onUpdateRecordField={updateRecordField}
             onAddRecord={addRecord}
+            onRemoveRecord={removeRecord}
             onOpenDetail={onOpenDetail}
             columnWidths={columnWidths}
             onColumnWidthsChange={handleColumnWidthsChange}

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -341,12 +341,21 @@ export function GridView({
             });
           }
         }
-        onRefresh();
+        const record = newRecord as DataRecordItem;
+        await undoManager.execute({
+          type: "ADD_RECORD",
+          description: "插入记录",
+          execute: async () => { onAddRecord(record); onRefresh(); },
+          undo: async () => {
+            await fetch(`/api/data-tables/${tableId}/records/${record.id}`, { method: "DELETE" });
+            onRemoveRecord(record.id);
+          },
+        });
       }
     } catch {
       toast.error("插入行失败");
     }
-  }, [tableId, records, onRefresh]);
+  }, [tableId, records, onRefresh, undoManager, onAddRecord, onRemoveRecord]);
 
   const handleDuplicateRecord = useCallback(async (recordId: string) => {
     const record = records.find((r) => r.id === recordId);
@@ -358,12 +367,21 @@ export function GridView({
         body: JSON.stringify({ data: { ...record.data } }),
       });
       if (res.ok) {
-        onRefresh();
+        const newRecord = (await res.json()) as DataRecordItem;
+        await undoManager.execute({
+          type: "ADD_RECORD",
+          description: "复制记录",
+          execute: async () => { onAddRecord(newRecord); onRefresh(); },
+          undo: async () => {
+            await fetch(`/api/data-tables/${tableId}/records/${newRecord.id}`, { method: "DELETE" });
+            onRemoveRecord(newRecord.id);
+          },
+        });
       }
     } catch {
       toast.error("复制行失败");
     }
-  }, [tableId, records, onRefresh]);
+  }, [tableId, records, undoManager, onAddRecord, onRemoveRecord, onRefresh]);
 
   // ── Can drag-sort rows? (only when no sorts, no grouping, has viewId, and admin) ──
   const canDragSort = useMemo(
@@ -728,7 +746,13 @@ export function GridView({
       await undoManager.execute({
         type: "DELETE_RECORD",
         description: "删除记录",
-        execute: async () => { await onDeleteRecord(recordId); },
+        execute: async () => {
+          const res = await fetch(`/api/data-tables/${tableId}/records/${recordId}`, {
+            method: "DELETE",
+          });
+          if (!res.ok) throw new Error("删除失败");
+          onRemoveRecord(recordId);
+        },
         undo: async () => {
           const res = await fetch(`/api/data-tables/${tableId}/records`, {
             method: "POST",
@@ -742,7 +766,7 @@ export function GridView({
         },
       });
     },
-    [flatRecords, undoManager, onDeleteRecord, tableId, onAddRecord]
+    [flatRecords, undoManager, tableId, onRemoveRecord, onAddRecord]
   );
 
   // ── Undoable view config helpers ─────────────────────────────────────────
@@ -1903,7 +1927,7 @@ export function GridView({
           }
         }}
         onInsertRow={handleInsertRow}
-        onDeleteRecord={(recordId) => void onDeleteRecord(recordId)}
+        onDeleteRecord={(recordId) => void handleDeleteWithUndo(recordId)}
         onDuplicateRecord={handleDuplicateRecord}
         onFilterByCell={(fieldKey, value) => {
           const newFilter: FilterCondition = { fieldKey, op: "eq", value };

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -75,6 +75,7 @@ interface GridViewProps {
   onRefresh: () => void;
   onUpdateRecordField: (recordId: string, fieldKey: string, value: unknown) => void;
   onAddRecord: (record: DataRecordItem) => void;
+  onRemoveRecord: (recordId: string) => void;
   onOpenDetail?: (recordId: string) => void;
   onOpenFieldsConfig?: () => void;
   onDeleteField?: (fieldKey: string) => void;
@@ -263,6 +264,7 @@ export function GridView({
   onRefresh,
   onUpdateRecordField,
   onAddRecord,
+  onRemoveRecord,
   onOpenDetail,
   columnWidths,
   onColumnWidthsChange,
@@ -715,6 +717,65 @@ export function GridView({
     setRichEditCell(null);
   }, [richEditCell, releaseCellLock]);
 
+  // ── Undoable record operations ──────────────────────────────────────────
+  const handleDeleteWithUndo = useCallback(
+    async (recordId: string) => {
+      const row = flatRecords.find((r) => r.record?.id === recordId);
+      const record = row?.record;
+      if (!record) return;
+      if (!confirm("确定要删除这条记录吗？")) return;
+      const recordData = { ...record.data };
+      await undoManager.execute({
+        type: "DELETE_RECORD",
+        description: "删除记录",
+        execute: async () => { await onDeleteRecord(recordId); },
+        undo: async () => {
+          const res = await fetch(`/api/data-tables/${tableId}/records`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ data: recordData }),
+          });
+          if (res.ok) {
+            const restored = (await res.json()) as DataRecordItem;
+            onAddRecord(restored);
+          }
+        },
+      });
+    },
+    [flatRecords, undoManager, onDeleteRecord, tableId, onAddRecord]
+  );
+
+  // ── Undoable view config helpers ─────────────────────────────────────────
+  const undoableSortChange = useCallback(
+    (sort: SortConfig | null) => {
+      const prev = [...sorts];
+      undoManager.execute({
+        type: "BATCH_UPDATE",
+        description: "修改排序",
+        execute: async () => { onSortChange(sort); },
+        undo: async () => {
+          for (const s of prev) onSortChange(s);
+          sorts.filter((s) => !prev.some((p) => p.fieldKey === s.fieldKey))
+            .forEach((s) => onSortClear(s.fieldKey));
+        },
+      });
+    },
+    [sorts, undoManager, onSortChange, onSortClear]
+  );
+
+  const undoableGroupByChange = useCallback(
+    (fieldKey: string | null) => {
+      const prev = groupBy;
+      undoManager.execute({
+        type: "BATCH_UPDATE",
+        description: "修改分组",
+        execute: async () => { onGroupByChange(fieldKey); },
+        undo: async () => { onGroupByChange(prev); },
+      });
+    },
+    [groupBy, undoManager, onGroupByChange]
+  );
+
   useEffect(() => {
     if (!onLockLost) return;
     return onLockLost((recordId, fieldKey) => {
@@ -1148,7 +1209,15 @@ export function GridView({
         return;
       }
       const record = (await res.json()) as DataRecordItem;
-      onAddRecord(record);
+      await undoManager.execute({
+        type: "ADD_RECORD",
+        description: "新建记录",
+        execute: async () => { onAddRecord(record); },
+        undo: async () => {
+          await fetch(`/api/data-tables/${tableId}/records/${record.id}`, { method: "DELETE" });
+          onRemoveRecord(record.id);
+        },
+      });
       // Move activeCell to new row, start editing first editable field
       const newRowIndex = flatRecords.length;
       const firstEditableField = orderedVisibleFields.find(
@@ -1169,7 +1238,7 @@ export function GridView({
     } catch {
       toast.error("新建行失败");
     }
-  }, [tableId, onAddRecord, flatRecords.length, orderedVisibleFields, setActiveCell, startEditing]);
+  }, [tableId, onAddRecord, onRemoveRecord, flatRecords.length, orderedVisibleFields, setActiveCell, startEditing, undoManager]);
 
   // Insert a new row below the given row index and start editing
   const handleInsertRowBelow = useCallback(async (currentRowIndex: number) => {
@@ -1184,7 +1253,15 @@ export function GridView({
         return;
       }
       const record = (await res.json()) as DataRecordItem;
-      onAddRecord(record);
+      await undoManager.execute({
+        type: "ADD_RECORD",
+        description: "插入记录",
+        execute: async () => { onAddRecord(record); },
+        undo: async () => {
+          await fetch(`/api/data-tables/${tableId}/records/${record.id}`, { method: "DELETE" });
+          onRemoveRecord(record.id);
+        },
+      });
       // New record is appended to the end; move active cell to it
       const newRowIndex = flatRecords.length;
       const firstEditableField = orderedVisibleFields.find(
@@ -1205,7 +1282,7 @@ export function GridView({
     } catch {
       toast.error("插入行失败");
     }
-  }, [tableId, onAddRecord, flatRecords.length, orderedVisibleFields, setActiveCell, startEditing]);
+  }, [tableId, onAddRecord, onRemoveRecord, flatRecords.length, orderedVisibleFields, setActiveCell, startEditing, undoManager]);
 
   // Duplicate a row: copy all editable fields into a new row below
   const handleDuplicateRow = useCallback(async (sourceRecord: DataRecordItem) => {
@@ -1230,7 +1307,15 @@ export function GridView({
         return;
       }
       const record = (await res.json()) as DataRecordItem;
-      onAddRecord(record);
+      await undoManager.execute({
+        type: "ADD_RECORD",
+        description: "复制记录",
+        execute: async () => { onAddRecord(record); },
+        undo: async () => {
+          await fetch(`/api/data-tables/${tableId}/records/${record.id}`, { method: "DELETE" });
+          onRemoveRecord(record.id);
+        },
+      });
       const newRowIndex = flatRecords.length;
       const firstEditableField = orderedVisibleFields.find(
         (f) => f.type !== FieldType.RELATION_SUBTABLE
@@ -1251,7 +1336,7 @@ export function GridView({
     } catch {
       toast.error("复制行失败");
     }
-  }, [tableId, onAddRecord, flatRecords.length, orderedVisibleFields, setActiveCell, startEditing]);
+  }, [tableId, onAddRecord, onRemoveRecord, flatRecords.length, orderedVisibleFields, setActiveCell, startEditing, undoManager]);
 
   // Auto-scroll on stableActiveCell change
   useEffect(() => {
@@ -1702,7 +1787,7 @@ export function GridView({
                   variant="ghost"
                   size="sm"
                   className="h-8 px-2 text-red-600"
-                  onClick={() => void onDeleteRecord(record.id)}
+                  onClick={() => void handleDeleteWithUndo(record.id)}
                   disabled={deletingIds.has(record.id)}
                 >
                   {deletingIds.has(record.id) ? (
@@ -1945,7 +2030,7 @@ export function GridView({
                     }
                     onSortChange={(sort) => {
                       if (sort) {
-                        onSortChange(sort);
+                        undoableSortChange(sort);
                       } else {
                         onSortClear(field.key);
                       }

--- a/src/hooks/use-table-data.ts
+++ b/src/hooks/use-table-data.ts
@@ -48,6 +48,7 @@ export interface UseTableDataReturn {
   deletingIds: Set<string>;
   updateRecordField: (recordId: string, fieldKey: string, value: unknown) => void;
   addRecord: (record: DataRecordItem) => void;
+  removeRecord: (recordId: string) => void;
   refresh: () => void;
   isConnected: boolean;
   activityFeed: import("@/types/realtime").ActivityEntry[];
@@ -236,6 +237,20 @@ export function useTableData({
           ...prev,
           records: [...prev.records, record],
           total: prev.total + 1,
+        };
+      });
+    },
+    []
+  );
+
+  const removeRecord = useCallback(
+    (recordId: string) => {
+      setRecordsData((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          records: prev.records.filter((r) => r.id !== recordId),
+          total: prev.total - 1,
         };
       });
     },
@@ -553,6 +568,7 @@ export function useTableData({
     deletingIds,
     updateRecordField,
     addRecord,
+    removeRecord,
     refresh,
     isConnected,
     activityFeed,


### PR DESCRIPTION
## Summary
- 新建记录（新建行/插入行/复制行）接入 undoManager，撤销时调用删除 API 还原
- 删除记录接入 undoManager，撤销时用原数据通过 POST API 重建记录
- 排序变更和分组变更加入撤销栈，撤销恢复之前的配置
- 新增 `removeRecord` 本地状态方法供撤销删除使用
- 撤销/重做 toast 显示具体操作描述（如"已撤销：新建记录"）

## Test plan
- [ ] 新建行后 Ctrl+Z 撤销，记录被删除
- [ ] 删除行后 Ctrl+Z 撤销，记录被恢复
- [ ] 修改排序后 Ctrl+Z 撤销，排序恢复
- [ ] 修改分组后 Ctrl+Z 撤销，分组恢复
- [ ] Ctrl+Y 重做正常工作
- [ ] 撤销/重做按钮在工具栏正常显示状态

Closes #115