### PR TITLE
[Feature] 移动端基础适配

### DIFF
--- a/src/components/data/record-detail-drawer.tsx
+++ b/src/components/data/record-detail-drawer.tsx
@@ -215,7 +215,7 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
               <div className="flex items-center justify-between">
                 <SheetTitle className="text-lg">记录详情</SheetTitle>
                 {recordIds && recordIds.length > 0 && currentIndex >= 0 && (
-                  <div className="flex items-center gap-1">
+                  <div className="flex items-center gap-1 relative z-10">
                     <Button
                       variant="ghost"
                       size="sm"

--- a/src/components/data/record-detail-drawer.tsx
+++ b/src/components/data/record-detail-drawer.tsx
@@ -200,7 +200,7 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="right" className="sm:max-w-md overflow-y-auto">
+      <SheetContent side="right" className="w-full sm:max-w-md overflow-y-auto">
         {loading ? (
           <div className="flex min-h-full items-center justify-center py-12">
             <Spinner className="size-6" />

--- a/src/components/data/record-table.tsx
+++ b/src/components/data/record-table.tsx
@@ -437,7 +437,7 @@ export function RecordTable({
     <div className="flex flex-col flex-1 min-h-0 gap-4">
       {/* Toolbar */}
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
-        <div className="flex items-center gap-2 w-full sm:w-auto">
+        <div className="flex items-center gap-2 w-full sm:w-auto flex-wrap">
           <ViewSelector
             tableId={tableId}
             currentViewId={viewId}
@@ -462,19 +462,21 @@ export function RecordTable({
               }}
             >
               <X className="h-3.5 w-3.5 mr-1" />
-              清除筛选
+              清除
             </Button>
           )}
-          <ConditionalFormatDialog
-            fields={fields}
-            rules={conditionalFormatRules}
-            onChange={setConditionalFormatRules}
-            quickCreateField={quickFormatField}
-            quickCreateValue={quickFormatValue}
-          />
+          <div className="hidden sm:block">
+            <ConditionalFormatDialog
+              fields={fields}
+              rules={conditionalFormatRules}
+              onChange={setConditionalFormatRules}
+              quickCreateField={quickFormatField}
+              quickCreateValue={quickFormatValue}
+            />
+          </div>
           <form
             onSubmit={(event) => event.preventDefault()}
-            className="flex-1 sm:flex-none"
+            className="flex-1 sm:flex-none min-w-0"
           >
             <Input
               placeholder="搜索记录..."
@@ -485,40 +487,47 @@ export function RecordTable({
           </form>
         </div>
         <div className="flex items-center gap-2 w-full sm:w-auto">
-          <KeyboardShortcutsDialog />
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              render={
-                <Button variant="outline" size="sm">
-                  <ArrowUpDown className="h-4 w-4 mr-1" />
-                  行高
-                </Button>
-              }
+          <div className="hidden sm:block">
+            <KeyboardShortcutsDialog />
+          </div>
+          <div className="hidden sm:block">
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                render={
+                  <Button variant="outline" size="sm">
+                    <ArrowUpDown className="h-4 w-4 mr-1" />
+                    行高
+                  </Button>
+                }
+              />
+              <DropdownMenuContent align="end">
+                {([
+                  [24, "紧凑"],
+                  [32, "标准"],
+                  [40, "宽松"],
+                  [56, "超高"],
+                ] as const).map(([h, label]) => (
+                  <DropdownMenuItem
+                    key={h}
+                    onClick={() => handleRowHeightChange(h)}
+                    className={rowHeight === h ? "font-bold bg-muted" : ""}
+                  >
+                    {label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+          <div className="hidden sm:block">
+            <FieldConfigPopover
+              fields={fields}
+              visibleFields={currentConfig.visibleFields}
+              fieldOrder={currentConfig.fieldOrder}
+              onChange={handleFieldConfigChange}
             />
-            <DropdownMenuContent align="end">
-              {([
-                [24, "紧凑"],
-                [32, "标准"],
-                [40, "宽松"],
-                [56, "超高"],
-              ] as const).map(([h, label]) => (
-                <DropdownMenuItem
-                  key={h}
-                  onClick={() => handleRowHeightChange(h)}
-                  className={rowHeight === h ? "font-bold bg-muted" : ""}
-                >
-                  {label}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <FieldConfigPopover
-            fields={fields}
-            visibleFields={currentConfig.visibleFields}
-            fieldOrder={currentConfig.fieldOrder}
-            onChange={handleFieldConfigChange}
-          />
-          <DropdownMenu>
+          </div>
+          <div className="hidden sm:block">
+            <DropdownMenu>
             <DropdownMenuTrigger
               render={
                 <Button variant="outline" size="sm">
@@ -550,6 +559,7 @@ export function RecordTable({
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
+          </div>
           {isAdmin && (
             <Link href={`/data/${tableId}/new`}>
               <Button size="sm" className="w-full sm:w-auto">

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -1835,7 +1835,7 @@ export function GridView({
       }
 
       return (
-        <tr key={record.id} className="border-b transition-colors hover:bg-primary/8 data-[state=selected]:bg-muted" style={rowStyle}>
+        <tr key={record.id} className="border-b transition-colors hover:bg-primary/8 data-[state=selected]:bg-muted sm:h-auto h-[44px]" style={rowStyle}>
           {rowContent}
         </tr>
       );
@@ -1986,7 +1986,7 @@ export function GridView({
           <Redo2 className="h-3.5 w-3.5" />
         </Button>
       </div>
-      <div className="flex-1 min-h-0 overflow-auto relative" ref={scrollRef}>
+      <div className="flex-1 min-h-0 overflow-auto relative" ref={scrollRef} style={{ WebkitOverflowScrolling: "touch" }}>
         <FindReplaceBar
           open={findBarOpen}
           onClose={() => setFindBarOpen(false)}

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -230,7 +230,7 @@ function DragHandleRow({
     <tr
       ref={ref}
       className={cn(
-        "border-b transition-colors hover:bg-muted/50",
+        "border-b transition-colors hover:bg-muted/50 sm:h-auto h-[44px]",
         isDragging && "opacity-50 bg-muted"
       )}
       style={style}


### PR DESCRIPTION
## Summary
- Grid 视图添加触摸横向滚动支持 (`-webkit-overflow-scrolling: touch`)
- 移动端行最小高度 44px，保证触控友好
- 工具栏移动端折叠：隐藏条件格式、键盘快捷键、行高、字段配置、导出等次要操作
- 搜索框移动端全宽显示
- 记录详情面板移动端全屏（`w-full` 替代固定宽度）

## Test plan
- [ ] 移动端/窄屏浏览器可横向触摸滚动表格
- [ ] 移动端工具栏简洁，核心操作可用
- [ ] 搜索框全宽
- [ ] 记录详情面板全屏显示
- [ ] 桌面端无回归（隐藏的按钮正常显示）

Closes #116