### PR TITLE
feat(timeline): 甘特图增强（依赖连线/拖拽改期/里程碑/缩放平移）(#119)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "cmdk": "^1.1.1",
         "echarts": "^6.0.0",
         "embla-carousel-react": "^8.6.0",
+        "frappe-gantt": "^1.2.2",
         "jszip": "^3.10.1",
         "lucide-react": "^1.7.0",
         "media-chrome": "^4.18.3",
@@ -11266,6 +11267,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/frappe-gantt": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/frappe-gantt/-/frappe-gantt-1.2.2.tgz",
+      "integrity": "sha512-1+uPNRa92LBIeKiZCVhJMiGIifJk5ONaoerXI8eBREXWRZGGoTJR5ATpMpsnAQcyBA6Gnq5wIht4eL+e4eHMBA==",
+      "license": "MIT"
     },
     "node_modules/fresh": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "cmdk": "^1.1.1",
     "echarts": "^6.0.0",
     "embla-carousel-react": "^8.6.0",
+    "frappe-gantt": "^1.2.2",
     "jszip": "^3.10.1",
     "lucide-react": "^1.7.0",
     "media-chrome": "^4.18.3",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -313,6 +313,10 @@ enum RelationCardinality {
   MULTIPLE
 }
 
+enum TaskDependencyType {
+  FS
+}
+
 model DataTable {
   id               String            @id @default(cuid())
   name             String            @unique
@@ -326,6 +330,7 @@ model DataTable {
   batchGenerations BatchGeneration[]
   templateVersions TemplateVersion[]
   views            DataView[]
+  taskDependencies TaskDependency[]
   createdBy        User              @relation(fields: [createdById], references: [id], onDelete: Cascade)
   createdById      String
   createdAt        DateTime          @default(now())
@@ -367,6 +372,8 @@ model DataRecord {
   data             Json
   relationRowsFrom DataRelationRow[] @relation("RelationRowsAsSource")
   relationRowsTo   DataRelationRow[] @relation("RelationRowsAsTarget")
+  successorDependencies   TaskDependency[] @relation("TaskDependencyAsSuccessor")
+  predecessorDependencies TaskDependency[] @relation("TaskDependencyAsPredecessor")
   records          Record[]
   createdBy        User              @relation(fields: [createdById], references: [id], onDelete: Cascade)
   createdById      String
@@ -381,6 +388,25 @@ model DataRecord {
   @@index([tableId, createdById])             // 复合索引加速用户记录查询
   changeHistories DataRecordChangeHistory[]
   comments        DataRecordComment[]
+}
+
+model TaskDependency {
+  id                  String             @id @default(cuid())
+  tableId             String
+  table               DataTable          @relation(fields: [tableId], references: [id], onDelete: Cascade)
+  successorRecordId   String
+  successorRecord     DataRecord         @relation("TaskDependencyAsSuccessor", fields: [successorRecordId], references: [id], onDelete: Cascade)
+  predecessorRecordId String
+  predecessorRecord   DataRecord         @relation("TaskDependencyAsPredecessor", fields: [predecessorRecordId], references: [id], onDelete: Cascade)
+  type                TaskDependencyType @default(FS)
+  lagDays             Int                @default(0)
+  required            Boolean            @default(true)
+  createdAt           DateTime           @default(now())
+  updatedAt           DateTime           @updatedAt
+
+  @@unique([successorRecordId, predecessorRecordId, type])
+  @@index([tableId, successorRecordId])
+  @@index([tableId, predecessorRecordId])
 }
 
 model DataRecordChangeHistory {
@@ -846,4 +872,3 @@ model DataRecordComment {
   @@index([createdById])
   @@map("data_record_comments")
 }
-

--- a/src/app/api/data-tables/[id]/dependencies/[depId]/route.ts
+++ b/src/app/api/data-tables/[id]/dependencies/[depId]/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getRouteSessionUser } from "@/lib/auth";
+import { deleteTaskDependency } from "@/lib/services/task-dependency.service";
+
+interface RouteParams {
+  params: Promise<{ id: string; depId: string }>;
+}
+
+function mapErrorStatus(code: string): number {
+  if (code === "NOT_FOUND") return 404;
+  return 400;
+}
+
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  const user = await getRouteSessionUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "未授权" }, { status: 401 });
+  }
+
+  if (user.role !== "ADMIN") {
+    return NextResponse.json({ error: "权限不足" }, { status: 403 });
+  }
+
+  const { id: tableId, depId } = await params;
+  const result = await deleteTaskDependency(tableId, depId);
+
+  if (!result.success) {
+    return NextResponse.json(
+      { error: result.error.message },
+      { status: mapErrorStatus(result.error.code) }
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/data-tables/[id]/dependencies/[depId]/route.ts
+++ b/src/app/api/data-tables/[id]/dependencies/[depId]/route.ts
@@ -8,7 +8,8 @@ interface RouteParams {
 
 function mapErrorStatus(code: string): number {
   if (code === "NOT_FOUND") return 404;
-  return 400;
+  if (code === "DELETE_FAILED") return 500;
+  return 500;
 }
 
 export async function DELETE(request: NextRequest, { params }: RouteParams) {

--- a/src/app/api/data-tables/[id]/dependencies/route.ts
+++ b/src/app/api/data-tables/[id]/dependencies/route.ts
@@ -5,6 +5,7 @@ import {
   upsertTaskDependency,
 } from "@/lib/services/task-dependency.service";
 import { taskDependencyInputSchema } from "@/validators/data-table";
+import { ZodError } from "zod";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -12,10 +13,11 @@ interface RouteParams {
 
 function mapErrorStatus(code: string): number {
   if (code === "NOT_FOUND") return 404;
+  if (code === "LIST_FAILED" || code === "UPSERT_FAILED") return 500;
   if (code === "SELF_LOOP" || code === "CROSS_TABLE_DEPENDENCY" || code === "INVALID_TYPE" || code === "RECORD_NOT_FOUND") {
     return 400;
   }
-  return 400;
+  return 500;
 }
 
 export async function GET(request: NextRequest, { params }: RouteParams) {
@@ -51,29 +53,35 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
 
   try {
     const body = await request.json();
-    const validated = taskDependencyInputSchema.parse(body);
+    const payload = Array.isArray(body)
+      ? taskDependencyInputSchema.array().parse(body)
+      : [taskDependencyInputSchema.parse(body)];
 
-    const result = await upsertTaskDependency({
-      tableId,
-      successorRecordId: validated.successorRecordId,
-      predecessorRecordId: validated.predecessorRecordId,
-      type: validated.type,
-      lagDays: validated.lagDays,
-      required: validated.required,
-    });
+    const results = [];
+    for (const item of payload) {
+      const result = await upsertTaskDependency({
+        tableId,
+        successorRecordId: item.successorRecordId,
+        predecessorRecordId: item.predecessorRecordId,
+        type: item.type,
+        lagDays: item.lagDays,
+        required: item.required,
+      });
 
-    if (!result.success) {
-      return NextResponse.json(
-        { error: result.error.message },
-        { status: mapErrorStatus(result.error.code) }
-      );
+      if (!result.success) {
+        return NextResponse.json(
+          { error: result.error.message },
+          { status: mapErrorStatus(result.error.code) }
+        );
+      }
+      results.push(result.data);
     }
 
-    return NextResponse.json(result.data);
+    return NextResponse.json(Array.isArray(body) ? results : results[0]);
   } catch (error) {
-    if (error instanceof Error && error.name === "ZodError") {
+    if (error instanceof ZodError) {
       return NextResponse.json(
-        { error: "数据验证失败", details: error },
+        { error: "数据验证失败", details: error.issues.map((item) => item.message) },
         { status: 400 }
       );
     }

--- a/src/app/api/data-tables/[id]/dependencies/route.ts
+++ b/src/app/api/data-tables/[id]/dependencies/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getRouteSessionUser } from "@/lib/auth";
+import {
+  listTaskDependencies,
+  upsertTaskDependency,
+} from "@/lib/services/task-dependency.service";
+import { taskDependencyInputSchema } from "@/validators/data-table";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+function mapErrorStatus(code: string): number {
+  if (code === "NOT_FOUND") return 404;
+  if (code === "SELF_LOOP" || code === "CROSS_TABLE_DEPENDENCY" || code === "INVALID_TYPE" || code === "RECORD_NOT_FOUND") {
+    return 400;
+  }
+  return 400;
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const user = await getRouteSessionUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "未授权" }, { status: 401 });
+  }
+
+  const { id: tableId } = await params;
+  const result = await listTaskDependencies(tableId);
+
+  if (!result.success) {
+    return NextResponse.json(
+      { error: result.error.message },
+      { status: mapErrorStatus(result.error.code) }
+    );
+  }
+
+  return NextResponse.json(result.data);
+}
+
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+  const user = await getRouteSessionUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "未授权" }, { status: 401 });
+  }
+
+  if (user.role !== "ADMIN") {
+    return NextResponse.json({ error: "权限不足" }, { status: 403 });
+  }
+
+  const { id: tableId } = await params;
+
+  try {
+    const body = await request.json();
+    const validated = taskDependencyInputSchema.parse(body);
+
+    const result = await upsertTaskDependency({
+      tableId,
+      successorRecordId: validated.successorRecordId,
+      predecessorRecordId: validated.predecessorRecordId,
+      type: validated.type,
+      lagDays: validated.lagDays,
+      required: validated.required,
+    });
+
+    if (!result.success) {
+      return NextResponse.json(
+        { error: result.error.message },
+        { status: mapErrorStatus(result.error.code) }
+      );
+    }
+
+    return NextResponse.json(result.data);
+  } catch (error) {
+    if (error instanceof Error && error.name === "ZodError") {
+      return NextResponse.json(
+        { error: "数据验证失败", details: error },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json(
+      { error: "保存依赖失败" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,7 +2,7 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 @import "streamdown/styles.css";
-@import "frappe-gantt/dist/frappe-gantt.css";
+@import "frappe-gantt";
 @import "./tokens.css";
 @import "./idrl-ui-globals.css";
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,7 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 @import "streamdown/styles.css";
+@import "frappe-gantt/dist/frappe-gantt.css";
 @import "./tokens.css";
 @import "./idrl-ui-globals.css";
 

--- a/src/components/data/record-table.tsx
+++ b/src/components/data/record-table.tsx
@@ -394,10 +394,12 @@ export function RecordTable({
       case "TIMELINE":
         return (
           <TimelineView
+            tableId={tableId}
             fields={fields}
             records={records}
             view={activeView}
             onOpenRecord={onOpenDetail ?? (() => {})}
+            onPatchRecord={handlePatchRecord}
             onViewOptionsChange={setViewOptions}
           />
         );

--- a/src/components/data/record-table.tsx
+++ b/src/components/data/record-table.tsx
@@ -142,6 +142,32 @@ export function RecordTable({
     }
   }, [viewId, currentView?.type]);
 
+  // Fallback sync: when URL carries a viewId but view list lags,
+  // fetch view detail directly to ensure correct renderer.
+  useEffect(() => {
+    if (!viewId) return;
+    let cancelled = false;
+
+    void fetch(`/api/data-tables/${tableId}/views/${viewId}`)
+      .then(async (res) => {
+        if (!res.ok) return null;
+        const data = (await res.json()) as { success?: boolean; data?: DataViewItem };
+        return data.success ? data.data : null;
+      })
+      .then((view) => {
+        if (!cancelled && view?.type) {
+          setViewType(view.type as ViewType);
+        }
+      })
+      .catch(() => {
+        // Ignore fallback sync failures and keep current UI state.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [tableId, viewId]);
+
   // ── Patch single field (for Kanban drag-and-drop) ────────────────────────
   const handlePatchRecord = useCallback(
     async (recordId: string, fieldKey: string, value: unknown) => {

--- a/src/components/data/views/timeline/timeline-adapter.ts
+++ b/src/components/data/views/timeline/timeline-adapter.ts
@@ -1,0 +1,147 @@
+import type { DataFieldItem, DataRecordItem } from "@/types/data-table";
+
+export type TimelineDependencyType = "FS";
+
+export interface TimelineDependencyInput {
+  id: string;
+  predecessorRecordId: string;
+  successorRecordId: string;
+  type?: TimelineDependencyType;
+  lagDays?: number;
+  required?: boolean;
+}
+
+export interface TimelineAdapterConfig {
+  startFieldKey: string;
+  endFieldKey?: string | null;
+  labelFieldKey: string;
+  milestoneFieldKey?: string | null;
+}
+
+export interface TimelineTask {
+  id: string;
+  recordId: string;
+  label: string;
+  startDate: Date;
+  endDate: Date;
+  isMilestone: boolean;
+  record: DataRecordItem;
+}
+
+export interface TimelineLink {
+  id: string;
+  dependencyId: string;
+  predecessorTaskId: string;
+  successorTaskId: string;
+  type: TimelineDependencyType;
+  lagDays: number;
+  required: boolean;
+}
+
+export interface TimelineGraph {
+  tasks: TimelineTask[];
+  links: TimelineLink[];
+}
+
+interface BuildTimelineGraphInput {
+  records: DataRecordItem[];
+  fields: DataFieldItem[];
+  dependencies: TimelineDependencyInput[];
+  config: TimelineAdapterConfig;
+}
+
+function toValidDate(value: unknown): Date | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+
+  if (typeof value !== "string" || value.length === 0) {
+    return null;
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function toBoolean(value: unknown): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value !== "string") return false;
+
+  const normalized = value.trim().toLowerCase();
+  return normalized === "true" || normalized === "1" || normalized === "yes" || normalized === "y";
+}
+
+function toLagDays(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return 0;
+}
+
+export function buildTimelineGraph({
+  records,
+  fields,
+  dependencies,
+  config,
+}: BuildTimelineGraphInput): TimelineGraph {
+  const fieldByKey = new Map(fields.map((field) => [field.key, field]));
+  const startField = fieldByKey.get(config.startFieldKey);
+  const labelField = fieldByKey.get(config.labelFieldKey);
+
+  if (!startField || startField.type !== "DATE" || !labelField) {
+    return { tasks: [], links: [] };
+  }
+
+  const endFieldKey = config.endFieldKey ?? null;
+  const milestoneFieldKey = config.milestoneFieldKey ?? null;
+
+  const tasks = records
+    .map<TimelineTask | null>((record) => {
+      const startDate = toValidDate(record.data[config.startFieldKey]);
+      if (!startDate) return null;
+
+      const parsedEndDate = endFieldKey ? toValidDate(record.data[endFieldKey]) : null;
+      const endDate = parsedEndDate ?? startDate;
+
+      return {
+        id: record.id,
+        recordId: record.id,
+        label: String(record.data[config.labelFieldKey] ?? record.id),
+        startDate,
+        endDate,
+        isMilestone: milestoneFieldKey ? toBoolean(record.data[milestoneFieldKey]) : false,
+        record,
+      };
+    })
+    .filter((task): task is TimelineTask => task !== null)
+    .sort((left, right) => {
+      const timeDelta = left.startDate.getTime() - right.startDate.getTime();
+      if (timeDelta !== 0) return timeDelta;
+      return left.recordId.localeCompare(right.recordId);
+    });
+
+  const taskIds = new Set(tasks.map((task) => task.id));
+
+  const links = dependencies
+    .map<TimelineLink | null>((dependency) => {
+      if (!taskIds.has(dependency.predecessorRecordId) || !taskIds.has(dependency.successorRecordId)) {
+        return null;
+      }
+
+      return {
+        id: dependency.id,
+        dependencyId: dependency.id,
+        predecessorTaskId: dependency.predecessorRecordId,
+        successorTaskId: dependency.successorRecordId,
+        type: dependency.type ?? "FS",
+        lagDays: toLagDays(dependency.lagDays),
+        required: dependency.required ?? true,
+      };
+    })
+    .filter((link): link is TimelineLink => link !== null);
+
+  return { tasks, links };
+}

--- a/src/components/data/views/timeline/timeline-adapter.ts
+++ b/src/components/data/views/timeline/timeline-adapter.ts
@@ -59,6 +59,15 @@ function toValidDate(value: unknown): Date | null {
     return null;
   }
 
+  const plainDate = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (plainDate) {
+    const year = Number(plainDate[1]);
+    const month = Number(plainDate[2]) - 1;
+    const day = Number(plainDate[3]);
+    const parsed = new Date(year, month, day);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+
   const parsed = new Date(value);
   return Number.isNaN(parsed.getTime()) ? null : parsed;
 }

--- a/src/components/data/views/timeline/timeline-config.tsx
+++ b/src/components/data/views/timeline/timeline-config.tsx
@@ -8,6 +8,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { FieldType } from "@/generated/prisma/enums";
 import type { DataFieldItem } from "@/types/data-table";
 
@@ -16,7 +17,10 @@ interface TimelineConfigProps {
   startDateField: string | null;
   endDateField: string | null;
   labelField: string | null;
+  milestoneFieldKey: string | null;
+  dependencyEnabled: boolean;
   onChange: (key: string, value: string | null) => void;
+  onToggleChange: (key: string, value: boolean) => void;
 }
 
 export function TimelineConfig({
@@ -24,9 +28,13 @@ export function TimelineConfig({
   startDateField,
   endDateField,
   labelField,
+  milestoneFieldKey,
+  dependencyEnabled,
   onChange,
+  onToggleChange,
 }: TimelineConfigProps) {
   const dateFields = fields.filter((f) => f.type === FieldType.DATE);
+  const booleanFields = fields.filter((f) => f.type === FieldType.BOOLEAN);
 
   return (
     <div className="grid gap-3 sm:grid-cols-3">
@@ -86,6 +94,35 @@ export function TimelineConfig({
             ))}
           </SelectContent>
         </Select>
+      </div>
+
+      <div className="grid gap-1.5">
+        <Label className="text-xs text-muted-foreground">里程碑字段</Label>
+        <Select
+          value={milestoneFieldKey ?? "_none"}
+          onValueChange={(v) => onChange("milestoneFieldKey", v === "_none" ? null : v)}
+        >
+          <SelectTrigger className="h-8 text-sm">
+            <SelectValue placeholder="可选" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="_none">不选择</SelectItem>
+            {booleanFields.map((f) => (
+              <SelectItem key={f.key} value={f.key}>
+                {f.label} ({f.key})
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex items-center justify-between rounded-md border px-3 py-2 sm:col-span-3">
+        <Label className="text-xs text-muted-foreground">启用依赖连线</Label>
+        <Switch
+          checked={dependencyEnabled}
+          onCheckedChange={(checked) => onToggleChange("dependencyEnabled", checked)}
+          size="sm"
+        />
       </div>
     </div>
   );

--- a/src/components/data/views/timeline/timeline-conflicts.test.ts
+++ b/src/components/data/views/timeline/timeline-conflicts.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+import type { DataFieldItem, DataRecordItem } from "@/types/data-table";
+import { buildTimelineGraph } from "./timeline-adapter";
+import { calculateTimelineConflicts } from "./timeline-conflicts";
+
+function createRecord(id: string, data: Record<string, unknown>): DataRecordItem {
+  return {
+    id,
+    tableId: "tbl-1",
+    data,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    createdByName: "tester",
+    updatedByName: null,
+  };
+}
+
+const fields: DataFieldItem[] = [
+  {
+    id: "f-start",
+    key: "start",
+    label: "开始",
+    type: "DATE" as DataFieldItem["type"],
+    required: false,
+    sortOrder: 0,
+  },
+  {
+    id: "f-end",
+    key: "end",
+    label: "结束",
+    type: "DATE" as DataFieldItem["type"],
+    required: false,
+    sortOrder: 1,
+  },
+  {
+    id: "f-label",
+    key: "name",
+    label: "名称",
+    type: "TEXT" as DataFieldItem["type"],
+    required: false,
+    sortOrder: 2,
+  },
+  {
+    id: "f-milestone",
+    key: "isMilestone",
+    label: "里程碑",
+    type: "BOOLEAN" as DataFieldItem["type"],
+    required: false,
+    sortOrder: 3,
+  },
+];
+
+describe("buildTimelineGraph + calculateTimelineConflicts", () => {
+  it("支持正 lagDays 冲突判定", () => {
+    const graph = buildTimelineGraph({
+      records: [
+        createRecord("A", { start: "2026-01-01", end: "2026-01-05", name: "A" }),
+        createRecord("B", { start: "2026-01-06", end: "2026-01-10", name: "B" }),
+      ],
+      fields,
+      dependencies: [
+        {
+          id: "dep-positive",
+          predecessorRecordId: "A",
+          successorRecordId: "B",
+          type: "FS",
+          lagDays: 2,
+          required: true,
+        },
+      ],
+      config: {
+        startFieldKey: "start",
+        endFieldKey: "end",
+        labelFieldKey: "name",
+        milestoneFieldKey: "isMilestone",
+      },
+    });
+
+    const result = calculateTimelineConflicts(graph.tasks, graph.links);
+
+    expect(result.dependencyIds).toEqual(["dep-positive"]);
+    expect(result.recordIds).toEqual(["A", "B"]);
+  });
+
+  it("支持零 lagDays：同日衔接不冲突", () => {
+    const graph = buildTimelineGraph({
+      records: [
+        createRecord("A", { start: "2026-01-01", end: "2026-01-05", name: "A" }),
+        createRecord("B", { start: "2026-01-05", end: "2026-01-08", name: "B" }),
+      ],
+      fields,
+      dependencies: [
+        {
+          id: "dep-zero",
+          predecessorRecordId: "A",
+          successorRecordId: "B",
+          type: "FS",
+          lagDays: 0,
+          required: true,
+        },
+      ],
+      config: {
+        startFieldKey: "start",
+        endFieldKey: "end",
+        labelFieldKey: "name",
+      },
+    });
+
+    const result = calculateTimelineConflicts(graph.tasks, graph.links);
+
+    expect(result.dependencyIds).toEqual([]);
+    expect(result.recordIds).toEqual([]);
+  });
+
+  it("支持负 lagDays 冲突判定", () => {
+    const graph = buildTimelineGraph({
+      records: [
+        createRecord("A", { start: "2026-01-01", end: "2026-01-10", name: "A" }),
+        createRecord("B", { start: "2026-01-07", end: "2026-01-12", name: "B" }),
+      ],
+      fields,
+      dependencies: [
+        {
+          id: "dep-negative",
+          predecessorRecordId: "A",
+          successorRecordId: "B",
+          type: "FS",
+          lagDays: -2,
+          required: true,
+        },
+      ],
+      config: {
+        startFieldKey: "start",
+        endFieldKey: "end",
+        labelFieldKey: "name",
+      },
+    });
+
+    const result = calculateTimelineConflicts(graph.tasks, graph.links);
+
+    expect(result.dependencyIds).toEqual(["dep-negative"]);
+    expect(result.recordIds).toEqual(["A", "B"]);
+  });
+
+  it("required=false 时不计冲突", () => {
+    const graph = buildTimelineGraph({
+      records: [
+        createRecord("A", { start: "2026-01-01", end: "2026-01-05", name: "A" }),
+        createRecord("B", { start: "2026-01-02", end: "2026-01-06", name: "B" }),
+      ],
+      fields,
+      dependencies: [
+        {
+          id: "dep-optional",
+          predecessorRecordId: "A",
+          successorRecordId: "B",
+          type: "FS",
+          lagDays: 3,
+          required: false,
+        },
+      ],
+      config: {
+        startFieldKey: "start",
+        endFieldKey: "end",
+        labelFieldKey: "name",
+      },
+    });
+
+    const result = calculateTimelineConflicts(graph.tasks, graph.links);
+
+    expect(result.dependencyIds).toEqual([]);
+    expect(result.recordIds).toEqual([]);
+  });
+
+  it("缺失开始日期记录会被 adapter 过滤，相关依赖不会参与冲突", () => {
+    const graph = buildTimelineGraph({
+      records: [
+        createRecord("A", { start: "2026-01-01", end: "2026-01-03", name: "A" }),
+        createRecord("B", { end: "2026-01-08", name: "B" }),
+      ],
+      fields,
+      dependencies: [
+        {
+          id: "dep-missing-date",
+          predecessorRecordId: "A",
+          successorRecordId: "B",
+          type: "FS",
+          lagDays: 0,
+          required: true,
+        },
+      ],
+      config: {
+        startFieldKey: "start",
+        endFieldKey: "end",
+        labelFieldKey: "name",
+      },
+    });
+
+    expect(graph.tasks.map((task) => task.recordId)).toEqual(["A"]);
+    expect(graph.links).toHaveLength(0);
+
+    const result = calculateTimelineConflicts(graph.tasks, graph.links);
+    expect(result.dependencyIds).toEqual([]);
+    expect(result.recordIds).toEqual([]);
+  });
+});

--- a/src/components/data/views/timeline/timeline-conflicts.ts
+++ b/src/components/data/views/timeline/timeline-conflicts.ts
@@ -1,0 +1,51 @@
+import type { TimelineLink, TimelineTask } from "./timeline-adapter";
+
+export interface TimelineConflictResult {
+  dependencyIds: string[];
+  recordIds: string[];
+}
+
+function normalizeToStartOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function addDays(date: Date, days: number): Date {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+}
+
+export function calculateTimelineConflicts(
+  tasks: TimelineTask[],
+  links: TimelineLink[]
+): TimelineConflictResult {
+  const taskById = new Map(tasks.map((task) => [task.id, task]));
+  const conflictedDependencyIds = new Set<string>();
+  const conflictedRecordIds = new Set<string>();
+
+  for (const link of links) {
+    if (!link.required || link.type !== "FS") {
+      continue;
+    }
+
+    const predecessor = taskById.get(link.predecessorTaskId);
+    const successor = taskById.get(link.successorTaskId);
+    if (!predecessor || !successor) {
+      continue;
+    }
+
+    const requiredStart = addDays(normalizeToStartOfDay(predecessor.endDate), link.lagDays);
+    const actualStart = normalizeToStartOfDay(successor.startDate);
+
+    if (actualStart < requiredStart) {
+      conflictedDependencyIds.add(link.dependencyId);
+      conflictedRecordIds.add(predecessor.recordId);
+      conflictedRecordIds.add(successor.recordId);
+    }
+  }
+
+  return {
+    dependencyIds: [...conflictedDependencyIds].sort(),
+    recordIds: [...conflictedRecordIds].sort(),
+  };
+}

--- a/src/components/data/views/timeline/timeline-gantt-frappe.tsx
+++ b/src/components/data/views/timeline/timeline-gantt-frappe.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { TimelineScale } from "./timeline-options";
+
+type FrappeGanttTask = {
+  id: string;
+  name: string;
+  start: string;
+  end: string;
+  progress?: number;
+  dependencies?: string;
+  custom_class?: string;
+};
+
+type FrappeGanttApiTask = {
+  id: string;
+  _start: Date;
+  _end: Date;
+};
+
+type FrappeGanttLink = {
+  id: string;
+  successorTaskId: string;
+  predecessorTaskId: string;
+  required: boolean;
+  conflict: boolean;
+};
+
+interface TimelineGanttFrappeProps {
+  tasks: FrappeGanttTask[];
+  links: FrappeGanttLink[];
+  scale: TimelineScale;
+  onOpenRecord: (recordId: string) => void;
+  onTaskDateChange?: (taskId: string, startDate: Date, endDate: Date) => Promise<void> | void;
+}
+
+type GanttCtor = new (
+  container: HTMLElement,
+  tasks: FrappeGanttTask[],
+  options: {
+    view_mode?: "Week" | "Month";
+    on_click?: (task: FrappeGanttApiTask) => void;
+    on_date_change?: (task: FrappeGanttApiTask, start: Date, end: Date) => void;
+  }
+) => { change_view_mode?: (mode: "Week" | "Month") => void };
+
+const VIEW_MODE_BY_SCALE: Record<TimelineScale, "Week" | "Month"> = {
+  week: "Week",
+  month: "Month",
+  quarter: "Month",
+};
+
+const PAN_STEP_BY_SCALE: Record<TimelineScale, number> = {
+  week: 280,
+  month: 420,
+  quarter: 720,
+};
+
+function applyLinkStyles(container: HTMLElement, links: FrappeGanttLink[]) {
+  const linkGroups = container.querySelectorAll<SVGGElement>(".gantt .arrow");
+  linkGroups.forEach((group, index) => {
+    const link = links[index];
+    if (!link) return;
+    const path = group.querySelector<SVGPathElement>("path");
+    if (!path) return;
+    path.style.stroke = link.conflict ? "#dc2626" : "#64748b";
+    path.style.strokeWidth = link.conflict ? "2.5" : "1.5";
+    path.style.strokeDasharray = link.required ? "none" : "4 3";
+  });
+}
+
+export function TimelineGanttFrappe({
+  tasks,
+  links,
+  scale,
+  onOpenRecord,
+  onTaskDateChange,
+}: TimelineGanttFrappeProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [isPanning, setIsPanning] = useState(false);
+  const panStateRef = useRef<{ startX: number; startScrollLeft: number } | null>(null);
+
+  const preparedTasks = useMemo<FrappeGanttTask[]>(() => {
+    const depByTask = new Map<string, string[]>();
+    for (const link of links) {
+      const deps = depByTask.get(link.successorTaskId) ?? [];
+      deps.push(link.predecessorTaskId);
+      depByTask.set(link.successorTaskId, deps);
+    }
+
+    return tasks.map((task) => ({
+      ...task,
+      dependencies: depByTask.get(task.id)?.join(","),
+    }));
+  }, [links, tasks]);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    let disposed = false;
+    containerRef.current.innerHTML = "";
+
+    const render = async () => {
+      const mod = await import("frappe-gantt");
+      if (disposed || !containerRef.current) return;
+      const Gantt = (mod.default ?? mod) as GanttCtor;
+      new Gantt(containerRef.current, preparedTasks, {
+        view_mode: VIEW_MODE_BY_SCALE[scale],
+        on_click: (task) => onOpenRecord(task.id),
+        on_date_change: (task, start, end) => {
+          void onTaskDateChange?.(task.id, start, end);
+        },
+      });
+      if (containerRef.current) {
+        applyLinkStyles(containerRef.current, links);
+      }
+    };
+
+    void render();
+
+    return () => {
+      disposed = true;
+    };
+  }, [links, onOpenRecord, onTaskDateChange, preparedTasks, scale]);
+
+  if (preparedTasks.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+        暂无可显示的时间线任务
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border bg-background">
+      <div className="flex items-center justify-end gap-1 border-b p-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            if (scrollRef.current) {
+              scrollRef.current.scrollLeft -= PAN_STEP_BY_SCALE[scale];
+            }
+          }}
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            if (scrollRef.current) {
+              scrollRef.current.scrollLeft += PAN_STEP_BY_SCALE[scale];
+            }
+          }}
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+      <div
+        ref={scrollRef}
+        className="overflow-x-auto cursor-grab active:cursor-grabbing"
+        onMouseDown={(event) => {
+          if (!scrollRef.current) return;
+          setIsPanning(true);
+          panStateRef.current = {
+            startX: event.clientX,
+            startScrollLeft: scrollRef.current.scrollLeft,
+          };
+        }}
+        onMouseMove={(event) => {
+          if (!isPanning || !scrollRef.current || !panStateRef.current) return;
+          const delta = event.clientX - panStateRef.current.startX;
+          scrollRef.current.scrollLeft = panStateRef.current.startScrollLeft - delta;
+        }}
+        onMouseUp={() => {
+          setIsPanning(false);
+          panStateRef.current = null;
+        }}
+        onMouseLeave={() => {
+          setIsPanning(false);
+          panStateRef.current = null;
+        }}
+      >
+        <div ref={containerRef} className="min-w-[960px] p-2" />
+      </div>
+      <style jsx global>{`
+        .timeline-task-conflict .bar {
+          fill: #fecaca !important;
+          stroke: #dc2626 !important;
+          stroke-width: 1.5px !important;
+        }
+        .timeline-task-milestone .bar {
+          rx: 2px !important;
+          ry: 2px !important;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/components/data/views/timeline/timeline-gantt-frappe.tsx
+++ b/src/components/data/views/timeline/timeline-gantt-frappe.tsx
@@ -61,8 +61,14 @@ const PAN_STEP_BY_SCALE: Record<TimelineScale, number> = {
 
 function applyLinkStyles(container: HTMLElement, links: FrappeGanttLink[]) {
   const linkGroups = container.querySelectorAll<SVGGElement>(".gantt .arrow");
+  const linkByEdge = new Map(
+    links.map((link) => [`${link.predecessorTaskId}->${link.successorTaskId}`, link])
+  );
+
   linkGroups.forEach((group, index) => {
-    const link = links[index];
+    const from = group.getAttribute("data-from");
+    const to = group.getAttribute("data-to");
+    const link = (from && to ? linkByEdge.get(`${from}->${to}`) : undefined) ?? links[index];
     if (!link) return;
     const path = group.querySelector<SVGPathElement>("path");
     if (!path) return;

--- a/src/components/data/views/timeline/timeline-gantt.tsx
+++ b/src/components/data/views/timeline/timeline-gantt.tsx
@@ -18,9 +18,9 @@ interface TimelineGanttProps {
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const COLUMN_WIDTH_BY_SCALE: Record<TimelineScale, number> = {
-  day: 32,
   week: 18,
   month: 8,
+  quarter: 4,
 };
 
 function getTimelineRange(items: TimelineBarItem[]): { min: Date; max: Date } {

--- a/src/components/data/views/timeline/timeline-options.tsx
+++ b/src/components/data/views/timeline/timeline-options.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 
-export type TimelineScale = "day" | "week" | "month";
+export type TimelineScale = "week" | "month" | "quarter";
 
 interface TimelineOptionsProps {
   scale: TimelineScale;
@@ -10,9 +10,9 @@ interface TimelineOptionsProps {
 }
 
 const OPTIONS: Array<{ value: TimelineScale; label: string }> = [
-  { value: "day", label: "日" },
   { value: "week", label: "周" },
   { value: "month", label: "月" },
+  { value: "quarter", label: "季度" },
 ];
 
 export function TimelineOptions({ scale, onScaleChange }: TimelineOptionsProps) {

--- a/src/components/data/views/timeline/timeline-view.tsx
+++ b/src/components/data/views/timeline/timeline-view.tsx
@@ -1,19 +1,32 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Settings2 } from "lucide-react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import type { DataFieldItem, DataRecordItem, DataViewItem } from "@/types/data-table";
+import type {
+  DataFieldItem,
+  DataRecordItem,
+  DataViewItem,
+  TaskDependencyItem,
+} from "@/types/data-table";
 import { FieldType } from "@/generated/prisma/enums";
-import { TimelineGantt } from "./timeline-gantt";
 import { TimelineOptions, type TimelineScale } from "./timeline-options";
 import { TimelineConfig } from "./timeline-config";
+import {
+  buildTimelineGraph,
+  type TimelineTask,
+} from "./timeline-adapter";
+import { calculateTimelineConflicts } from "./timeline-conflicts";
+import { TimelineGanttFrappe } from "./timeline-gantt-frappe";
 
 interface TimelineViewProps {
+  tableId: string;
   fields: DataFieldItem[];
   records: DataRecordItem[];
   view: DataViewItem;
   onOpenRecord: (recordId: string) => void;
+  onPatchRecord: (recordId: string, fieldKey: string, value: unknown) => Promise<void>;
   onViewOptionsChange?: (options: Record<string, unknown>) => void;
 }
 
@@ -21,30 +34,87 @@ function asFieldKey(raw: unknown): string | null {
   return typeof raw === "string" && raw.length > 0 ? raw : null;
 }
 
-function toDateValue(raw: unknown): Date | null {
-  if (typeof raw !== "string" || raw.length === 0) return null;
-  const date = new Date(raw);
-  return Number.isNaN(date.getTime()) ? null : date;
+function formatDateOnly(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function asScale(raw: unknown): TimelineScale {
+  if (raw === "week" || raw === "month" || raw === "quarter") {
+    return raw;
+  }
+  return "week";
 }
 
 export function TimelineView({
+  tableId,
   fields,
   records,
   view,
   onOpenRecord,
+  onPatchRecord,
   onViewOptionsChange,
 }: TimelineViewProps) {
-  const [scale, setScale] = useState<TimelineScale>("week");
+  const [scale, setScale] = useState<TimelineScale>(
+    asScale(view.viewOptions.timelineScale)
+  );
   const [showConfig, setShowConfig] = useState(false);
+  const [dependencies, setDependencies] = useState<TaskDependencyItem[]>([]);
+  const [isDependencyLoading, setIsDependencyLoading] = useState(false);
+
   const startDateField = asFieldKey(view.viewOptions.startDateField);
   const endDateField = asFieldKey(view.viewOptions.endDateField);
   const labelField = asFieldKey(view.viewOptions.labelField);
+  const milestoneFieldKey = asFieldKey(view.viewOptions.milestoneFieldKey);
+  const dependencyEnabled = view.viewOptions.dependencyEnabled !== false;
 
   const hasValidStartField = fields.some(
     (field) => field.key === startDateField && field.type === FieldType.DATE
   );
   const hasValidLabelField = fields.some((field) => field.key === labelField);
   const isConfigured = hasValidStartField && hasValidLabelField;
+
+  useEffect(() => {
+    setScale(asScale(view.viewOptions.timelineScale));
+  }, [view.viewOptions.timelineScale]);
+
+  useEffect(() => {
+    if (!dependencyEnabled) {
+      setDependencies([]);
+      return;
+    }
+
+    let cancelled = false;
+    setIsDependencyLoading(true);
+
+    fetch(`/api/data-tables/${tableId}/dependencies`)
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const data = await response.json();
+        if (!cancelled) {
+          setDependencies(Array.isArray(data) ? (data as TaskDependencyItem[]) : []);
+        }
+      })
+      .catch((error) => {
+        console.error("Failed to load task dependencies:", error);
+        if (!cancelled) {
+          setDependencies([]);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsDependencyLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [dependencyEnabled, tableId]);
 
   const handleConfigChange = useCallback(
     (key: string, value: string | null) => {
@@ -57,33 +127,130 @@ export function TimelineView({
     [onViewOptionsChange, view.viewOptions]
   );
 
-  const items = useMemo(() => {
+  const handleToggleConfigChange = useCallback(
+    (key: string, value: boolean) => {
+      if (!onViewOptionsChange) return;
+      onViewOptionsChange({
+        ...view.viewOptions,
+        [key]: value,
+      });
+    },
+    [onViewOptionsChange, view.viewOptions]
+  );
+
+  const handleScaleChange = useCallback(
+    (nextScale: TimelineScale) => {
+      setScale(nextScale);
+      if (!onViewOptionsChange) return;
+      onViewOptionsChange({
+        ...view.viewOptions,
+        timelineScale: nextScale,
+      });
+    },
+    [onViewOptionsChange, view.viewOptions]
+  );
+
+  const graph = useMemo(() => {
     if (!isConfigured || !startDateField || !labelField) {
-      return [];
+      return { tasks: [] as TimelineTask[], links: [] as ReturnType<typeof buildTimelineGraph>["links"] };
     }
 
-    return records
-      .map((record) => {
-        const startDate = toDateValue(record.data[startDateField]);
-        if (!startDate) return null;
+    return buildTimelineGraph({
+      records,
+      fields,
+      dependencies: dependencyEnabled ? dependencies : [],
+      config: {
+        startFieldKey: startDateField,
+        endFieldKey: endDateField,
+        labelFieldKey: labelField,
+        milestoneFieldKey,
+      },
+    });
+  }, [
+    dependencies,
+    dependencyEnabled,
+    endDateField,
+    fields,
+    isConfigured,
+    labelField,
+    milestoneFieldKey,
+    records,
+    startDateField,
+  ]);
 
-        const endValue = endDateField ? toDateValue(record.data[endDateField]) : null;
-        const resolvedEndDate = endValue ?? startDate;
+  const taskById = useMemo(
+    () => new Map(graph.tasks.map((task) => [task.id, task])),
+    [graph.tasks]
+  );
 
+  const conflict = useMemo(
+    () => calculateTimelineConflicts(graph.tasks, graph.links),
+    [graph.links, graph.tasks]
+  );
+
+  const conflictDepIdSet = useMemo(
+    () => new Set(conflict.dependencyIds),
+    [conflict.dependencyIds]
+  );
+
+  const conflictTaskIdSet = useMemo(
+    () => new Set(conflict.recordIds),
+    [conflict.recordIds]
+  );
+
+  const frappeTasks = useMemo(
+    () =>
+      graph.tasks.map((task) => {
+        const baseClass = task.isMilestone ? "timeline-task-milestone" : "timeline-task";
+        const conflictClass = conflictTaskIdSet.has(task.recordId) ? " timeline-task-conflict" : "";
         return {
-          record,
-          label: String(record.data[labelField] ?? record.id),
-          startDate,
-          endDate: resolvedEndDate,
+          id: task.id,
+          name: task.label,
+          start: formatDateOnly(task.startDate),
+          end: formatDateOnly(task.isMilestone ? task.startDate : task.endDate),
+          progress: 0,
+          custom_class: `${baseClass}${conflictClass}`,
         };
-      })
-      .filter((item): item is NonNullable<typeof item> => item !== null)
-      .sort((left, right) => left.startDate.getTime() - right.startDate.getTime());
-  }, [endDateField, isConfigured, labelField, records, startDateField]);
+      }),
+    [conflictTaskIdSet, graph.tasks]
+  );
+
+  const frappeLinks = useMemo(
+    () =>
+      graph.links.map((link) => ({
+        id: link.id,
+        successorTaskId: link.successorTaskId,
+        predecessorTaskId: link.predecessorTaskId,
+        required: link.required,
+        conflict: conflictDepIdSet.has(link.dependencyId),
+      })),
+    [conflictDepIdSet, graph.links]
+  );
+
+  const handleTaskDateChange = useCallback(
+    async (taskId: string, startDate: Date, endDate: Date) => {
+      if (!startDateField) return;
+      const task = taskById.get(taskId);
+      if (!task) return;
+
+      const nextStart = formatDateOnly(startDate);
+      const nextEnd = formatDateOnly(task.isMilestone ? startDate : endDate);
+
+      try {
+        await onPatchRecord(task.recordId, startDateField, nextStart);
+        if (endDateField) {
+          await onPatchRecord(task.recordId, endDateField, nextEnd);
+        }
+      } catch (error) {
+        console.error("Failed to patch timeline task date:", error);
+        toast.error("保存任务日期失败，请重试");
+      }
+    },
+    [endDateField, onPatchRecord, startDateField, taskById]
+  );
 
   return (
     <div className="space-y-3">
-      {/* Toolbar: config toggle + scale selector */}
       <div className="flex items-center justify-between">
         <Button
           variant={showConfig ? "secondary" : "ghost"}
@@ -93,10 +260,9 @@ export function TimelineView({
           <Settings2 className="h-4 w-4 mr-1" />
           配置
         </Button>
-        <TimelineOptions scale={scale} onScaleChange={setScale} />
+        <TimelineOptions scale={scale} onScaleChange={handleScaleChange} />
       </div>
 
-      {/* Config panel */}
       {showConfig && (
         <div className="rounded-md border p-3">
           <TimelineConfig
@@ -104,14 +270,31 @@ export function TimelineView({
             startDateField={startDateField}
             endDateField={endDateField}
             labelField={labelField}
+            milestoneFieldKey={milestoneFieldKey}
+            dependencyEnabled={dependencyEnabled}
             onChange={handleConfigChange}
+            onToggleChange={handleToggleConfigChange}
           />
         </div>
       )}
 
-      {/* Content */}
       {isConfigured ? (
-        <TimelineGantt items={items} scale={scale} onOpenRecord={onOpenRecord} />
+        <div className="space-y-2">
+          <TimelineGanttFrappe
+            tasks={frappeTasks}
+            links={frappeLinks}
+            scale={scale}
+            onOpenRecord={onOpenRecord}
+            onTaskDateChange={handleTaskDateChange}
+          />
+          {(isDependencyLoading || conflict.dependencyIds.length > 0) && (
+            <p className="text-xs text-muted-foreground">
+              {isDependencyLoading
+                ? "正在加载依赖数据..."
+                : `检测到 ${conflict.dependencyIds.length} 条依赖冲突（已高亮显示）`}
+            </p>
+          )}
+        </div>
       ) : (
         <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
           <p className="mb-3">时间线视图需要配置开始日期字段（DATE 类型）和标题字段</p>

--- a/src/components/data/views/timeline/timeline-view.tsx
+++ b/src/components/data/views/timeline/timeline-view.tsx
@@ -235,14 +235,28 @@ export function TimelineView({
 
       const nextStart = formatDateOnly(startDate);
       const nextEnd = formatDateOnly(task.isMilestone ? startDate : endDate);
+      const previousStart = formatDateOnly(task.startDate);
+      const previousEnd = formatDateOnly(task.isMilestone ? task.startDate : task.endDate);
+      let startPatched = false;
 
       try {
         await onPatchRecord(task.recordId, startDateField, nextStart);
+        startPatched = true;
         if (endDateField) {
           await onPatchRecord(task.recordId, endDateField, nextEnd);
         }
       } catch (error) {
         console.error("Failed to patch timeline task date:", error);
+        if (startPatched) {
+          try {
+            await onPatchRecord(task.recordId, startDateField, previousStart);
+            if (endDateField) {
+              await onPatchRecord(task.recordId, endDateField, previousEnd);
+            }
+          } catch (rollbackError) {
+            console.error("Failed to rollback timeline task date:", rollbackError);
+          }
+        }
         toast.error("保存任务日期失败，请重试");
       }
     },

--- a/src/hooks/use-table-data.ts
+++ b/src/hooks/use-table-data.ts
@@ -64,6 +64,19 @@ export interface UseTableDataReturn {
   cursorPositions: Map<string, { userId: string; userName: string; recordId: string; fieldKey: string; color: string }>;
 }
 
+function resolveViewIdFromSearchParams(
+  params: { get: (key: string) => string | null }
+): string | null {
+  const direct = params.get("viewId");
+  if (direct) return direct;
+
+  // Fallback for environments where searchParams may lag behind URL updates.
+  if (typeof window !== "undefined") {
+    return new URLSearchParams(window.location.search).get("viewId");
+  }
+  return null;
+}
+
 function buildTablePath(tableId: string, params: URLSearchParams): string {
   const query = params.toString();
   return query ? `/data/${tableId}?${query}` : `/data/${tableId}`;
@@ -93,7 +106,7 @@ export function useTableData({
     searchParams.get("search") ?? ""
   );
   const [viewId, setViewId] = useState<string | null>(
-    searchParams.get("viewId") ?? null
+    resolveViewIdFromSearchParams(searchParams)
   );
   const [views, setViews] = useState<DataViewItem[]>([]);
   const [isViewConfigReady, setIsViewConfigReady] = useState(
@@ -298,7 +311,7 @@ export function useTableData({
   }, []);
 
   useEffect(() => {
-    const nextViewId = searchParams.get("viewId") ?? null;
+    const nextViewId = resolveViewIdFromSearchParams(searchParams);
     const isViewChanged = nextViewId !== viewId;
 
     setSearch(searchParams.get("search") ?? "");

--- a/src/lib/services/task-dependency.service.test.ts
+++ b/src/lib/services/task-dependency.service.test.ts
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  deleteTaskDependency,
+  listTaskDependencies,
+  upsertTaskDependency,
+} from "./task-dependency.service";
+
+type MockDataRecord = {
+  id: string;
+  tableId: string;
+};
+
+type MockTaskDependency = {
+  id: string;
+  tableId: string;
+  successorRecordId: string;
+  predecessorRecordId: string;
+  type: "FS";
+  lagDays: number;
+  required: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+const store = vi.hoisted(() => ({
+  records: [] as MockDataRecord[],
+  dependencies: [] as MockTaskDependency[],
+  seq: 1,
+}));
+
+const dbMock = vi.hoisted(() => ({
+  dataRecord: {
+    findMany: vi.fn(async ({ where }: { where: { id: { in: string[] } } }) => {
+      const ids = new Set(where.id.in);
+      return store.records.filter((record) => ids.has(record.id));
+    }),
+  },
+  taskDependency: {
+    findMany: vi.fn(async ({ where }: { where: { tableId: string } }) =>
+      store.dependencies
+        .filter((item) => item.tableId === where.tableId)
+        .sort((left, right) => left.createdAt.getTime() - right.createdAt.getTime())
+    ),
+    upsert: vi.fn(async ({
+      where,
+      update,
+      create,
+    }: {
+      where: {
+        successorRecordId_predecessorRecordId_type: {
+          successorRecordId: string;
+          predecessorRecordId: string;
+          type: "FS";
+        };
+      };
+      update: {
+        tableId: string;
+        lagDays: number;
+        required: boolean;
+      };
+      create: {
+        tableId: string;
+        successorRecordId: string;
+        predecessorRecordId: string;
+        type: "FS";
+        lagDays: number;
+        required: boolean;
+      };
+    }) => {
+      const composite = where.successorRecordId_predecessorRecordId_type;
+      const existing = store.dependencies.find((item) => (
+        item.successorRecordId === composite.successorRecordId &&
+        item.predecessorRecordId === composite.predecessorRecordId &&
+        item.type === composite.type
+      ));
+
+      if (existing) {
+        existing.tableId = update.tableId;
+        existing.lagDays = update.lagDays;
+        existing.required = update.required;
+        existing.updatedAt = new Date("2026-04-19T00:00:00.000Z");
+        return { ...existing };
+      }
+
+      const row: MockTaskDependency = {
+        id: `dep-${store.seq++}`,
+        ...create,
+        createdAt: new Date("2026-04-18T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-18T00:00:00.000Z"),
+      };
+      store.dependencies.push(row);
+      return { ...row };
+    }),
+    deleteMany: vi.fn(async ({ where }: { where: { id: string; tableId: string } }) => {
+      const before = store.dependencies.length;
+      store.dependencies = store.dependencies.filter((item) => (
+        !(item.id === where.id && item.tableId === where.tableId)
+      ));
+      return { count: before - store.dependencies.length };
+    }),
+  },
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: dbMock,
+}));
+
+describe("task-dependency.service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store.records = [
+      { id: "record-1", tableId: "table-1" },
+      { id: "record-2", tableId: "table-1" },
+      { id: "record-3", tableId: "table-2" },
+    ];
+    store.dependencies = [];
+    store.seq = 1;
+  });
+
+  it("listTaskDependencies returns dependencies by table", async () => {
+    store.dependencies.push(
+      {
+        id: "dep-1",
+        tableId: "table-1",
+        successorRecordId: "record-1",
+        predecessorRecordId: "record-2",
+        type: "FS",
+        lagDays: 0,
+        required: true,
+        createdAt: new Date("2026-04-18T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-18T00:00:00.000Z"),
+      },
+      {
+        id: "dep-2",
+        tableId: "table-2",
+        successorRecordId: "record-3",
+        predecessorRecordId: "record-1",
+        type: "FS",
+        lagDays: 1,
+        required: false,
+        createdAt: new Date("2026-04-18T00:01:00.000Z"),
+        updatedAt: new Date("2026-04-18T00:01:00.000Z"),
+      }
+    );
+
+    const result = await listTaskDependencies("table-1");
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({
+        id: "dep-1",
+        tableId: "table-1",
+        type: "FS",
+      });
+    }
+  });
+
+  it("upsertTaskDependency creates dependency", async () => {
+    const result = await upsertTaskDependency({
+      tableId: "table-1",
+      successorRecordId: "record-1",
+      predecessorRecordId: "record-2",
+      type: "FS",
+      lagDays: 2,
+      required: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(store.dependencies).toHaveLength(1);
+    expect(store.dependencies[0]).toMatchObject({
+      successorRecordId: "record-1",
+      predecessorRecordId: "record-2",
+      lagDays: 2,
+      required: true,
+    });
+  });
+
+  it("upsertTaskDependency rejects self-loop", async () => {
+    const result = await upsertTaskDependency({
+      tableId: "table-1",
+      successorRecordId: "record-1",
+      predecessorRecordId: "record-1",
+      type: "FS",
+      lagDays: 0,
+      required: true,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe("SELF_LOOP");
+    }
+  });
+
+  it("upsertTaskDependency rejects cross-table dependency", async () => {
+    const result = await upsertTaskDependency({
+      tableId: "table-1",
+      successorRecordId: "record-1",
+      predecessorRecordId: "record-3",
+      type: "FS",
+      lagDays: 0,
+      required: true,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe("CROSS_TABLE_DEPENDENCY");
+    }
+  });
+
+  it("upsertTaskDependency handles duplicate by updating existing row", async () => {
+    const first = await upsertTaskDependency({
+      tableId: "table-1",
+      successorRecordId: "record-1",
+      predecessorRecordId: "record-2",
+      type: "FS",
+      lagDays: 0,
+      required: true,
+    });
+
+    expect(first.success).toBe(true);
+
+    const second = await upsertTaskDependency({
+      tableId: "table-1",
+      successorRecordId: "record-1",
+      predecessorRecordId: "record-2",
+      type: "FS",
+      lagDays: 5,
+      required: false,
+    });
+
+    expect(second.success).toBe(true);
+    expect(store.dependencies).toHaveLength(1);
+    expect(store.dependencies[0]).toMatchObject({
+      lagDays: 5,
+      required: false,
+    });
+  });
+
+  it("deleteTaskDependency removes dependency", async () => {
+    store.dependencies.push({
+      id: "dep-1",
+      tableId: "table-1",
+      successorRecordId: "record-1",
+      predecessorRecordId: "record-2",
+      type: "FS",
+      lagDays: 0,
+      required: true,
+      createdAt: new Date("2026-04-18T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-18T00:00:00.000Z"),
+    });
+
+    const result = await deleteTaskDependency("table-1", "dep-1");
+
+    expect(result.success).toBe(true);
+    expect(store.dependencies).toHaveLength(0);
+  });
+});

--- a/src/lib/services/task-dependency.service.ts
+++ b/src/lib/services/task-dependency.service.ts
@@ -76,9 +76,8 @@ export async function listTaskDependencies(
     });
 
     return { success: true, data: rows.map(mapTaskDependencyItem) };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "获取依赖失败";
-    return { success: false, error: { code: "LIST_FAILED", message } };
+  } catch {
+    return { success: false, error: { code: "LIST_FAILED", message: "获取依赖失败" } };
   }
 }
 
@@ -127,9 +126,8 @@ export async function upsertTaskDependency(input: {
     });
 
     return { success: true, data: mapTaskDependencyItem(row) };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "保存依赖失败";
-    return { success: false, error: { code: "UPSERT_FAILED", message } };
+  } catch {
+    return { success: false, error: { code: "UPSERT_FAILED", message: "保存依赖失败" } };
   }
 }
 
@@ -153,8 +151,7 @@ export async function deleteTaskDependency(
     }
 
     return { success: true, data: null };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "删除依赖失败";
-    return { success: false, error: { code: "DELETE_FAILED", message } };
+  } catch {
+    return { success: false, error: { code: "DELETE_FAILED", message: "删除依赖失败" } };
   }
 }

--- a/src/lib/services/task-dependency.service.ts
+++ b/src/lib/services/task-dependency.service.ts
@@ -1,0 +1,160 @@
+import { db } from "@/lib/db";
+import type { ServiceResult, TaskDependencyItem, TaskDependencyType } from "@/types/data-table";
+
+function mapTaskDependencyItem(row: {
+  id: string;
+  tableId: string;
+  successorRecordId: string;
+  predecessorRecordId: string;
+  type: TaskDependencyType;
+  lagDays: number;
+  required: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}): TaskDependencyItem {
+  return {
+    id: row.id,
+    tableId: row.tableId,
+    successorRecordId: row.successorRecordId,
+    predecessorRecordId: row.predecessorRecordId,
+    type: row.type,
+    lagDays: row.lagDays,
+    required: row.required,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+async function validateDependencyRecords(params: {
+  tableId: string;
+  successorRecordId: string;
+  predecessorRecordId: string;
+}): Promise<ServiceResult<null>> {
+  const { tableId, successorRecordId, predecessorRecordId } = params;
+
+  if (successorRecordId === predecessorRecordId) {
+    return {
+      success: false,
+      error: { code: "SELF_LOOP", message: "不允许自循环依赖" },
+    };
+  }
+
+  const records = await db.dataRecord.findMany({
+    where: {
+      id: { in: [successorRecordId, predecessorRecordId] },
+    },
+    select: {
+      id: true,
+      tableId: true,
+    },
+  });
+
+  if (records.length !== 2) {
+    return {
+      success: false,
+      error: { code: "RECORD_NOT_FOUND", message: "依赖记录不存在" },
+    };
+  }
+
+  if (records.some((record) => record.tableId !== tableId)) {
+    return {
+      success: false,
+      error: { code: "CROSS_TABLE_DEPENDENCY", message: "不允许跨表依赖" },
+    };
+  }
+
+  return { success: true, data: null };
+}
+
+export async function listTaskDependencies(
+  tableId: string
+): Promise<ServiceResult<TaskDependencyItem[]>> {
+  try {
+    const rows = await db.taskDependency.findMany({
+      where: { tableId },
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    });
+
+    return { success: true, data: rows.map(mapTaskDependencyItem) };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "获取依赖失败";
+    return { success: false, error: { code: "LIST_FAILED", message } };
+  }
+}
+
+export async function upsertTaskDependency(input: {
+  tableId: string;
+  successorRecordId: string;
+  predecessorRecordId: string;
+  type: TaskDependencyType;
+  lagDays: number;
+  required: boolean;
+}): Promise<ServiceResult<TaskDependencyItem>> {
+  try {
+    if (input.type !== "FS") {
+      return {
+        success: false,
+        error: { code: "INVALID_TYPE", message: "当前仅支持 FS 依赖" },
+      };
+    }
+
+    const validation = await validateDependencyRecords(input);
+    if (!validation.success) {
+      return validation;
+    }
+
+    const row = await db.taskDependency.upsert({
+      where: {
+        successorRecordId_predecessorRecordId_type: {
+          successorRecordId: input.successorRecordId,
+          predecessorRecordId: input.predecessorRecordId,
+          type: input.type,
+        },
+      },
+      update: {
+        tableId: input.tableId,
+        lagDays: input.lagDays,
+        required: input.required,
+      },
+      create: {
+        tableId: input.tableId,
+        successorRecordId: input.successorRecordId,
+        predecessorRecordId: input.predecessorRecordId,
+        type: input.type,
+        lagDays: input.lagDays,
+        required: input.required,
+      },
+    });
+
+    return { success: true, data: mapTaskDependencyItem(row) };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "保存依赖失败";
+    return { success: false, error: { code: "UPSERT_FAILED", message } };
+  }
+}
+
+export async function deleteTaskDependency(
+  tableId: string,
+  depId: string
+): Promise<ServiceResult<null>> {
+  try {
+    const result = await db.taskDependency.deleteMany({
+      where: {
+        id: depId,
+        tableId,
+      },
+    });
+
+    if (result.count === 0) {
+      return {
+        success: false,
+        error: { code: "NOT_FOUND", message: "依赖不存在" },
+      };
+    }
+
+    return { success: true, data: null };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "删除依赖失败";
+    return { success: false, error: { code: "DELETE_FAILED", message } };
+  }
+}

--- a/src/types/data-table.ts
+++ b/src/types/data-table.ts
@@ -143,6 +143,20 @@ export interface DataTableDetail extends DataTableListItem {
   businessKeys?: string[];
 }
 
+export type TaskDependencyType = "FS";
+
+export interface TaskDependencyItem {
+  id: string;
+  tableId: string;
+  successorRecordId: string;
+  predecessorRecordId: string;
+  type: TaskDependencyType;
+  lagDays: number;
+  required: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
 // ========== Record Types ==========
 
 export interface DataRecordItem{

--- a/src/types/data-table.ts
+++ b/src/types/data-table.ts
@@ -153,8 +153,8 @@ export interface TaskDependencyItem {
   type: TaskDependencyType;
   lagDays: number;
   required: boolean;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAt: Date | string;
+  updatedAt: Date | string;
 }
 
 // ========== Record Types ==========

--- a/src/validators/data-table.ts
+++ b/src/validators/data-table.ts
@@ -124,6 +124,18 @@ export const updateFieldsSchema = z.object({
   businessKeys: z.array(z.string()).max(5).optional(),
 });
 
+// ========== Task Dependency Schemas ==========
+
+export const dependencyTypeSchema = z.enum(["FS"]);
+
+export const taskDependencyInputSchema = z.object({
+  successorRecordId: z.string().min(1, "successorRecordId 不能为空"),
+  predecessorRecordId: z.string().min(1, "predecessorRecordId 不能为空"),
+  type: dependencyTypeSchema.default("FS"),
+  lagDays: z.number().int().default(0),
+  required: z.boolean().default(true),
+});
+
 // ========== Record Schemas ==========
 
 export const recordQuerySchema = z.object({
@@ -192,6 +204,7 @@ export const reorderSchema = z.object({
 export type CreateTableInput = z.infer<typeof createTableSchema>;
 export type UpdateTableInput = z.infer<typeof updateTableSchema>;
 export type UpdateFieldsInput = z.infer<typeof updateFieldsSchema>;
+export type TaskDependencyInput = z.infer<typeof taskDependencyInputSchema>;
 export type DataFieldInput = z.input<typeof dataFieldItemSchema>;
 export type RecordQueryInput = z.infer<typeof recordQuerySchema>;
 export type CreateRecordInput = z.infer<typeof createRecordSchema>;


### PR DESCRIPTION
## 目标
实现 Issue #119 的甘特图增强：依赖连线、拖拽调整日期、冲突高亮、里程碑、时间轴缩放与平移。

## 主要变更

### 1) 通用依赖数据层
- 新增 Prisma 模型 `TaskDependency`（`successorRecordId` / `predecessorRecordId` / `type` / `lagDays` / `required`）
- 新增依赖 API：
  - `GET /api/data-tables/:id/dependencies`
  - `PUT /api/data-tables/:id/dependencies`（支持单条与批量 upsert）
  - `DELETE /api/data-tables/:id/dependencies/:depId`
- 新增服务层：`list/upsert/delete`，包含 `self-loop` 与跨表校验
- 错误处理加固：服务端故障返回 500，移除底层异常细节透传
- 新增依赖输入校验 schema 与类型定义

### 2) Timeline 域层能力
- 新增 `timeline-adapter.ts`：将 records + dependencies 映射为甘特任务/连线
- 新增 `timeline-conflicts.ts`：`required + FS + lagDays` 冲突检测
- 新增对应单测
- 日期解析加固：`YYYY-MM-DD` 走本地日期解析，规避时区日偏移

### 3) UI 集成（frappe-gantt）
- 接入 `frappe-gantt` 新渲染组件 `timeline-gantt-frappe.tsx`
- `TimelineView` 接入依赖 API、冲突高亮、拖拽改期回写
- 拖拽回写一致性修复：开始日期成功、结束日期失败时自动回滚
- 配置面板新增：里程碑字段、依赖开关
- 缩放层级改为：`week/month/quarter`
- 支持平移：空白区拖拽 + 左右按钮步进
- `record-table` 为 Timeline 注入 `onPatchRecord`

## 验证
- `npx eslint src/components/data/views/timeline src/components/data/record-table.tsx src/app/api/data-tables/[id]/dependencies src/lib/services/task-dependency.service.ts src/lib/services/task-dependency.service.test.ts src/types/data-table.ts src/validators/data-table.ts`
- `npm run test:run -- src/lib/services/task-dependency.service.test.ts src/components/data/views/timeline/timeline-conflicts.test.ts`

结果：通过（11 tests passed）

## 备注
- 依赖冲突策略采用“宽松模式”：允许保存并高亮冲突。
- `quarter` 目前基于 Month 视图近似表达（步进与交互已分离）。