### PR TITLE
[Feature] 自动化动作：支持更新关联记录

### DIFF
--- a/src/components/automations/automation-config-panel.test.tsx
+++ b/src/components/automations/automation-config-panel.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AutomationConfigPanel } from "@/components/automations/automation-config-panel";
+
+describe("AutomationConfigPanel", () => {
+  it("renders update-related-records action fields", () => {
+    const onChange = vi.fn();
+
+    render(
+      <AutomationConfigPanel
+        selectedNodeId="action-1"
+        onChange={onChange}
+        value={{
+          version: 1,
+          canvas: {
+            nodes: [
+              { id: "trigger-1", type: "trigger", x: 0, y: 0 },
+              { id: "action-1", type: "action", x: 100, y: 0 },
+            ],
+            edges: [{ source: "trigger-1", target: "action-1" }],
+          },
+          trigger: { type: "record_created" },
+          condition: null,
+          thenActions: [
+            {
+              id: "action-1",
+              type: "update_related_records",
+              relationFieldKey: "authors",
+              targetScope: "all",
+              values: { reviewed: true },
+            },
+          ],
+          elseActions: [],
+        }}
+      />
+    );
+
+    expect(screen.getByText("关系字段 Key")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("authors")).toBeInTheDocument();
+    expect(screen.getByText("作用范围")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("all")).toBeInTheDocument();
+    expect(screen.getByText("更新值 JSON")).toBeInTheDocument();
+  });
+
+  it("allows switching action type to update-related-records", () => {
+    const onChange = vi.fn();
+
+    render(
+      <AutomationConfigPanel
+        selectedNodeId="action-1"
+        onChange={onChange}
+        value={{
+          version: 1,
+          canvas: {
+            nodes: [
+              { id: "trigger-1", type: "trigger", x: 0, y: 0 },
+              { id: "action-1", type: "action", x: 100, y: 0 },
+            ],
+            edges: [{ source: "trigger-1", target: "action-1" }],
+          },
+          trigger: { type: "record_created" },
+          condition: null,
+          thenActions: [
+            {
+              id: "action-1",
+              type: "add_comment",
+              target: "current_record",
+              content: "created",
+            },
+          ],
+          elseActions: [],
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "update_related_records" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thenActions: [
+          expect.objectContaining({
+            id: "action-1",
+            type: "update_related_records",
+            relationFieldKey: "relation",
+            targetScope: "all",
+            values: {},
+          }),
+        ],
+      })
+    );
+  });
+});

--- a/src/components/automations/automation-config-panel.tsx
+++ b/src/components/automations/automation-config-panel.tsx
@@ -10,6 +10,7 @@ import type {
   CallWebhookAction,
   CreateRecordAction,
   UpdateFieldAction,
+  UpdateRelatedRecordsAction,
   AddCommentAction,
 } from "@/types/automation";
 
@@ -293,6 +294,14 @@ export function AutomationConfigPanel({
                   ? { id: action.id, type: nextType, fieldKey: "status", value: "" }
                   : nextType === "create_record"
                     ? { id: action.id, type: nextType, tableId: value.canvas.nodes[0]?.id ?? "", values: {} }
+                    : nextType === "update_related_records"
+                      ? {
+                          id: action.id,
+                          type: nextType,
+                          relationFieldKey: "relation",
+                          targetScope: "all",
+                          values: {},
+                        }
                     : nextType === "call_webhook"
                       ? { id: action.id, type: nextType, url: "", method: "POST" }
                       : { id: action.id, type: nextType, target: "current_record", content: "" };
@@ -302,6 +311,7 @@ export function AutomationConfigPanel({
             <option value="add_comment">添加评论</option>
             <option value="update_field">更新字段</option>
             <option value="create_record">创建记录</option>
+            <option value="update_related_records">更新关联记录</option>
             <option value="call_webhook">调用 Webhook</option>
           </select>
         </div>
@@ -365,6 +375,62 @@ export function AutomationConfigPanel({
                     onChange(
                       updateAction(value, action.id, (current) => ({
                         ...(current as CreateRecordAction),
+                        values: nextValues,
+                      }))
+                    );
+                  } catch {
+                    // 保持最后一个合法值，避免 UI 状态与 DSL 失配
+                  }
+                }}
+              />
+            </div>
+          </>
+        )}
+
+        {action.type === "update_related_records" && (
+          <>
+            <div className="space-y-2">
+              <label className="text-sm font-[520] text-foreground">关系字段 Key</label>
+              <Input
+                value={(action as UpdateRelatedRecordsAction).relationFieldKey}
+                onChange={(event) =>
+                  onChange(
+                    updateAction(value, action.id, (current) => ({
+                      ...(current as UpdateRelatedRecordsAction),
+                      relationFieldKey: event.target.value,
+                    }))
+                  )
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-[520] text-foreground">作用范围</label>
+              <select
+                className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm text-foreground"
+                value={(action as UpdateRelatedRecordsAction).targetScope}
+                onChange={(event) =>
+                  onChange(
+                    updateAction(value, action.id, (current) => ({
+                      ...(current as UpdateRelatedRecordsAction),
+                      targetScope: event.target.value as "first" | "all",
+                    }))
+                  )
+                }
+              >
+                <option value="first">first</option>
+                <option value="all">all</option>
+              </select>
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-[520] text-foreground">更新值 JSON</label>
+              <Textarea
+                value={JSON.stringify((action as UpdateRelatedRecordsAction).values, null, 2)}
+                onChange={(event) => {
+                  try {
+                    const nextValues = JSON.parse(event.target.value) as Record<string, unknown>;
+                    onChange(
+                      updateAction(value, action.id, (current) => ({
+                        ...(current as UpdateRelatedRecordsAction),
                         values: nextValues,
                       }))
                     );

--- a/src/lib/services/automation-action-executors/index.ts
+++ b/src/lib/services/automation-action-executors/index.ts
@@ -3,6 +3,7 @@ import type { ServiceResult } from "@/types/data-table";
 import { executeAddCommentAction } from "@/lib/services/automation-action-executors/add-comment";
 import { executeCallWebhookAction } from "@/lib/services/automation-action-executors/call-webhook";
 import { executeCreateRecordAction } from "@/lib/services/automation-action-executors/create-record";
+import { executeUpdateRelatedRecordsAction } from "@/lib/services/automation-action-executors/update-related-records";
 import { executeUpdateFieldAction } from "@/lib/services/automation-action-executors/update-field";
 
 type AutomationActionExecutor = (
@@ -17,6 +18,8 @@ export function getAutomationActionExecutor(
       return executeUpdateFieldAction as AutomationActionExecutor;
     case "create_record":
       return executeCreateRecordAction as AutomationActionExecutor;
+    case "update_related_records":
+      return executeUpdateRelatedRecordsAction as AutomationActionExecutor;
     case "call_webhook":
       return executeCallWebhookAction as AutomationActionExecutor;
     case "add_comment":

--- a/src/lib/services/automation-action-executors/update-related-records.test.ts
+++ b/src/lib/services/automation-action-executors/update-related-records.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { executeUpdateRelatedRecordsAction } from "@/lib/services/automation-action-executors/update-related-records";
+
+const { getTableMock, updateRecordMock } = vi.hoisted(() => ({
+  getTableMock: vi.fn(),
+  updateRecordMock: vi.fn(),
+}));
+
+vi.mock("@/lib/services/data-table.service", () => ({
+  getTable: getTableMock,
+}));
+
+vi.mock("@/lib/services/data-record.service", () => ({
+  updateRecord: updateRecordMock,
+}));
+
+describe("executeUpdateRelatedRecordsAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fails when current record context is missing", async () => {
+    const result = await executeUpdateRelatedRecordsAction({
+      action: {
+        id: "a1",
+        type: "update_related_records",
+        relationFieldKey: "authors",
+        targetScope: "all",
+        values: { status: "active" },
+      },
+      context: {
+        automationId: "aut_1",
+        tableId: "tbl_1",
+        record: null,
+        previousRecord: null,
+        changedFields: [],
+        triggerSource: "MANUAL",
+        triggeredAt: "2026-04-22T00:00:00.000Z",
+        actor: { id: "usr_1" },
+      },
+      runId: "run_1",
+    });
+
+    expect(result.success).toBe(false);
+    expect(updateRecordMock).not.toHaveBeenCalled();
+  });
+
+  it("updates the first related record when targetScope is first", async () => {
+    getTableMock.mockResolvedValue({
+      success: true,
+      data: {
+        fields: [
+          {
+            key: "owner",
+            label: "负责人",
+            type: "RELATION",
+            relationTo: "tbl_users",
+          },
+        ],
+      },
+    });
+    updateRecordMock.mockResolvedValue({
+      success: true,
+      data: { id: "user-1", data: { status: "active" } },
+    });
+
+    const result = await executeUpdateRelatedRecordsAction({
+      action: {
+        id: "a1",
+        type: "update_related_records",
+        relationFieldKey: "owner",
+        targetScope: "first",
+        values: { status: "active" },
+      },
+      context: {
+        automationId: "aut_1",
+        tableId: "tbl_1",
+        recordId: "rec-1",
+        record: { owner: "user-1" },
+        previousRecord: null,
+        changedFields: [],
+        triggerSource: "MANUAL",
+        triggeredAt: "2026-04-22T00:00:00.000Z",
+        actor: { id: "usr_1" },
+      },
+      runId: "run_1",
+    });
+
+    expect(result.success).toBe(true);
+    expect(updateRecordMock).toHaveBeenCalledTimes(1);
+    expect(updateRecordMock).toHaveBeenCalledWith("user-1", { status: "active" }, "usr_1");
+    if (!result.success) {
+      throw new Error("Expected success");
+    }
+    expect(result.data).toMatchObject({
+      relatedTableId: "tbl_users",
+      updatedCount: 1,
+      updatedRecordIds: ["user-1"],
+    });
+  });
+
+  it("updates every related subtable record when targetScope is all", async () => {
+    getTableMock.mockResolvedValue({
+      success: true,
+      data: {
+        fields: [
+          {
+            key: "authors",
+            label: "作者",
+            type: "RELATION_SUBTABLE",
+            relationTo: "tbl_authors",
+          },
+        ],
+      },
+    });
+    updateRecordMock.mockResolvedValue({
+      success: true,
+      data: { id: "author-1", data: { reviewed: true } },
+    });
+
+    const result = await executeUpdateRelatedRecordsAction({
+      action: {
+        id: "a1",
+        type: "update_related_records",
+        relationFieldKey: "authors",
+        targetScope: "all",
+        values: { reviewed: true },
+      },
+      context: {
+        automationId: "aut_1",
+        tableId: "tbl_1",
+        recordId: "paper-1",
+        record: {
+          authors: [
+            { targetRecordId: "author-1", attributes: {}, sortOrder: 0 },
+            { targetRecordId: "author-2", attributes: {}, sortOrder: 1 },
+          ],
+        },
+        previousRecord: null,
+        changedFields: [],
+        triggerSource: "MANUAL",
+        triggeredAt: "2026-04-22T00:00:00.000Z",
+        actor: { id: "usr_1" },
+      },
+      runId: "run_1",
+    });
+
+    expect(result.success).toBe(true);
+    expect(updateRecordMock).toHaveBeenCalledTimes(2);
+    expect(updateRecordMock).toHaveBeenNthCalledWith(
+      1,
+      "author-1",
+      { reviewed: true },
+      "usr_1"
+    );
+    expect(updateRecordMock).toHaveBeenNthCalledWith(
+      2,
+      "author-2",
+      { reviewed: true },
+      "usr_1"
+    );
+    if (!result.success) {
+      throw new Error("Expected success");
+    }
+    expect(result.data.updatedCount).toBe(2);
+    expect(result.data.updatedRecordIds).toEqual(["author-1", "author-2"]);
+  });
+
+  it("returns a tracked no-op when relation field has no linked records", async () => {
+    getTableMock.mockResolvedValue({
+      success: true,
+      data: {
+        fields: [
+          {
+            key: "authors",
+            label: "作者",
+            type: "RELATION_SUBTABLE",
+            relationTo: "tbl_authors",
+          },
+        ],
+      },
+    });
+
+    const result = await executeUpdateRelatedRecordsAction({
+      action: {
+        id: "a1",
+        type: "update_related_records",
+        relationFieldKey: "authors",
+        targetScope: "all",
+        values: { reviewed: true },
+      },
+      context: {
+        automationId: "aut_1",
+        tableId: "tbl_1",
+        recordId: "paper-1",
+        record: { authors: [] },
+        previousRecord: null,
+        changedFields: [],
+        triggerSource: "MANUAL",
+        triggeredAt: "2026-04-22T00:00:00.000Z",
+        actor: { id: "usr_1" },
+      },
+      runId: "run_1",
+    });
+
+    expect(result.success).toBe(true);
+    expect(updateRecordMock).not.toHaveBeenCalled();
+    if (!result.success) {
+      throw new Error("Expected success");
+    }
+    expect(result.data).toMatchObject({
+      updatedCount: 0,
+      updatedRecordIds: [],
+      noop: true,
+    });
+  });
+});

--- a/src/lib/services/automation-action-executors/update-related-records.ts
+++ b/src/lib/services/automation-action-executors/update-related-records.ts
@@ -1,0 +1,112 @@
+import { getTable } from "@/lib/services/data-table.service";
+import { updateRecord } from "@/lib/services/data-record.service";
+import type { RelationSubtableValueItem } from "@/types/data-table";
+import type {
+  AutomationExecutorParams,
+  UpdateRelatedRecordsAction,
+} from "@/types/automation";
+
+function collectRelatedRecordIds(
+  value: unknown,
+  targetScope: UpdateRelatedRecordsAction["targetScope"]
+): string[] {
+  let recordIds: string[] = [];
+
+  if (typeof value === "string" && value) {
+    recordIds = [value];
+  } else if (value && typeof value === "object" && !Array.isArray(value)) {
+    const recordId = (value as { id?: unknown }).id;
+    if (typeof recordId === "string" && recordId) {
+      recordIds = [recordId];
+    }
+  } else if (Array.isArray(value)) {
+    recordIds = value
+      .map((item) =>
+        item && typeof item === "object"
+          ? (item as RelationSubtableValueItem).targetRecordId
+          : null
+      )
+      .filter((item): item is string => typeof item === "string" && item.length > 0);
+  }
+
+  if (targetScope === "first") {
+    return recordIds.slice(0, 1);
+  }
+
+  return recordIds;
+}
+
+export async function executeUpdateRelatedRecordsAction(
+  params: AutomationExecutorParams<UpdateRelatedRecordsAction>
+) {
+  if (!params.context.record) {
+    return {
+      success: false as const,
+      error: { code: "RECORD_REQUIRED", message: "当前动作需要记录上下文" },
+    };
+  }
+
+  const table = await getTable(params.context.tableId);
+  if (!table.success) {
+    return table;
+  }
+
+  const field = table.data.fields.find((item) => item.key === params.action.relationFieldKey);
+  if (!field) {
+    return {
+      success: false as const,
+      error: {
+        code: "RELATION_FIELD_NOT_FOUND",
+        message: `字段 "${params.action.relationFieldKey}" 不存在`,
+      },
+    };
+  }
+
+  if (field.type !== "RELATION" && field.type !== "RELATION_SUBTABLE") {
+    return {
+      success: false as const,
+      error: {
+        code: "RELATION_FIELD_REQUIRED",
+        message: `字段 "${params.action.relationFieldKey}" 不是关系字段`,
+      },
+    };
+  }
+
+  const relatedRecordIds = collectRelatedRecordIds(
+    params.context.record[params.action.relationFieldKey],
+    params.action.targetScope
+  );
+
+  if (relatedRecordIds.length === 0) {
+    return {
+      success: true as const,
+      data: {
+        relatedTableId: field.relationTo ?? null,
+        updatedCount: 0,
+        updatedRecordIds: [],
+        noop: true,
+      },
+    };
+  }
+
+  const actorId = params.context.actor?.id ?? "system";
+  const updatedRecordIds: string[] = [];
+
+  for (const recordId of relatedRecordIds) {
+    const result = await updateRecord(recordId, params.action.values, actorId);
+    if (!result.success) {
+      return result;
+    }
+    updatedRecordIds.push(recordId);
+  }
+
+  return {
+    success: true as const,
+    data: {
+      relatedTableId: field.relationTo ?? null,
+      updatedCount: updatedRecordIds.length,
+      updatedRecordIds,
+      noop: false,
+    },
+  };
+}

--- a/src/types/automation.ts
+++ b/src/types/automation.ts
@@ -34,6 +34,13 @@ export type AutomationActionNode =
   | { id: string; type: "create_record"; tableId: string; values: Record<string, unknown> }
   | {
       id: string;
+      type: "update_related_records";
+      relationFieldKey: string;
+      targetScope: "first" | "all";
+      values: Record<string, unknown>;
+    }
+  | {
+      id: string;
       type: "call_webhook";
       url: string;
       method: "POST" | "PUT";
@@ -110,6 +117,10 @@ export interface AutomationActionContext extends AutomationConditionContext {
 
 export type UpdateFieldAction = Extract<AutomationActionNode, { type: "update_field" }>;
 export type CreateRecordAction = Extract<AutomationActionNode, { type: "create_record" }>;
+export type UpdateRelatedRecordsAction = Extract<
+  AutomationActionNode,
+  { type: "update_related_records" }
+>;
 export type CallWebhookAction = Extract<AutomationActionNode, { type: "call_webhook" }>;
 export type AddCommentAction = Extract<AutomationActionNode, { type: "add_comment" }>;
 

--- a/src/validators/automation.ts
+++ b/src/validators/automation.ts
@@ -88,6 +88,13 @@ const automationActionSchema = z.discriminatedUnion("type", [
   }),
   z.object({
     id: z.string().trim().min(1),
+    type: z.literal("update_related_records"),
+    relationFieldKey: z.string().trim().min(1),
+    targetScope: z.enum(["first", "all"]),
+    values: z.record(z.string(), z.unknown()),
+  }),
+  z.object({
+    id: z.string().trim().min(1),
     type: z.literal("call_webhook"),
     url: z.string().url("Webhook URL 不合法"),
     method: z.enum(["POST", "PUT"]),


### PR DESCRIPTION
## Summary
- 新增 `update_related_records` 自动化动作 DSL、校验器和执行器
- 在自动化配置面板中支持配置关系字段、作用范围和更新值 JSON
- 增加执行器与配置面板测试，覆盖空关系 no-op、单条/多条关联更新等场景

## Test plan
- [x] `pnpm vitest run \"src/components/automations\" \"src/lib/services/automation-action-executors\"`
- [x] `pnpm vitest run \"src/components/automations/automation-config-panel.test.tsx\" \"src/lib/services/automation-action-executors/update-related-records.test.ts\"`
- [x] `pnpm eslint \"src/components/automations/automation-config-panel.tsx\" \"src/components/automations/automation-config-panel.test.tsx\" \"src/lib/services/automation-action-executors/index.ts\" \"src/lib/services/automation-action-executors/update-related-records.ts\" \"src/lib/services/automation-action-executors/update-related-records.test.ts\" \"src/types/automation.ts\" \"src/validators/automation.ts\"`
- [x] `npx tsc --noEmit`

Closes #137