### PR TITLE
fix: 修复货币字段小数位保存后不生效 (#130)

### DIFF
--- a/src/app/api/data-tables/[id]/fields/route.ts
+++ b/src/app/api/data-tables/[id]/fields/route.ts
@@ -162,7 +162,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       }
     }
 
-    return NextResponse.json({ ...result.data, backfillWarning });
+    return NextResponse.json({ fields: result.data, backfillWarning });
   } catch (error) {
     if (error instanceof ZodError) {
       const errorMessages = error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', ');

--- a/src/components/data/field-config-form.test.tsx
+++ b/src/components/data/field-config-form.test.tsx
@@ -148,6 +148,20 @@ vi.mock("@/generated/prisma/enums", () => ({
     EMAIL: "EMAIL",
     PHONE: "PHONE",
     FILE: "FILE",
+    URL: "URL",
+    BOOLEAN: "BOOLEAN",
+    AUTO_NUMBER: "AUTO_NUMBER",
+    SYSTEM_TIMESTAMP: "SYSTEM_TIMESTAMP",
+    SYSTEM_USER: "SYSTEM_USER",
+    FORMULA: "FORMULA",
+    COUNT: "COUNT",
+    LOOKUP: "LOOKUP",
+    ROLLUP: "ROLLUP",
+    RICH_TEXT: "RICH_TEXT",
+    RATING: "RATING",
+    CURRENCY: "CURRENCY",
+    PERCENTAGE: "PERCENTAGE",
+    DURATION: "DURATION",
     RELATION: "RELATION",
     RELATION_SUBTABLE: "RELATION_SUBTABLE",
   },
@@ -372,6 +386,51 @@ describe("FieldConfigForm", () => {
             }),
           ],
         },
+      })
+    );
+  });
+
+  it("切换到货币字段时会正确回填并提交小数位配置", () => {
+    const currencyField: DataFieldItem = {
+      id: "currency-field-id",
+      key: "budget",
+      label: "预算",
+      type: FieldType.CURRENCY,
+      required: false,
+      options: { currencyCode: "USD", currencyDecimals: 0 },
+      sortOrder: 0,
+    };
+
+    const { rerender } = render(
+      <FieldConfigForm
+        open
+        onOpenChange={onOpenChangeMock}
+        field={null}
+        availableTables={availableTables}
+        onSubmit={onSubmitMock}
+      />
+    );
+
+    rerender(
+      <FieldConfigForm
+        open
+        onOpenChange={onOpenChangeMock}
+        field={currencyField}
+        availableTables={availableTables}
+        onSubmit={onSubmitMock}
+      />
+    );
+
+    const decimalsInput = screen.getByLabelText("小数位数") as HTMLInputElement;
+    expect(decimalsInput.value).toBe("0");
+
+    fireEvent.change(decimalsInput, { target: { value: "3" } });
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    expect(onSubmitMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: FieldType.CURRENCY,
+        options: { currencyCode: "USD", currencyDecimals: 3 },
       })
     );
   });

--- a/src/components/data/field-config-form.tsx
+++ b/src/components/data/field-config-form.tsx
@@ -317,6 +317,11 @@ export function FieldConfigForm({
     const opts = parseFieldOptions(field?.options);
     return (opts.durationFormat as string) ?? "hh:mm";
   });
+  const [systemFieldKind, setSystemFieldKind] = useState<"created" | "updated">(() => {
+    const opts = parseFieldOptions(field?.options);
+    return opts.kind ?? "created";
+  });
+  const [error, setError] = useState("");
 
   // Load target table fields when lookup source field changes
   useEffect(() => {
@@ -405,7 +410,7 @@ export function FieldConfigForm({
       if (cycle) return cycle;
     }
     return null;
-  }, [formulaExpression, allFields, field?.key]);
+  }, [formulaExpression, allFields, field]);
 
   // Live preview: fetch sample record once when form opens
   const [sampleData, setSampleData] = useState<Record<string, unknown> | null>(null);
@@ -448,10 +453,18 @@ export function FieldConfigForm({
     setRelationFields(relTable?.fields ?? []);
     setFormulaExpression(opts.formula ?? "");
     setCountSourceFieldId(opts.countSourceFieldId ?? "");
+    setLookupSourceFieldId(opts.lookupSourceFieldId ?? "");
+    setLookupTargetFieldKey(opts.lookupTargetFieldKey ?? "");
     setRollupSourceFieldId(opts.rollupSourceFieldId ?? "");
     setRollupTargetFieldKey(opts.rollupTargetFieldKey ?? "");
     setRollupAggregateType((opts.rollupAggregateType as RollupAggregateType) ?? "");
     setRollupConditions((opts.rollupConditions as FilterGroup[]) ?? []);
+    setRatingMax((opts.ratingMax as number) ?? 5);
+    setRatingAllowHalf((opts.ratingAllowHalf as boolean) ?? false);
+    setCurrencyCode((opts.currencyCode as string) ?? "CNY");
+    setCurrencyDecimals((opts.currencyDecimals as number) ?? 2);
+    setPercentageDecimals((opts.percentageDecimals as number) ?? 0);
+    setDurationFormat((opts.durationFormat as string) ?? "hh:mm");
     setSystemFieldKind(opts.kind ?? "created");
     setError("");
   }, [field, availableTables]);
@@ -465,11 +478,6 @@ export function FieldConfigForm({
       return undefined;
     }
   }, [formulaExpression, formulaError, sampleData]);
-  const [systemFieldKind, setSystemFieldKind] = useState<"created" | "updated">(() => {
-    const opts = parseFieldOptions(field?.options);
-    return opts.kind ?? "created";
-  });
-  const [error, setError] = useState("");
 
   const isRelationType =
     fieldType === FieldType.RELATION || fieldType === FieldType.RELATION_SUBTABLE;

--- a/src/components/data/field-config-list.tsx
+++ b/src/components/data/field-config-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   Table,
@@ -131,6 +131,33 @@ export function FieldConfigList({
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
+  useEffect(() => {
+    setFields(
+      initialFields.map((f) => ({
+        id: f.id,
+        key: f.key,
+        label: f.label,
+        type: f.type,
+        required: f.required,
+        options: f.options,
+        relationTo: f.relationTo,
+        displayField: f.displayField,
+        relationCardinality: f.relationCardinality,
+        inverseRelationCardinality: f.inverseRelationCardinality,
+        inverseFieldId: f.inverseFieldId,
+        inverseFieldKey: f.inverseFieldKey,
+        isSystemManagedInverse: f.isSystemManagedInverse,
+        relationSchema: f.relationSchema,
+        defaultValue: f.defaultValue,
+        sortOrder: f.sortOrder,
+      }))
+    );
+  }, [initialFields]);
+
+  useEffect(() => {
+    setBusinessKeys(initialBusinessKeys ?? []);
+  }, [initialBusinessKeys]);
+
   const handleAddField = (data: DataFieldInput) => {
     setFields([...fields, toFieldItem(data, fields.length)]);
     setIsFormOpen(false);
@@ -171,6 +198,8 @@ export function FieldConfigList({
       // Update local state from API response to ensure consistency with DB
       if (Array.isArray(result)) {
         setFields(result as DataFieldItem[]);
+      } else if (Array.isArray(result.fields)) {
+        setFields(result.fields as DataFieldItem[]);
       }
 
       router.refresh();
@@ -191,7 +220,7 @@ export function FieldConfigList({
   const tablesWithFields = availableTables.map((t) => ({
     id: t.id,
     name: t.name,
-    fields: t.id === tableId ? initialFields : [],
+    fields: t.id === tableId ? fields : [],
   }));
 
   // Handle opening the edit form - find field from current fields state

--- a/src/validators/data-table.ts
+++ b/src/validators/data-table.ts
@@ -69,11 +69,11 @@ export const dataFieldItemSchema = z.object({
   options: z.union([
     z.array(z.string()),
     z.array(z.object({ label: z.string(), color: z.string() })),
-    z.object({ formula: z.string() }),
-    z.object({ nextValue: z.number() }),
-    z.object({ kind: z.enum(["created", "updated"]) }),
-    z.object({ countSourceFieldId: z.string() }),
-    z.object({ lookupSourceFieldId: z.string(), lookupTargetFieldKey: z.string() }),
+    z.object({ formula: z.string() }).strict(),
+    z.object({ nextValue: z.number() }).strict(),
+    z.object({ kind: z.enum(["created", "updated"]) }).strict(),
+    z.object({ countSourceFieldId: z.string() }).strict(),
+    z.object({ lookupSourceFieldId: z.string(), lookupTargetFieldKey: z.string() }).strict(),
     z.object({
       rollupSourceFieldId: z.string(),
       rollupTargetFieldKey: z.string(),
@@ -82,21 +82,21 @@ export const dataFieldItemSchema = z.object({
         "ARRAYJOIN", "ARRAYUNIQUE", "TRUE_COUNT", "FALSE_COUNT",
       ]),
       rollupConditions: z.array(filterGroupSchema).optional(),
-    }),
+    }).strict(),
     z.object({
       ratingMax: z.number().int().min(1).max(10).default(5),
       ratingAllowHalf: z.boolean().default(false),
-    }),
+    }).strict(),
     z.object({
       currencyCode: z.enum(["CNY", "USD", "EUR"]),
       currencyDecimals: z.number().int().min(0).max(6).default(2),
-    }),
+    }).strict(),
     z.object({
       percentageDecimals: z.number().int().min(0).max(4).default(0),
-    }),
+    }).strict(),
     z.object({
       durationFormat: z.enum(["hh:mm", "mm:ss", "hh:mm:ss"]),
-    }),
+    }).strict(),
   ]).nullable().optional(),
   relationTo: z.string().nullable().optional(),
   displayField: z.string().nullable().optional(),


### PR DESCRIPTION
## 变更说明

修复 Issue #130：数据表货币字段修改小数位数后保存不生效。

### 根因
- `options` 使用 `z.union([...])` 进行校验时，部分分支会错误吞掉不匹配字段，导致货币配置可能被错误解析，`currencyDecimals` 未按预期保留。
- 字段配置页保存链路存在返回结构与本地状态同步不一致问题，保存后页面可能继续使用旧字段快照。
- 字段配置表单在字段切换时，对扩展类型 options 的回填不完整。

### 修复内容
- 在 `src/validators/data-table.ts` 中，对 `options` 里的对象分支使用 `.strict()`，避免跨类型错误匹配。
- 在 `src/components/data/field-config-form.tsx` 中补齐扩展配置项（含货币小数位）的状态回填。
- 在 `src/app/api/data-tables/[id]/fields/route.ts` 中统一返回 `{ fields, backfillWarning }`。
- 在 `src/components/data/field-config-list.tsx` 中修复保存后字段状态与业务键状态同步逻辑，并使用最新本地字段构建表关联上下文。
- 增加 `src/components/data/field-config-form.test.tsx` 回归测试，覆盖货币字段小数位回填与提交。

## 影响范围
- 数据表字段配置（货币字段）
- 字段配置页保存后刷新与状态一致性

## 验证
- ESLint 针对改动文件通过。