### PR TITLE
[Feature] 协作体验优化：单元格评论 + @提及补全 + 通知推送

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -678,6 +678,8 @@ enum NotificationType {
   DUE_TODAY
   OVERDUE
   MANUAL_REMIND
+  COMMENT_MENTION
+  COMMENT_REPLY
 }
 
 model Notification {
@@ -826,6 +828,7 @@ model DataRecordComment {
   id         String   @id @default(cuid())
   recordId   String
   record     DataRecord @relation(fields: [recordId], references: [id], onDelete: Cascade)
+  fieldKey   String?
   content    String
   parentId   String?
   parent     DataRecordComment?  @relation("CommentReplies", fields: [parentId], references: [id], onDelete: Cascade)
@@ -838,6 +841,7 @@ model DataRecordComment {
   updatedAt  DateTime @updatedAt
 
   @@index([recordId, createdAt(sort: Asc)])
+  @@index([recordId, fieldKey])
   @@index([parentId])
   @@index([createdById])
   @@map("data_record_comments")

--- a/src/app/api/data-tables/[id]/records/[recordId]/comments/route.ts
+++ b/src/app/api/data-tables/[id]/records/[recordId]/comments/route.ts
@@ -5,6 +5,7 @@ import {
   listComments,
   createComment,
   getUnresolvedCount,
+  getCellCommentCounts,
 } from "@/lib/services/data-record-comment.service";
 
 type RouteParams = { params: Promise<{ id: string; recordId: string }> };
@@ -12,6 +13,7 @@ type RouteParams = { params: Promise<{ id: string; recordId: string }> };
 const createSchema = z.object({
   content: z.string().min(1, "评论内容不能为空"),
   parentId: z.string().optional(),
+  fieldKey: z.string().optional(),
   mentions: z.array(z.string()).optional(),
 });
 
@@ -33,6 +35,18 @@ export async function GET(
     const ids = idsParam.split(",").filter(Boolean);
     const counts = await getUnresolvedCount(ids);
     return NextResponse.json(Object.fromEntries(counts));
+  }
+
+  // Cell-level comment counts endpoint
+  const cellCountsParam = url.searchParams.get("cellCounts");
+  if (cellCountsParam) {
+    const ids = cellCountsParam.split(",").filter(Boolean);
+    const counts = await getCellCommentCounts(ids);
+    const result: Record<string, Record<string, number>> = {};
+    for (const [recordId, fieldCounts] of counts) {
+      result[recordId] = fieldCounts;
+    }
+    return NextResponse.json(result);
   }
 
   const result = await listComments(recordId);

--- a/src/app/api/users/search/route.ts
+++ b/src/app/api/users/search/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { z } from "zod";
+
+const schema = z.object({
+  q: z.string().min(1).max(100),
+});
+
+export async function GET(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "未授权" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const parsed = schema.safeParse({ q: searchParams.get("q") || "" });
+  if (!parsed.success) {
+    return NextResponse.json({ items: [] });
+  }
+
+  const { q } = parsed.data;
+
+  const users = await db.user.findMany({
+    where: {
+      OR: [
+        { name: { contains: q, mode: "insensitive" } },
+        { email: { contains: q, mode: "insensitive" } },
+      ],
+    },
+    select: { id: true, name: true, email: true },
+    take: 10,
+    orderBy: { name: "asc" },
+  });
+
+  return NextResponse.json({ items: users });
+}

--- a/src/components/data/cell-comment-panel.tsx
+++ b/src/components/data/cell-comment-panel.tsx
@@ -18,6 +18,7 @@ interface CellCommentPanelProps {
   recordId: string;
   fieldKey?: string;
   fieldName?: string;
+  onCommentChange?: () => void;
 }
 
 interface UserOption {
@@ -26,7 +27,7 @@ interface UserOption {
   email: string;
 }
 
-export function CellCommentPanel({ tableId, recordId, fieldKey, fieldName }: CellCommentPanelProps) {
+export function CellCommentPanel({ tableId, recordId, fieldKey, fieldName, onCommentChange }: CellCommentPanelProps) {
   const [comments, setComments] = useState<CommentItem[]>([]);
   const [newContent, setNewContent] = useState("");
   const [replyTo, setReplyTo] = useState<string | null>(null);
@@ -147,6 +148,7 @@ export function CellCommentPanel({ tableId, recordId, fieldKey, fieldName }: Cel
     );
     if (res.ok) {
       await fetchComments();
+      onCommentChange?.();
     }
   };
 
@@ -157,6 +159,7 @@ export function CellCommentPanel({ tableId, recordId, fieldKey, fieldName }: Cel
     );
     if (res.ok) {
       await fetchComments();
+      onCommentChange?.();
     }
   };
 
@@ -171,6 +174,7 @@ export function CellCommentPanel({ tableId, recordId, fieldKey, fieldName }: Cel
     );
     if (res.ok) {
       await fetchComments();
+      onCommentChange?.();
     }
   };
 

--- a/src/components/data/cell-comment-panel.tsx
+++ b/src/components/data/cell-comment-panel.tsx
@@ -1,0 +1,470 @@
+"use client";
+
+import { useEffect, useState, useCallback, useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { Check, MessageSquare, MoreHorizontal, Reply, Trash2, X } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import { UserAvatar } from "@/components/data/user-avatar";
+import type { CommentItem } from "@/lib/services/data-record-comment.service";
+
+interface CellCommentPanelProps {
+  tableId: string;
+  recordId: string;
+  fieldKey?: string;
+  fieldName?: string;
+}
+
+interface UserOption {
+  id: string;
+  name: string;
+  email: string;
+}
+
+export function CellCommentPanel({ tableId, recordId, fieldKey, fieldName }: CellCommentPanelProps) {
+  const [comments, setComments] = useState<CommentItem[]>([]);
+  const [newContent, setNewContent] = useState("");
+  const [replyTo, setReplyTo] = useState<string | null>(null);
+  const [replyContent, setReplyContent] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+
+  // @mention state
+  const [mentionQuery, setMentionQuery] = useState<string | null>(null);
+  const [mentionResults, setMentionResults] = useState<UserOption[]>([]);
+  const [mentionIndex, setMentionIndex] = useState(0);
+  const [showMentions, setShowMentions] = useState(false);
+  const [mentionStart, setMentionStart] = useState(-1);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const replyInputRef = useRef<HTMLTextAreaElement>(null);
+
+  const fetchComments = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `/api/data-tables/${tableId}/records/${recordId}/comments`
+      );
+      if (res.ok) {
+        const data: CommentItem[] = await res.json();
+        const filtered = fieldKey
+          ? data.filter((c) => c.fieldKey === fieldKey || c.fieldKey === null)
+          : data;
+        setComments(filtered);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setIsLoading(false);
+    }
+  }, [tableId, recordId, fieldKey]);
+
+  useEffect(() => {
+    fetchComments();
+  }, [fetchComments]);
+
+  // @mention search
+  useEffect(() => {
+    if (mentionQuery === null) {
+      return;
+    }
+    const timer = setTimeout(async () => {
+      try {
+        const q = mentionQuery || "a";
+        const res = await fetch(`/api/users/search?q=${encodeURIComponent(q)}`);
+        if (res.ok) {
+          const data = await res.json();
+          setMentionResults(data.items ?? []);
+          setShowMentions((data.items ?? []).length > 0);
+          setMentionIndex(0);
+        }
+      } catch {
+        // ignore
+      }
+    }, 200);
+    return () => clearTimeout(timer);
+  }, [mentionQuery]);
+
+  const handleInputChange = (value: string, textarea: HTMLTextAreaElement) => {
+    const cursorPos = textarea.selectionStart;
+    setNewContent(value);
+
+    // detect @mention
+    const textBeforeCursor = value.slice(0, cursorPos);
+    const atMatch = textBeforeCursor.match(/@([^@\s]*)$/);
+    if (atMatch) {
+      setMentionStart(cursorPos - atMatch[0].length);
+      setMentionQuery(atMatch[1]);
+    } else {
+      setShowMentions(false);
+      setMentionQuery(null);
+    }
+  };
+
+  const insertMention = (user: UserOption, isReply: boolean) => {
+    const textarea = isReply ? replyInputRef.current : inputRef.current;
+    if (!textarea) return;
+
+    const value = isReply ? replyContent : newContent;
+    const cursorPos = textarea.selectionStart;
+
+    const atMatch = value.slice(0, cursorPos).match(/@([^@\s]*)$/);
+    if (!atMatch) return;
+
+    const start = cursorPos - atMatch[0].length;
+    const newValue = value.slice(0, start) + `@${user.name} ` + value.slice(cursorPos);
+
+    if (isReply) {
+      setReplyContent(newValue);
+    } else {
+      setNewContent(newValue);
+    }
+    setShowMentions(false);
+    setMentionQuery(null);
+
+    setTimeout(() => {
+      const newPos = start + user.name.length + 2;
+      textarea.focus();
+      textarea.setSelectionRange(newPos, newPos);
+    }, 0);
+  };
+
+  const handleSubmit = async (content: string, parentId?: string) => {
+    if (!content.trim()) return;
+    const res = await fetch(
+      `/api/data-tables/${tableId}/records/${recordId}/comments`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          content: content.trim(),
+          parentId,
+          fieldKey: fieldKey ?? undefined,
+        }),
+      }
+    );
+    if (res.ok) {
+      await fetchComments();
+    }
+  };
+
+  const handleDelete = async (commentId: string) => {
+    const res = await fetch(
+      `/api/data-tables/${tableId}/records/${recordId}/comments/${commentId}`,
+      { method: "DELETE" }
+    );
+    if (res.ok) {
+      await fetchComments();
+    }
+  };
+
+  const handleResolve = async (commentId: string) => {
+    const res = await fetch(
+      `/api/data-tables/${tableId}/records/${recordId}/comments/${commentId}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "resolve" }),
+      }
+    );
+    if (res.ok) {
+      await fetchComments();
+    }
+  };
+
+  const formatTime = (date: Date | string) => {
+    const d = new Date(date);
+    const now = new Date();
+    const diffMs = now.getTime() - d.getTime();
+    const diffMin = Math.floor(diffMs / 60000);
+    if (diffMin < 1) return "刚刚";
+    if (diffMin < 60) return `${diffMin} 分钟前`;
+    const diffHour = Math.floor(diffMin / 60);
+    if (diffHour < 24) return `${diffHour} 小时前`;
+    return d.toLocaleDateString("zh-CN", { month: "short", day: "numeric" });
+  };
+
+  const highlightMentions = (content: string) => {
+    const parts = content.split(/(@\S+)/g);
+    return parts.map((part, i) =>
+      part.startsWith("@") ? (
+        <span key={i} className="text-blue-600 font-medium">{part}</span>
+      ) : (
+        part
+      )
+    );
+  };
+
+  const mentionDropdown = (isReply: boolean) => {
+    if (!showMentions || mentionResults.length === 0) return null;
+    const textarea = isReply ? replyInputRef.current : inputRef.current;
+    const rect = textarea?.getBoundingClientRect();
+    if (!rect) return null;
+    return (
+      <div
+        className="fixed bg-popover border rounded-md shadow-lg max-h-40 overflow-y-auto z-[60]"
+        style={{
+          left: rect.left,
+          top: rect.top - 170 > 0 ? rect.top - 170 : rect.bottom + 4,
+          width: Math.min(rect.width, 320),
+        }}
+      >
+        {mentionResults.map((user, i) => (
+          <button
+            key={user.id}
+            type="button"
+            className={cn(
+              "w-full flex items-center gap-2 px-3 py-1.5 text-sm hover:bg-muted/50 text-left",
+              i === mentionIndex && "bg-muted/50"
+            )}
+            onClick={() => insertMention(user, isReply)}
+            onMouseEnter={() => setMentionIndex(i)}
+          >
+            <UserAvatar name={user.name} size="sm" />
+            <div className="min-w-0">
+              <div className="font-medium truncate">{user.name}</div>
+              <div className="text-xs text-muted-foreground truncate">{user.email}</div>
+            </div>
+          </button>
+        ))}
+      </div>
+    );
+  };
+
+  if (isLoading) {
+    return <div className="p-4 text-sm text-muted-foreground">加载评论...</div>;
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-y-auto space-y-3 p-3">
+        {comments.length === 0 && (
+          <div className="text-center py-6 text-muted-foreground text-sm">
+            暂无评论
+          </div>
+        )}
+        {comments.map((comment) => (
+          <div
+            key={comment.id}
+            className={cn(
+              "rounded-lg border p-2.5 space-y-1.5",
+              comment.isResolved && "opacity-60 bg-muted/30"
+            )}
+          >
+            <div className="flex items-start justify-between gap-2">
+              <div className="flex items-center gap-2">
+                <UserAvatar name={comment.createdByName} size="sm" />
+                <div>
+                  <span className="text-sm font-medium">{comment.createdByName}</span>
+                  <span className="text-xs text-muted-foreground ml-2">
+                    {formatTime(comment.createdAt)}
+                  </span>
+                </div>
+              </div>
+              <div className="flex items-center gap-1">
+                {comment.isResolved && (
+                  <span className="text-xs text-green-600 flex items-center gap-0.5">
+                    <Check className="h-3 w-3" /> 已解决
+                  </span>
+                )}
+                <DropdownMenu>
+                  <DropdownMenuTrigger
+                    render={
+                      <Button variant="ghost" size="sm" className="h-6 w-6 p-0">
+                        <MoreHorizontal className="h-3.5 w-3.5" />
+                      </Button>
+                    }
+                  />
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onClick={() => handleResolve(comment.id)}>
+                      <Check className="h-3.5 w-3.5 mr-2" />
+                      {comment.isResolved ? "取消解决" : "标记为已解决"}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => setReplyTo(comment.id)}>
+                      <Reply className="h-3.5 w-3.5 mr-2" />
+                      回复
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => handleDelete(comment.id)}
+                      className="text-red-600"
+                    >
+                      <Trash2 className="h-3.5 w-3.5 mr-2" />
+                      删除
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            </div>
+            <div className="text-sm pl-8 whitespace-pre-wrap">
+              {highlightMentions(comment.content)}
+            </div>
+
+            {/* Replies */}
+            {comment.replies.length > 0 && (
+              <div className="pl-8 space-y-1.5 mt-1.5 border-l-2 border-muted">
+                {comment.replies.map((reply) => (
+                  <div key={reply.id} className="pl-3 py-1">
+                    <div className="flex items-center gap-2">
+                      <UserAvatar name={reply.createdByName} size="sm" />
+                      <span className="text-sm font-medium">{reply.createdByName}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {formatTime(reply.createdAt)}
+                      </span>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-5 w-5 p-0 ml-auto text-muted-foreground hover:text-red-600"
+                        onClick={() => handleDelete(reply.id)}
+                      >
+                        <X className="h-3 w-3" />
+                      </Button>
+                    </div>
+                    <div className="text-sm pl-8 whitespace-pre-wrap">
+                      {highlightMentions(reply.content)}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Reply input */}
+            {replyTo === comment.id && (
+              <div className="pl-8 relative">
+                {mentionDropdown(true)}
+                <div className="flex gap-2">
+                  <textarea
+                    ref={replyInputRef}
+                    className="flex-1 text-sm border rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-primary resize-none min-h-[32px]"
+                    placeholder="回复... 输入 @ 提及用户"
+                    value={replyContent}
+                    rows={1}
+                    onChange={(e) => {
+                      setReplyContent(e.target.value);
+                      const cursorPos = e.target.selectionStart;
+                      const textBeforeCursor = e.target.value.slice(0, cursorPos);
+                      const atMatch = textBeforeCursor.match(/@([^@\s]*)$/);
+                      if (atMatch) {
+                        setMentionQuery(atMatch[1]);
+                      } else {
+                        setShowMentions(false);
+                        setMentionQuery(null);
+                      }
+                    }}
+                    onKeyDown={(e) => {
+                      if (showMentions) {
+                        if (e.key === "ArrowDown") {
+                          e.preventDefault();
+                          setMentionIndex((i) => Math.min(i + 1, mentionResults.length - 1));
+                          return;
+                        }
+                        if (e.key === "ArrowUp") {
+                          e.preventDefault();
+                          setMentionIndex((i) => Math.max(i - 1, 0));
+                          return;
+                        }
+                        if (e.key === "Enter" || e.key === "Tab") {
+                          e.preventDefault();
+                          if (mentionResults[mentionIndex]) {
+                            insertMention(mentionResults[mentionIndex], true);
+                          }
+                          return;
+                        }
+                        if (e.key === "Escape") {
+                          setShowMentions(false);
+                          return;
+                        }
+                      }
+                      if (e.key === "Enter" && !e.shiftKey && replyContent.trim()) {
+                        e.preventDefault();
+                        handleSubmit(replyContent, comment.id);
+                        setReplyContent("");
+                        setReplyTo(null);
+                      }
+                    }}
+                    autoFocus
+                  />
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => { setReplyTo(null); setReplyContent(""); }}
+                  >
+                    取消
+                  </Button>
+                  <Button
+                    size="sm"
+                    disabled={!replyContent.trim()}
+                    onClick={() => {
+                      handleSubmit(replyContent, comment.id);
+                      setReplyContent("");
+                      setReplyTo(null);
+                    }}
+                  >
+                    发送
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* New comment input */}
+      <div className="border-t p-3 relative">
+        {mentionDropdown(false)}
+        <div className="flex gap-2">
+          <textarea
+            ref={inputRef}
+            className="flex-1 text-sm border rounded px-3 py-2 focus:outline-none focus:ring-1 focus:ring-primary resize-none min-h-[36px]"
+            placeholder={fieldName ? `关于「${fieldName}」的评论... 输入 @ 提及用户` : "添加评论... 输入 @ 提及用户"}
+            value={newContent}
+            rows={1}
+            onChange={(e) => handleInputChange(e.target.value, e.target)}
+            onKeyDown={(e) => {
+              if (showMentions) {
+                if (e.key === "ArrowDown") {
+                  e.preventDefault();
+                  setMentionIndex((i) => Math.min(i + 1, mentionResults.length - 1));
+                  return;
+                }
+                if (e.key === "ArrowUp") {
+                  e.preventDefault();
+                  setMentionIndex((i) => Math.max(i - 1, 0));
+                  return;
+                }
+                if (e.key === "Enter" || e.key === "Tab") {
+                  e.preventDefault();
+                  if (mentionResults[mentionIndex]) {
+                    insertMention(mentionResults[mentionIndex], false);
+                  }
+                  return;
+                }
+                if (e.key === "Escape") {
+                  setShowMentions(false);
+                  return;
+                }
+              }
+              if (e.key === "Enter" && !e.shiftKey && newContent.trim()) {
+                e.preventDefault();
+                handleSubmit(newContent);
+                setNewContent("");
+              }
+            }}
+          />
+          <Button
+            size="sm"
+            disabled={!newContent.trim()}
+            onClick={() => {
+              handleSubmit(newContent);
+              setNewContent("");
+            }}
+          >
+            <MessageSquare className="h-3.5 w-3.5 mr-1" />
+            发送
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/data/cell-context-menu.tsx
+++ b/src/components/data/cell-context-menu.tsx
@@ -7,6 +7,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu"
+import { MessageSquare } from "lucide-react"
 import type { CellContext } from "@/hooks/use-cell-context"
 import type { DataFieldItem, DataRecordItem } from "@/types/data-table"
 import { ReactNode, useCallback } from "react"
@@ -39,6 +40,7 @@ interface CellContextMenuProps {
   onSelectRow?: (recordId: string) => void
   onSelectColumn?: (fieldKey: string) => void
   onSelectAll?: () => void
+  onAddCellComment?: (recordId: string, fieldKey: string) => void
   children: ReactNode
 }
 
@@ -70,6 +72,7 @@ export function CellContextMenu({
   onSelectRow,
   onSelectColumn,
   onSelectAll,
+  onAddCellComment,
   children,
 }: CellContextMenuProps) {
   const { targetType, recordId, fieldKey, colIndex, rowIndex } = context
@@ -91,6 +94,10 @@ export function CellContextMenu({
             编辑单元格
           </ContextMenuItem>
         )}
+        <ContextMenuItem onClick={() => onAddCellComment?.(recordId, fieldKey)}>
+          <MessageSquare className="h-3.5 w-3.5 mr-2" />
+          添加评论
+        </ContextMenuItem>
         <ContextMenuItem onClick={() => onCopyCellValue?.(recordId, fieldKey)}>
           复制单元格值
         </ContextMenuItem>

--- a/src/components/data/comment-panel.tsx
+++ b/src/components/data/comment-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Check, MessageSquare, MoreHorizontal, Reply, Trash2, X } from "lucide-react";
 import {
@@ -13,6 +13,12 @@ import { cn } from "@/lib/utils";
 import { UserAvatar } from "@/components/data/user-avatar";
 import type { CommentItem } from "@/lib/services/data-record-comment.service";
 
+interface UserOption {
+  id: string;
+  name: string;
+  email: string;
+}
+
 interface CommentPanelProps {
   tableId: string;
   recordId: string;
@@ -24,6 +30,15 @@ export function CommentPanel({ tableId, recordId }: CommentPanelProps) {
   const [replyTo, setReplyTo] = useState<string | null>(null);
   const [replyContent, setReplyContent] = useState("");
   const [isLoading, setIsLoading] = useState(true);
+
+  // @mention state
+  const [mentionQuery, setMentionQuery] = useState<string | null>(null);
+  const [mentionResults, setMentionResults] = useState<UserOption[]>([]);
+  const [mentionIndex, setMentionIndex] = useState(0);
+  const [showMentions, setShowMentions] = useState(false);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const replyInputRef = useRef<HTMLTextAreaElement>(null);
+  const [activeInput, setActiveInput] = useState<"main" | "reply">("main");
 
   const fetchComments = useCallback(async () => {
     try {
@@ -44,6 +59,67 @@ export function CommentPanel({ tableId, recordId }: CommentPanelProps) {
   useEffect(() => {
     fetchComments();
   }, [fetchComments]);
+
+  // @mention search
+  useEffect(() => {
+    if (mentionQuery === null) return;
+    const timer = setTimeout(async () => {
+      try {
+        const q = mentionQuery || "a";
+        const res = await fetch(`/api/users/search?q=${encodeURIComponent(q)}`);
+        if (res.ok) {
+          const data = await res.json();
+          setMentionResults(data.items ?? []);
+          setShowMentions((data.items ?? []).length > 0);
+          setMentionIndex(0);
+        }
+      } catch {
+        // ignore
+      }
+    }, 200);
+    return () => clearTimeout(timer);
+  }, [mentionQuery]);
+
+  const detectMention = (value: string, textarea: HTMLTextAreaElement) => {
+    const cursorPos = textarea.selectionStart;
+    const textBeforeCursor = value.slice(0, cursorPos);
+    const atMatch = textBeforeCursor.match(/@([^@\s]*)$/);
+    if (atMatch) {
+      setMentionQuery(atMatch[1]);
+    } else {
+      setShowMentions(false);
+      setMentionQuery(null);
+    }
+  };
+
+  const insertMention = (user: UserOption) => {
+    const isReply = activeInput === "reply";
+    const textarea = isReply ? replyInputRef.current : inputRef.current;
+    if (!textarea) return;
+
+    const value = isReply ? replyContent : newContent;
+    const cursorPos = textarea.selectionStart;
+
+    const atMatch = value.slice(0, cursorPos).match(/@([^@\s]*)$/);
+    if (!atMatch) return;
+
+    const start = cursorPos - atMatch[0].length;
+    const newValue = value.slice(0, start) + `@${user.name} ` + value.slice(cursorPos);
+
+    if (isReply) {
+      setReplyContent(newValue);
+    } else {
+      setNewContent(newValue);
+    }
+    setShowMentions(false);
+    setMentionQuery(null);
+
+    setTimeout(() => {
+      const newPos = start + user.name.length + 2;
+      textarea.focus();
+      textarea.setSelectionRange(newPos, newPos);
+    }, 0);
+  };
 
   const handleSubmit = async (content: string, parentId?: string) => {
     if (!content.trim()) return;
@@ -105,6 +181,76 @@ export function CommentPanel({ tableId, recordId }: CommentPanelProps) {
         part
       )
     );
+  };
+
+  const mentionDropdown = () => {
+    if (!showMentions || mentionResults.length === 0) return null;
+    const textarea = activeInput === "reply" ? replyInputRef.current : inputRef.current;
+    const rect = textarea?.getBoundingClientRect();
+    if (!rect) return null;
+    return (
+      <div
+        className="fixed bg-popover border rounded-md shadow-lg max-h-40 overflow-y-auto z-[60]"
+        style={{
+          left: rect.left,
+          top: rect.top - 170 > 0 ? rect.top - 170 : rect.bottom + 4,
+          width: Math.min(rect.width, 320),
+        }}
+      >
+        {mentionResults.map((user, i) => (
+          <button
+            key={user.id}
+            type="button"
+            className={cn(
+              "w-full flex items-center gap-2 px-3 py-1.5 text-sm hover:bg-muted/50 text-left",
+              i === mentionIndex && "bg-muted/50"
+            )}
+            onClick={() => insertMention(user)}
+            onMouseEnter={() => setMentionIndex(i)}
+          >
+            <UserAvatar name={user.name} size="sm" />
+            <div className="min-w-0">
+              <div className="font-medium truncate">{user.name}</div>
+              <div className="text-xs text-muted-foreground truncate">{user.email}</div>
+            </div>
+          </button>
+        ))}
+      </div>
+    );
+  };
+
+  const handleInputKeyDown = (
+    e: React.KeyboardEvent<HTMLTextAreaElement>,
+    isReply: boolean,
+    submitFn: () => void
+  ) => {
+    if (showMentions) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setMentionIndex((i) => Math.min(i + 1, mentionResults.length - 1));
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setMentionIndex((i) => Math.max(i - 1, 0));
+        return;
+      }
+      if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault();
+        if (mentionResults[mentionIndex]) {
+          insertMention(mentionResults[mentionIndex]);
+        }
+        return;
+      }
+      if (e.key === "Escape") {
+        setShowMentions(false);
+        return;
+      }
+    }
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      submitFn();
+    }
   };
 
   if (isLoading) {
@@ -205,39 +351,47 @@ export function CommentPanel({ tableId, recordId }: CommentPanelProps) {
 
             {/* Reply input */}
             {replyTo === comment.id && (
-              <div className="pl-8 flex gap-2">
-                <input
-                  className="flex-1 text-sm border rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-primary"
-                  placeholder="回复..."
+              <div className="pl-8 relative">
+                <textarea
+                  ref={replyInputRef}
+                  className="flex-1 text-sm border rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-primary resize-none min-h-[32px] w-full"
+                  placeholder="回复... 输入 @ 提及用户"
                   value={replyContent}
-                  onChange={(e) => setReplyContent(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && !e.shiftKey && replyContent.trim()) {
+                  rows={1}
+                  onChange={(e) => {
+                    setReplyContent(e.target.value);
+                    detectMention(e.target.value, e.target);
+                  }}
+                  onFocus={() => setActiveInput("reply")}
+                  onKeyDown={(e) => handleInputKeyDown(e, true, () => {
+                    if (replyContent.trim()) {
                       handleSubmit(replyContent, comment.id);
                       setReplyContent("");
                       setReplyTo(null);
                     }
-                  }}
+                  })}
                   autoFocus
                 />
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onClick={() => { setReplyTo(null); setReplyContent(""); }}
-                >
-                  取消
-                </Button>
-                <Button
-                  size="sm"
-                  disabled={!replyContent.trim()}
-                  onClick={() => {
-                    handleSubmit(replyContent, comment.id);
-                    setReplyContent("");
-                    setReplyTo(null);
-                  }}
-                >
-                  发送
-                </Button>
+                <div className="flex gap-2 mt-1 justify-end">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => { setReplyTo(null); setReplyContent(""); }}
+                  >
+                    取消
+                  </Button>
+                  <Button
+                    size="sm"
+                    disabled={!replyContent.trim()}
+                    onClick={() => {
+                      handleSubmit(replyContent, comment.id);
+                      setReplyContent("");
+                      setReplyTo(null);
+                    }}
+                  >
+                    发送
+                  </Button>
+                </div>
               </div>
             )}
           </div>
@@ -245,20 +399,27 @@ export function CommentPanel({ tableId, recordId }: CommentPanelProps) {
       </div>
 
       {/* New comment input */}
-      <div className="border-t p-3">
-        <div className="flex gap-2">
-          <input
-            className="flex-1 text-sm border rounded px-3 py-2 focus:outline-none focus:ring-1 focus:ring-primary"
-            placeholder="添加评论... 使用 @用户名 提及"
-            value={newContent}
-            onChange={(e) => setNewContent(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && !e.shiftKey && newContent.trim()) {
-                handleSubmit(newContent);
-                setNewContent("");
-              }
-            }}
-          />
+      <div className="border-t p-3 relative">
+        {mentionDropdown()}
+        <textarea
+          ref={inputRef}
+          className="w-full text-sm border rounded px-3 py-2 focus:outline-none focus:ring-1 focus:ring-primary resize-none min-h-[36px]"
+          placeholder="添加评论... 输入 @ 提及用户"
+          value={newContent}
+          rows={1}
+          onChange={(e) => {
+            setNewContent(e.target.value);
+            detectMention(e.target.value, e.target);
+          }}
+          onFocus={() => setActiveInput("main")}
+          onKeyDown={(e) => handleInputKeyDown(e, false, () => {
+            if (newContent.trim()) {
+              handleSubmit(newContent);
+              setNewContent("");
+            }
+          })}
+        />
+        <div className="flex justify-end mt-1">
           <Button
             size="sm"
             disabled={!newContent.trim()}

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -838,6 +838,18 @@ export function GridView({
 
   // ── Cell comment popover ──
   const [cellCommentTarget, setCellCommentTarget] = useState<{ recordId: string; fieldKey: string } | null>(null);
+  const refreshCellCommentCounts = useCallback(() => {
+    if (!tableId || records.length === 0) return;
+    const ids = records.map((r) => r.id);
+    fetch(`/api/data-tables/${tableId}/records/${ids[0]}/comments?cellCounts=${ids.join(",")}`)
+      .then((res) => (res.ok ? res.json() : {}))
+      .then((data: Record<string, Record<string, number>>) => setCellCommentCounts(data))
+      .catch(() => {});
+    fetch(`/api/data-tables/${tableId}/records/${ids[0]}/comments?ids=${ids.join(",")}`)
+      .then((res) => (res.ok ? res.json() : {}))
+      .then((data: Record<string, number>) => setCommentCounts(data))
+      .catch(() => {});
+  }, [tableId, records]);
 
   // ── Fill handle (drag-fill) ──────────────────────────────────────────────
   const [fillRange, setFillRange] = useState<{ startRow: number; startCol: number; endRow: number; endCol: number } | null>(null);
@@ -2293,6 +2305,7 @@ export function GridView({
               recordId={cellCommentTarget.recordId}
               fieldKey={cellCommentTarget.fieldKey}
               fieldName={fields.find((f) => f.key === cellCommentTarget.fieldKey)?.label}
+              onCommentChange={refreshCellCommentCounts}
             />
           </div>
         </div>

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -50,6 +50,7 @@ import { TableSkeleton } from "@/components/ui/skeleton";
 import { ColumnResizer } from "@/components/data/column-resizer";
 import { useCellContext } from "@/hooks/use-cell-context";
 import { CellContextMenu } from "@/components/data/cell-context-menu";
+import { CellCommentPanel } from "@/components/data/cell-comment-panel";
 import { toast } from "sonner";
 
 const DEFAULT_COL_WIDTH = 160;
@@ -820,6 +821,7 @@ export function GridView({
 
   // ── Comment counts ──
   const [commentCounts, setCommentCounts] = useState<Record<string, number>>({});
+  const [cellCommentCounts, setCellCommentCounts] = useState<Record<string, Record<string, number>>>({});
   const recordIdsKey = records.map((r) => r.id).join(",");
   useEffect(() => {
     if (!tableId || recordIdsKey.length === 0) return;
@@ -828,7 +830,14 @@ export function GridView({
       .then((res) => (res.ok ? res.json() : {}))
       .then((data: Record<string, number>) => setCommentCounts(data))
       .catch(() => {});
+    fetch(`/api/data-tables/${tableId}/records/${ids[0]}/comments?cellCounts=${ids.join(",")}`)
+      .then((res) => (res.ok ? res.json() : {}))
+      .then((data: Record<string, Record<string, number>>) => setCellCommentCounts(data))
+      .catch(() => {});
   }, [tableId, recordIdsKey]);
+
+  // ── Cell comment popover ──
+  const [cellCommentTarget, setCellCommentTarget] = useState<{ recordId: string; fieldKey: string } | null>(null);
 
   // ── Fill handle (drag-fill) ──────────────────────────────────────────────
   const [fillRange, setFillRange] = useState<{ startRow: number; startCol: number; endRow: number; endCol: number } | null>(null);
@@ -1806,6 +1815,20 @@ export function GridView({
                     onMouseDown={(e) => handleFillStart(e, record, field)}
                   />
                 )}
+                {cellCommentCounts[record.id]?.[field.key] > 0 && (
+                  <div
+                    className="absolute top-0 right-0 z-20 cursor-pointer"
+                    title={`${cellCommentCounts[record.id][field.key]} 条评论`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setCellCommentTarget({ recordId: record.id, fieldKey: field.key });
+                    }}
+                  >
+                    <div className="bg-amber-400 text-white text-[8px] leading-none rounded-bl-md rounded-tr-md px-1 py-0.5 font-medium">
+                      {cellCommentCounts[record.id][field.key]}
+                    </div>
+                  </div>
+                )}
                 {(() => {
                   const cursorsOnCell: { userName: string; color: string }[] = [];
                   if (cursorPositions) {
@@ -1909,6 +1932,8 @@ export function GridView({
       handleFillStart,
       cursorPositions,
       commentCounts,
+      cellCommentCounts,
+      fields,
     ]
   );
 
@@ -2006,6 +2031,9 @@ export function GridView({
         onSelectColumn={() => {}}
         onSelectAll={() => {
           setSelectedIdsSet(new Set(records.map((r) => r.id)));
+        }}
+        onAddCellComment={(recordId, fieldKey) => {
+          setCellCommentTarget({ recordId, fieldKey });
         }}
       >
       <div className="flex items-center gap-1 px-2 py-1 border-b">
@@ -2237,6 +2265,39 @@ export function GridView({
         </table>
       </div>
       </CellContextMenu>
+
+      {/* Cell comment popover */}
+      {cellCommentTarget && (
+        <div
+          className="fixed inset-0 z-50"
+          onClick={() => setCellCommentTarget(null)}
+        >
+          <div
+            className="absolute right-4 top-16 w-96 max-h-[70vh] bg-background border rounded-lg shadow-xl flex flex-col"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between px-3 py-2 border-b">
+              <span className="text-sm font-medium">
+                单元格评论
+                {(() => {
+                  const f = fields.find((f) => f.key === cellCommentTarget.fieldKey);
+                  return f ? ` — ${f.label}` : "";
+                })()}
+              </span>
+              <Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={() => setCellCommentTarget(null)}>
+                <span className="text-lg leading-none">&times;</span>
+              </Button>
+            </div>
+            <CellCommentPanel
+              tableId={tableId}
+              recordId={cellCommentTarget.recordId}
+              fieldKey={cellCommentTarget.fieldKey}
+              fieldName={fields.find((f) => f.key === cellCommentTarget.fieldKey)?.label}
+            />
+          </div>
+        </div>
+      )}
+
       {/* Fill mode toggle popup */}
       {fillComplete && (
         <div

--- a/src/components/layout/notification-bell.tsx
+++ b/src/components/layout/notification-bell.tsx
@@ -12,6 +12,8 @@ const TYPE_BADGE: Record<NotificationType, { color: string; label: string }> = {
   DUE_TODAY: { color: "bg-amber-500", label: "今天到期" },
   OVERDUE: { color: "bg-red-500", label: "已到期" },
   MANUAL_REMIND: { color: "bg-amber-500", label: "催办提醒" },
+  COMMENT_MENTION: { color: "bg-purple-500", label: "提及通知" },
+  COMMENT_REPLY: { color: "bg-green-500", label: "评论回复" },
 };
 
 function formatRelativeTime(date: Date): string {
@@ -99,7 +101,7 @@ export function NotificationBell() {
   };
 
   const handleMarkAsRead = async (notification: NotificationItem) => {
-    if (notification.isRead || !notification.taskId) return;
+    if (notification.isRead) return;
 
     try {
       const res = await fetch("/api/notifications/read", {
@@ -114,7 +116,9 @@ export function NotificationBell() {
         );
         setUnreadCount((c) => Math.max(0, c - 1));
         setOpen(false);
-        router.push(`/collections/${notification.taskId}`);
+        if (notification.taskId) {
+          router.push(`/collections/${notification.taskId}`);
+        }
       }
     } catch {
       toast.error("操作失败");

--- a/src/lib/services/data-record-comment.service.ts
+++ b/src/lib/services/data-record-comment.service.ts
@@ -1,10 +1,12 @@
 import { db } from "@/lib/db";
 import type { ServiceResult } from "@/types/data-table";
 import type { InputJsonValue } from "@/generated/prisma/internal/prismaNamespace";
+import { createNotifications } from "./notification.service";
 
 export interface CommentItem {
   id: string;
   recordId: string;
+  fieldKey: string | null;
   content: string;
   parentId: string | null;
   mentions: unknown;
@@ -18,6 +20,7 @@ export interface CommentItem {
 
 interface CreateCommentInput {
   recordId: string;
+  fieldKey?: string;
   content: string;
   parentId?: string;
   mentions?: string[];
@@ -26,6 +29,7 @@ interface CreateCommentInput {
 type DbComment = {
   id: string;
   recordId: string;
+  fieldKey: string | null;
   content: string;
   parentId: string | null;
   mentions: unknown;
@@ -41,6 +45,7 @@ function toCommentItem(c: DbComment): CommentItem {
   return {
     id: c.id,
     recordId: c.recordId,
+    fieldKey: c.fieldKey,
     content: c.content,
     parentId: c.parentId,
     mentions: c.mentions,
@@ -97,6 +102,7 @@ export async function createComment(
   const comment = await db.dataRecordComment.create({
     data: {
       recordId: input.recordId,
+      fieldKey: input.fieldKey ?? null,
       content: input.content,
       parentId: input.parentId ?? null,
       createdById: userId,
@@ -107,7 +113,13 @@ export async function createComment(
       replies: { include: { createdBy: { select: { name: true } } } },
     },
   });
-  return { success: true, data: toCommentItem(comment as unknown as DbComment) };
+
+  const result = toCommentItem(comment as unknown as DbComment);
+
+  // Fire-and-forget notifications
+  void sendCommentNotifications(userId, result, mentions);
+
+  return { success: true, data: result };
 }
 
 export async function updateComment(
@@ -190,4 +202,82 @@ export async function getUnresolvedCount(
     map.set(row.recordId, row._count);
   }
   return map;
+}
+
+export async function getCellCommentCounts(
+  recordIds: string[]
+): Promise<Map<string, Record<string, number>>> {
+  if (recordIds.length === 0) return new Map();
+
+  const rows = await db.dataRecordComment.findMany({
+    where: {
+      recordId: { in: recordIds },
+      fieldKey: { not: null },
+      isResolved: false,
+    },
+    select: { recordId: true, fieldKey: true },
+  });
+
+  const map = new Map<string, Record<string, number>>();
+  for (const row of rows) {
+    if (!row.fieldKey) continue;
+    const existing = map.get(row.recordId) ?? {};
+    existing[row.fieldKey] = (existing[row.fieldKey] ?? 0) + 1;
+    map.set(row.recordId, existing);
+  }
+  return map;
+}
+
+async function sendCommentNotifications(
+  authorId: string,
+  comment: CommentItem,
+  mentions: string[] | null
+) {
+  const notifications: Array<{
+    recipientId: string;
+    type: "COMMENT_MENTION" | "COMMENT_REPLY";
+    title: string;
+    content: string;
+  }> = [];
+
+  // @mention notifications
+  if (mentions && mentions.length > 0) {
+    const mentionedUsers = await db.user.findMany({
+      where: { name: { in: mentions } },
+      select: { id: true, name: true },
+    });
+    for (const user of mentionedUsers) {
+      if (user.id === authorId) continue;
+      notifications.push({
+        recipientId: user.id,
+        type: "COMMENT_MENTION",
+        title: "在评论中提及了你",
+        content: comment.content.length > 100
+          ? comment.content.slice(0, 100) + "..."
+          : comment.content,
+      });
+    }
+  }
+
+  // Reply notification
+  if (comment.parentId) {
+    const parent = await db.dataRecordComment.findUnique({
+      where: { id: comment.parentId },
+      select: { createdById: true },
+    });
+    if (parent && parent.createdById !== authorId) {
+      notifications.push({
+        recipientId: parent.createdById,
+        type: "COMMENT_REPLY",
+        title: "回复了你的评论",
+        content: comment.content.length > 100
+          ? comment.content.slice(0, 100) + "..."
+          : comment.content,
+      });
+    }
+  }
+
+  if (notifications.length > 0) {
+    await createNotifications(notifications);
+  }
 }

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,4 +1,4 @@
-export type NotificationType = "TASK_ASSIGNED" | "DUE_TODAY" | "OVERDUE" | "MANUAL_REMIND";
+export type NotificationType = "TASK_ASSIGNED" | "DUE_TODAY" | "OVERDUE" | "MANUAL_REMIND" | "COMMENT_MENTION" | "COMMENT_REPLY";
 
 export type NotificationItem = {
   id: string;


### PR DESCRIPTION
## Summary
- 单元格级评论：右键单元格→"添加评论"，评论关联 (recordId, fieldKey)，面板显示字段名上下文
- @提及自动补全：输入 @ 弹出用户搜索下拉框，支持键盘导航选择，选中自动插入 @用户名
- 通知推送：@提及时发送 COMMENT_MENTION 通知，评论回复发送 COMMENT_REPLY 通知
- 单元格评论标识：有评论的单元格右上角显示黄色计数角标
- 新增公开用户搜索 API `/api/users/search`（认证用户可用）

## Test plan
- [x] 右键单元格 → "添加评论" → 输入评论 → 发送 → 查看显示
- [x] 输入 @ → 弹出用户列表 → 键盘导航选择 → 自动插入用户名
- [x] 被提及用户收到铃铛通知（验证 COMMENT_MENTION 类型显示）
- [x] 单元格有评论时显示黄色角标

Closes #120

🤖 Generated with [Claude Code](https://claude.ai/code)