### PR TITLE
[Feature] 自动化运行：实时结果通知与前端联动

### DIFF
--- a/docs/superpowers/plans/2026-04-23-automation-run-realtime.md
+++ b/docs/superpowers/plans/2026-04-23-automation-run-realtime.md
@@ -1,0 +1,1497 @@
+# Automation Run Realtime Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为自动化详情页增加 SSE 实时反馈链路，让手动触发后的运行列表、状态变化和展开详情无需手动刷新即可更新。
+
+**Architecture:** 新增自动化域专用实时事件类型和 `automation-realtime.service`，通过 `/api/automations/[id]/realtime` 向详情页推送 `run created / run updated / step updated` 事件。前端通过 `useAutomationRunRealtime` 和一个客户端包装组件维护运行列表状态，`AutomationRunActions` 负责触发反馈，`AutomationRunLog` 负责增量更新与详情重载。
+
+**Tech Stack:** Next.js 16, React 19, TypeScript, Vitest, PostgreSQL `LISTEN/NOTIFY`, 原有 service-layer 模式, 原有 Base UI / shadcn 组件, `sonner`.
+
+---
+
+## File Structure
+
+### New files
+
+- `src/types/automation-realtime.ts`
+  Purpose: 定义自动化详情页使用的 SSE 事件类型，不污染现有 `src/types/realtime.ts`。
+- `src/lib/services/automation-realtime.service.ts`
+  Purpose: 提供按 `automationId` 订阅和发布实时事件的服务，内部维护独立 `LISTEN/NOTIFY` 通道。
+- `src/app/api/automations/[id]/realtime/route.ts`
+  Purpose: SSE 订阅入口，校验权限并输出 `connected`、`heartbeat` 与自动化实时事件。
+- `src/hooks/use-automation-run-realtime.ts`
+  Purpose: 客户端封装 `EventSource`，向页面分发运行创建、状态更新、步骤更新事件。
+- `src/components/automations/automation-detail-live.tsx`
+  Purpose: 在详情页中维护客户端运行状态，将 SSE 更新和手动触发反馈接到 `AutomationRunActions` 与 `AutomationRunLog`。
+- `src/app/api/automations/[id]/realtime/route.test.ts`
+  Purpose: 路由权限和 SSE 初始输出测试。
+- `src/hooks/use-automation-run-realtime.test.ts`
+  Purpose: Hook 事件解析与连接状态测试。
+- `src/components/automations/automation-run-actions.test.tsx`
+  Purpose: 手动触发成功、失败和回调行为测试。
+
+### Modified files
+
+- `src/lib/services/automation-run.service.ts`
+  Purpose: 在创建 run、run 状态变化、step 状态变化时发布自动化实时事件。
+- `src/lib/services/automation-run.service.test.ts`
+  Purpose: 验证 run / step 更新时的事件发布。
+- `src/app/(dashboard)/automations/[id]/page.tsx`
+  Purpose: 用客户端包装组件替换直接渲染 `AutomationRunActions` 与 `AutomationRunLog` 的方式。
+- `src/components/automations/automation-run-actions.tsx`
+  Purpose: 去掉 `router.refresh()` 依赖，增加 `onRunQueued` 回调和 `toast` 反馈。
+- `src/components/automations/automation-run-log.tsx`
+  Purpose: 支持外部注入实时 run 列表、展开详情重载和终态提示协作。
+- `src/components/automations/automation-run-log.test.tsx`
+  Purpose: 覆盖 run 增量更新、详情刷新和现有展开行为。
+
+---
+
+### Task 1: 定义自动化实时事件类型与发布服务
+
+**Files:**
+- Create: `src/types/automation-realtime.ts`
+- Create: `src/lib/services/automation-realtime.service.ts`
+- Test: `src/lib/services/automation-realtime.service.test.ts`
+
+- [ ] **Step 1: 写失败测试，固定自动化域的订阅 / 发布语义**
+
+```ts
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const { poolQueryMock } = vi.hoisted(() => ({
+  poolQueryMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  pool: {
+    query: poolQueryMock,
+  },
+}));
+
+describe("automation-realtime.service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("publishes an automation run update event through pg_notify", async () => {
+    const { publishAutomationRealtimeEvent } = await import("./automation-realtime.service");
+
+    await publishAutomationRealtimeEvent({
+      type: "automation_run_updated",
+      automationId: "aut-1",
+      run: {
+        id: "run-1",
+        automationId: "aut-1",
+        status: "RUNNING",
+        triggerSource: "MANUAL",
+        triggerPayload: {},
+        contextSnapshot: {},
+        startedAt: "2026-04-23T00:00:00.000Z",
+        finishedAt: null,
+        durationMs: null,
+        errorCode: null,
+        errorMessage: null,
+        createdAt: "2026-04-23T00:00:00.000Z",
+      },
+    });
+
+    expect(poolQueryMock).toHaveBeenCalledWith(expect.stringContaining("pg_notify"), [
+      "automation_run_events",
+      expect.stringContaining("\"automationId\":\"aut-1\""),
+    ]);
+  });
+
+  it("subscribes and unsubscribes listeners by automationId", async () => {
+    const {
+      subscribeToAutomation,
+      broadcastToAutomation,
+    } = await import("./automation-realtime.service");
+
+    const listener = vi.fn();
+    const unsubscribe = subscribeToAutomation("aut-1", listener);
+
+    broadcastToAutomation("aut-1", {
+      type: "automation_run_created",
+      automationId: "aut-1",
+      run: {
+        id: "run-1",
+        automationId: "aut-1",
+        status: "PENDING",
+        triggerSource: "MANUAL",
+        triggerPayload: {},
+        contextSnapshot: {},
+        startedAt: null,
+        finishedAt: null,
+        durationMs: null,
+        errorCode: null,
+        errorMessage: null,
+        createdAt: "2026-04-23T00:00:00.000Z",
+      },
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    broadcastToAutomation("aut-1", {
+      type: "automation_run_step_updated",
+      automationId: "aut-1",
+      runId: "run-1",
+      stepId: "step-1",
+      status: "SUCCEEDED",
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试，确认先红**
+
+Run: `pnpm vitest run "src/lib/services/automation-realtime.service.test.ts"`
+Expected: FAIL，报错缺少 `automation-realtime.service.ts` 或缺少目标导出。
+
+- [ ] **Step 3: 添加自动化实时事件类型**
+
+```ts
+import type { AutomationRunItem, AutomationRunStepStatus } from "@/types/automation";
+
+export type AutomationRealtimeConnectedEvent = {
+  type: "connected";
+  automationId: string;
+};
+
+export type AutomationRealtimeHeartbeatEvent = {
+  type: "heartbeat";
+  ts: number;
+};
+
+export type AutomationRunCreatedEvent = {
+  type: "automation_run_created";
+  automationId: string;
+  run: AutomationRunItem;
+};
+
+export type AutomationRunUpdatedEvent = {
+  type: "automation_run_updated";
+  automationId: string;
+  run: AutomationRunItem;
+};
+
+export type AutomationRunStepUpdatedEvent = {
+  type: "automation_run_step_updated";
+  automationId: string;
+  runId: string;
+  stepId: string;
+  status: AutomationRunStepStatus;
+};
+
+export type AutomationRealtimeEvent =
+  | AutomationRunCreatedEvent
+  | AutomationRunUpdatedEvent
+  | AutomationRunStepUpdatedEvent;
+
+export type AutomationRealtimeStreamEvent =
+  | AutomationRealtimeConnectedEvent
+  | AutomationRealtimeHeartbeatEvent
+  | AutomationRealtimeEvent;
+```
+
+- [ ] **Step 4: 以现有数据表 realtime 的模式实现自动化发布服务**
+
+```ts
+import { Client } from "pg";
+import { pool } from "@/lib/db";
+import type { AutomationRealtimeEvent } from "@/types/automation-realtime";
+
+type AutomationRealtimeListener = (event: AutomationRealtimeEvent) => void;
+
+const CHANNEL = "automation_run_events";
+const listeners = new Map<string, Set<AutomationRealtimeListener>>();
+let listenClient: Client | null = null;
+let initPromise: Promise<void> | null = null;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+function scheduleReconnect(): void {
+  if (reconnectTimer || listeners.size === 0) {
+    return;
+  }
+
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    void ensureListening();
+  }, 3000);
+}
+
+async function ensureListening(): Promise<void> {
+  if (listenClient) {
+    return;
+  }
+
+  if (initPromise) {
+    await initPromise;
+    return;
+  }
+
+  initPromise = (async () => {
+    const client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+    await client.query(`LISTEN ${CHANNEL}`);
+
+    client.on("notification", (msg) => {
+      if (!msg.payload) {
+        return;
+      }
+
+      try {
+        const event = JSON.parse(msg.payload) as AutomationRealtimeEvent;
+        const scopedListeners = listeners.get(event.automationId);
+        if (!scopedListeners) {
+          return;
+        }
+
+        for (const listener of scopedListeners) {
+          listener(event);
+        }
+      } catch {
+        // ignore malformed events
+      }
+    });
+
+    client.on("error", () => {
+      listenClient = null;
+      initPromise = null;
+      scheduleReconnect();
+    });
+
+    client.on("end", () => {
+      listenClient = null;
+      initPromise = null;
+      scheduleReconnect();
+    });
+
+    listenClient = client;
+  })();
+
+  await initPromise;
+}
+
+export async function publishAutomationRealtimeEvent(
+  event: AutomationRealtimeEvent
+): Promise<void> {
+  await pool.query(`SELECT pg_notify($1, $2)`, [CHANNEL, JSON.stringify(event)]);
+}
+
+export function subscribeToAutomation(
+  automationId: string,
+  listener: AutomationRealtimeListener
+): () => void {
+  if (!listeners.has(automationId)) {
+    listeners.set(automationId, new Set());
+  }
+
+  listeners.get(automationId)!.add(listener);
+  void ensureListening();
+
+  return () => {
+    const scopedListeners = listeners.get(automationId);
+    if (!scopedListeners) {
+      return;
+    }
+
+    scopedListeners.delete(listener);
+    if (scopedListeners.size === 0) {
+      listeners.delete(automationId);
+    }
+  };
+}
+
+export function broadcastToAutomation(
+  automationId: string,
+  event: AutomationRealtimeEvent
+): void {
+  const scopedListeners = listeners.get(automationId);
+  if (!scopedListeners) {
+    return;
+  }
+
+  for (const listener of scopedListeners) {
+    listener(event);
+  }
+}
+
+export function shutdownAutomationRealtime(): void {
+  if (listenClient) {
+    void listenClient.end();
+    listenClient = null;
+    initPromise = null;
+  }
+
+  listeners.clear();
+}
+```
+
+- [ ] **Step 5: 回跑测试，确认转绿**
+
+Run: `pnpm vitest run "src/lib/services/automation-realtime.service.test.ts"`
+Expected: PASS，2 个测试通过。
+
+- [ ] **Step 6: 提交本任务**
+
+```bash
+git add "src/types/automation-realtime.ts" \
+  "src/lib/services/automation-realtime.service.ts" \
+  "src/lib/services/automation-realtime.service.test.ts"
+git commit -m "feat(automation): add realtime event service"
+```
+
+---
+
+### Task 2: 在运行服务中发布事件，并提供 SSE 路由
+
+**Files:**
+- Modify: `src/lib/services/automation-run.service.ts`
+- Modify: `src/lib/services/automation-run.service.test.ts`
+- Create: `src/app/api/automations/[id]/realtime/route.ts`
+- Create: `src/app/api/automations/[id]/realtime/route.test.ts`
+
+- [ ] **Step 1: 先写运行服务失败测试，锁定发布点**
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createAutomationRun,
+  markAutomationRunStarted,
+  markAutomationRunStepFailed,
+} from "@/lib/services/automation-run.service";
+
+const { publishAutomationRealtimeEventMock } = vi.hoisted(() => ({
+  publishAutomationRealtimeEventMock: vi.fn(),
+}));
+
+vi.mock("@/lib/services/automation-realtime.service", () => ({
+  publishAutomationRealtimeEvent: publishAutomationRealtimeEventMock,
+}));
+
+describe("automation-run realtime publishing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("publishes run created after persisting a pending run", async () => {
+    const result = await createAutomationRun({
+      automationId: "aut-1",
+      triggerSource: "MANUAL",
+      triggerPayload: {},
+      contextSnapshot: {
+        tableId: "tbl-1",
+        record: null,
+        previousRecord: null,
+        changedFields: [],
+        triggeredAt: "2026-04-23T00:00:00.000Z",
+        actor: { id: "user-1" },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(publishAutomationRealtimeEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "automation_run_created",
+        automationId: "aut-1",
+      })
+    );
+  });
+
+  it("publishes step updated after marking a step failed", async () => {
+    await markAutomationRunStepFailed("step-1", {
+      code: "ACTION_EXECUTION_FAILED",
+      message: "Webhook returned 500",
+    });
+
+    expect(publishAutomationRealtimeEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "automation_run_step_updated",
+        stepId: "step-1",
+        status: "FAILED",
+      })
+    );
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试，确认先红**
+
+Run: `pnpm vitest run "src/lib/services/automation-run.service.test.ts"`
+Expected: FAIL，提示未调用 `publishAutomationRealtimeEvent`。
+
+- [ ] **Step 3: 修改运行服务，让关键状态更新直接返回最新 row 并发布事件**
+
+```ts
+import { publishAutomationRealtimeEvent } from "@/lib/services/automation-realtime.service";
+
+async function emitRunUpdatedEvent(row: {
+  id: string;
+  automationId: string;
+  status: string;
+  triggerSource: string;
+  triggerPayload: unknown;
+  contextSnapshot: unknown;
+  startedAt: Date | null;
+  finishedAt: Date | null;
+  durationMs: number | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+  createdAt: Date;
+}) {
+  await publishAutomationRealtimeEvent({
+    type: "automation_run_updated",
+    automationId: row.automationId,
+    run: mapAutomationRunItem(row),
+  });
+}
+
+export async function createAutomationRun(
+  input: EnqueueAutomationRunInput
+): Promise<ServiceResult<{ id: string }>> {
+  try {
+    const created = await db.automationRun.create({
+      data: {
+        automationId: input.automationId,
+        status: "PENDING",
+        triggerSource: input.triggerSource,
+        triggerPayload: toJsonValue(input.triggerPayload),
+        contextSnapshot: toJsonValue(input.contextSnapshot),
+      },
+      select: {
+        id: true,
+        automationId: true,
+        status: true,
+        triggerSource: true,
+        triggerPayload: true,
+        contextSnapshot: true,
+        startedAt: true,
+        finishedAt: true,
+        durationMs: true,
+        errorCode: true,
+        errorMessage: true,
+        createdAt: true,
+      },
+    });
+
+    await publishAutomationRealtimeEvent({
+      type: "automation_run_created",
+      automationId: created.automationId,
+      run: mapAutomationRunItem(created),
+    });
+
+    return { success: true, data: { id: created.id } };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "创建自动化运行记录失败";
+    return { success: false, error: { code: "CREATE_RUN_FAILED", message } };
+  }
+}
+
+export async function markAutomationRunStarted(runId: string): Promise<ServiceResult<null>> {
+  try {
+    const updated = await db.automationRun.update({
+      where: { id: runId },
+      data: {
+        status: "RUNNING",
+        startedAt: new Date(),
+      },
+      select: {
+        id: true,
+        automationId: true,
+        status: true,
+        triggerSource: true,
+        triggerPayload: true,
+        contextSnapshot: true,
+        startedAt: true,
+        finishedAt: true,
+        durationMs: true,
+        errorCode: true,
+        errorMessage: true,
+        createdAt: true,
+      },
+    });
+
+    await emitRunUpdatedEvent(updated);
+    return { success: true, data: null };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "标记自动化运行开始失败";
+    return { success: false, error: { code: "MARK_RUN_STARTED_FAILED", message } };
+  }
+}
+
+export async function markAutomationRunStepFailed(
+  stepId: string,
+  error: { code?: string; message: string }
+): Promise<ServiceResult<null>> {
+  try {
+    const updated = await db.automationRunStep.update({
+      where: { id: stepId },
+      data: {
+        status: "FAILED",
+        errorCode: error.code ?? "STEP_FAILED",
+        errorMessage: error.message,
+        finishedAt: new Date(),
+      },
+      select: {
+        id: true,
+        runId: true,
+        status: true,
+        run: {
+          select: {
+            automationId: true,
+          },
+        },
+      },
+    });
+
+    await publishAutomationRealtimeEvent({
+      type: "automation_run_step_updated",
+      automationId: updated.run.automationId,
+      runId: updated.runId,
+      stepId: updated.id,
+      status: updated.status as "FAILED",
+    });
+
+    return { success: true, data: null };
+  } catch (updateError) {
+    const message =
+      updateError instanceof Error ? updateError.message : "标记自动化步骤失败失败";
+    return { success: false, error: { code: "MARK_RUN_STEP_FAILED_FAILED", message } };
+  }
+}
+```
+
+- [ ] **Step 4: 先写 SSE 路由失败测试**
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authMock = vi.fn();
+const getAutomationMock = vi.fn();
+const subscribeToAutomationMock = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  auth: authMock,
+}));
+
+vi.mock("@/lib/services/automation.service", () => ({
+  getAutomation: getAutomationMock,
+}));
+
+vi.mock("@/lib/services/automation-realtime.service", () => ({
+  subscribeToAutomation: subscribeToAutomationMock,
+}));
+
+describe("api/automations/[id]/realtime route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    authMock.mockResolvedValue(null);
+    const { GET } = await import("./route");
+
+    const response = await GET({ signal: new AbortController().signal } as never, {
+      params: Promise.resolve({ id: "aut-1" }),
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("streams a connected event for an owned automation", async () => {
+    authMock.mockResolvedValue({ user: { id: "user-1" } });
+    getAutomationMock.mockResolvedValue({
+      success: true,
+      data: { id: "aut-1", name: "同步作者信息" },
+    });
+    subscribeToAutomationMock.mockReturnValue(() => undefined);
+    const { GET } = await import("./route");
+    const controller = new AbortController();
+
+    const response = await GET({ signal: controller.signal } as never, {
+      params: Promise.resolve({ id: "aut-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toContain("text/event-stream");
+  });
+});
+```
+
+- [ ] **Step 5: 运行路由测试，确认先红**
+
+Run: `pnpm vitest run "src/app/api/automations/[id]/realtime/route.test.ts"`
+Expected: FAIL，报错缺少 SSE 路由文件。
+
+- [ ] **Step 6: 实现 SSE 路由**
+
+```ts
+import { NextRequest } from "next/server";
+import { auth } from "@/lib/auth";
+import { getAutomation } from "@/lib/services/automation.service";
+import { subscribeToAutomation } from "@/lib/services/automation-realtime.service";
+import type { AutomationRealtimeEvent } from "@/types/automation-realtime";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const { id: automationId } = await params;
+  const automation = await getAutomation(automationId, session.user.id);
+  if (!automation.success) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(
+        encoder.encode(
+          `data: ${JSON.stringify({ type: "connected", automationId })}\n\n`
+        )
+      );
+
+      const unsubscribe = subscribeToAutomation(
+        automationId,
+        (event: AutomationRealtimeEvent) => {
+          try {
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+          } catch {
+            // stream already closed
+          }
+        }
+      );
+
+      const heartbeat = setInterval(() => {
+        try {
+          controller.enqueue(
+            encoder.encode(`data: ${JSON.stringify({ type: "heartbeat", ts: Date.now() })}\n\n`)
+          );
+        } catch {
+          clearInterval(heartbeat);
+        }
+      }, 30000);
+
+      request.signal.addEventListener("abort", () => {
+        unsubscribe();
+        clearInterval(heartbeat);
+        try {
+          controller.close();
+        } catch {
+          // already closed
+        }
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}
+```
+
+- [ ] **Step 7: 回跑测试，确认转绿**
+
+Run:
+- `pnpm vitest run "src/lib/services/automation-run.service.test.ts"`
+- `pnpm vitest run "src/app/api/automations/[id]/realtime/route.test.ts"`
+
+Expected: PASS，服务测试和路由测试都通过。
+
+- [ ] **Step 8: 提交本任务**
+
+```bash
+git add "src/lib/services/automation-run.service.ts" \
+  "src/lib/services/automation-run.service.test.ts" \
+  "src/app/api/automations/[id]/realtime/route.ts" \
+  "src/app/api/automations/[id]/realtime/route.test.ts"
+git commit -m "feat(automation): stream run status updates"
+```
+
+---
+
+### Task 3: 增加客户端实时 Hook 和详情页状态容器
+
+**Files:**
+- Create: `src/hooks/use-automation-run-realtime.ts`
+- Create: `src/hooks/use-automation-run-realtime.test.ts`
+- Create: `src/components/automations/automation-detail-live.tsx`
+- Modify: `src/app/(dashboard)/automations/[id]/page.tsx`
+
+- [ ] **Step 1: 先写 Hook 失败测试**
+
+```ts
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useAutomationRunRealtime } from "./use-automation-run-realtime";
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  onerror: (() => void) | null = null;
+  close = vi.fn();
+
+  constructor(public url: string) {
+    MockEventSource.instances.push(this);
+  }
+}
+
+describe("useAutomationRunRealtime", () => {
+  it("creates an EventSource and forwards run update events", () => {
+    vi.stubGlobal("EventSource", MockEventSource as unknown as typeof EventSource);
+    const onRunUpdated = vi.fn();
+
+    renderHook(() =>
+      useAutomationRunRealtime({
+        automationId: "aut-1",
+        onRunUpdated,
+      })
+    );
+
+    const instance = MockEventSource.instances[0];
+    instance.onmessage?.(
+      new MessageEvent("message", {
+        data: JSON.stringify({
+          type: "automation_run_updated",
+          automationId: "aut-1",
+          run: {
+            id: "run-1",
+            automationId: "aut-1",
+            status: "RUNNING",
+            triggerSource: "MANUAL",
+            triggerPayload: {},
+            contextSnapshot: {},
+            startedAt: "2026-04-23T00:00:00.000Z",
+            finishedAt: null,
+            durationMs: null,
+            errorCode: null,
+            errorMessage: null,
+            createdAt: "2026-04-23T00:00:00.000Z",
+          },
+        }),
+      })
+    );
+
+    expect(onRunUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "run-1", status: "RUNNING" })
+    );
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试，确认先红**
+
+Run: `pnpm vitest run "src/hooks/use-automation-run-realtime.test.ts"`
+Expected: FAIL，缺少 Hook 文件或导出。
+
+- [ ] **Step 3: 实现 Hook**
+
+```ts
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type {
+  AutomationRealtimeEvent,
+  AutomationRealtimeStreamEvent,
+} from "@/types/automation-realtime";
+import type { AutomationRunItem, AutomationRunStepStatus } from "@/types/automation";
+
+interface UseAutomationRunRealtimeOptions {
+  automationId: string;
+  enabled?: boolean;
+  onRunCreated?: (run: AutomationRunItem) => void;
+  onRunUpdated?: (run: AutomationRunItem) => void;
+  onRunStepUpdated?: (event: {
+    runId: string;
+    stepId: string;
+    status: AutomationRunStepStatus;
+  }) => void;
+}
+
+export function useAutomationRunRealtime({
+  automationId,
+  enabled = true,
+  onRunCreated,
+  onRunUpdated,
+  onRunStepUpdated,
+}: UseAutomationRunRealtimeOptions) {
+  const [isConnected, setIsConnected] = useState(false);
+  const callbacksRef = useRef({ onRunCreated, onRunUpdated, onRunStepUpdated });
+
+  useEffect(() => {
+    callbacksRef.current = { onRunCreated, onRunUpdated, onRunStepUpdated };
+  }, [onRunCreated, onRunUpdated, onRunStepUpdated]);
+
+  useEffect(() => {
+    if (!enabled || !automationId) {
+      return;
+    }
+
+    const eventSource = new EventSource(`/api/automations/${automationId}/realtime`);
+
+    eventSource.onopen = () => {
+      setIsConnected(true);
+    };
+
+    eventSource.onmessage = (event) => {
+      try {
+        const payload = JSON.parse(event.data) as AutomationRealtimeStreamEvent;
+        if (payload.type === "connected" || payload.type === "heartbeat") {
+          return;
+        }
+
+        const realtimeEvent = payload as AutomationRealtimeEvent;
+        if (realtimeEvent.type === "automation_run_created") {
+          callbacksRef.current.onRunCreated?.(realtimeEvent.run);
+          return;
+        }
+
+        if (realtimeEvent.type === "automation_run_updated") {
+          callbacksRef.current.onRunUpdated?.(realtimeEvent.run);
+          return;
+        }
+
+        callbacksRef.current.onRunStepUpdated?.({
+          runId: realtimeEvent.runId,
+          stepId: realtimeEvent.stepId,
+          status: realtimeEvent.status,
+        });
+      } catch {
+        // ignore malformed events
+      }
+    };
+
+    eventSource.onerror = () => {
+      setIsConnected(false);
+    };
+
+    return () => {
+      eventSource.close();
+      setIsConnected(false);
+    };
+  }, [automationId, enabled]);
+
+  return { isConnected };
+}
+```
+
+- [ ] **Step 4: 新增详情页客户端状态容器**
+
+```tsx
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+import { AutomationRunActions } from "@/components/automations/automation-run-actions";
+import { AutomationRunLog } from "@/components/automations/automation-run-log";
+import { useAutomationRunRealtime } from "@/hooks/use-automation-run-realtime";
+import type { AutomationRunItem, AutomationRunStepStatus } from "@/types/automation";
+
+type AutomationDetailLiveProps = {
+  automationId: string;
+  initialRuns: AutomationRunItem[];
+};
+
+function upsertRun(items: AutomationRunItem[], nextRun: AutomationRunItem): AutomationRunItem[] {
+  const existingIndex = items.findIndex((item) => item.id === nextRun.id);
+  if (existingIndex === -1) {
+    return [nextRun, ...items].slice(0, 10);
+  }
+
+  const nextItems = [...items];
+  nextItems[existingIndex] = nextRun;
+  return nextItems;
+}
+
+export function AutomationDetailLive({
+  automationId,
+  initialRuns,
+}: AutomationDetailLiveProps) {
+  const [runs, setRuns] = useState(initialRuns);
+  const seenTerminalRef = useRef(new Set<string>());
+
+  const handleRunUpdated = useCallback((run: AutomationRunItem) => {
+    setRuns((current) => upsertRun(current, run));
+
+    const isTerminal = run.status === "SUCCEEDED" || run.status === "FAILED";
+    if (!isTerminal || seenTerminalRef.current.has(run.id)) {
+      return;
+    }
+
+    seenTerminalRef.current.add(run.id);
+    if (run.status === "SUCCEEDED") {
+      toast.success("自动化运行成功");
+    } else {
+      toast.error(run.errorMessage ?? "自动化运行失败");
+    }
+  }, []);
+
+  const realtime = useAutomationRunRealtime({
+    automationId,
+    onRunCreated: (run) => setRuns((current) => upsertRun(current, run)),
+    onRunUpdated: handleRunUpdated,
+    onRunStepUpdated: (_event: { runId: string; stepId: string; status: AutomationRunStepStatus }) => {
+      // AutomationRunLog receives the latest runs and handles detail refetch internally.
+    },
+  });
+
+  const helperText = useMemo(
+    () =>
+      realtime.isConnected ? undefined : "实时连接已断开，状态可能不是最新，请稍后刷新页面。",
+    [realtime.isConnected]
+  );
+
+  return (
+    <div className="space-y-4">
+      <AutomationRunActions automationId={automationId} />
+      <AutomationRunLog items={runs} helperText={helperText} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: 用状态容器替换详情页直连结构**
+
+```tsx
+import { AutomationDetailLive } from "@/components/automations/automation-detail-live";
+
+// ...
+<div className="mt-4">
+  <AutomationDetailLive
+    automationId={result.data.id}
+    initialRuns={runItems}
+  />
+</div>
+
+// remove the standalone AutomationRunActions / AutomationRunLog rendering below
+```
+
+- [ ] **Step 6: 回跑测试，确认 Hook 转绿**
+
+Run: `pnpm vitest run "src/hooks/use-automation-run-realtime.test.ts"`
+Expected: PASS，Hook 能正确分发事件。
+
+- [ ] **Step 7: 提交本任务**
+
+```bash
+git add "src/hooks/use-automation-run-realtime.ts" \
+  "src/hooks/use-automation-run-realtime.test.ts" \
+  "src/components/automations/automation-detail-live.tsx" \
+  "src/app/(dashboard)/automations/[id]/page.tsx"
+git commit -m "feat(automation): add live run detail state"
+```
+
+---
+
+### Task 4: 改造触发按钮和运行日志，使其支持实时联动
+
+**Files:**
+- Modify: `src/components/automations/automation-run-actions.tsx`
+- Create: `src/components/automations/automation-run-actions.test.tsx`
+- Modify: `src/components/automations/automation-run-log.tsx`
+- Modify: `src/components/automations/automation-run-log.test.tsx`
+
+- [ ] **Step 1: 先写触发按钮失败测试**
+
+```tsx
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AutomationRunActions } from "./automation-run-actions";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("AutomationRunActions", () => {
+  it("calls onRunQueued after a successful manual run", async () => {
+    const onRunQueued = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          success: true,
+          data: { runId: "run-1" },
+        }),
+      })
+    );
+
+    render(<AutomationRunActions automationId="aut-1" onRunQueued={onRunQueued} />);
+    fireEvent.click(screen.getByRole("button", { name: "手动运行" }));
+
+    await waitFor(() => {
+      expect(onRunQueued).toHaveBeenCalledWith("run-1");
+    });
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试，确认先红**
+
+Run: `pnpm vitest run "src/components/automations/automation-run-actions.test.tsx"`
+Expected: FAIL，组件还没有 `onRunQueued` props。
+
+- [ ] **Step 3: 改造触发按钮组件**
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { Loader2, PlayCircle } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+
+type AutomationRunActionsProps = {
+  automationId: string;
+  onRunQueued?: (runId: string) => void;
+};
+
+export function AutomationRunActions({
+  automationId,
+  onRunQueued,
+}: AutomationRunActionsProps) {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleRun() {
+    setPending(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/automations/${automationId}/run`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
+      });
+      const payload = (await response.json()) as
+        | { success: true; data: { runId: string } }
+        | { error?: { message?: string } };
+
+      if (!response.ok) {
+        const message = "error" in payload ? payload.error?.message : undefined;
+        setError(message ?? "触发自动化失败");
+        toast.error(message ?? "触发自动化失败");
+        return;
+      }
+
+      if ("success" in payload && payload.success) {
+        onRunQueued?.(payload.data.runId);
+        toast.success(`已创建运行任务 ${payload.data.runId}`);
+      }
+    } catch {
+      setError("触发自动化失败");
+      toast.error("触发自动化失败");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <Button type="button" variant="outline" onClick={handleRun} disabled={pending}>
+        {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : <PlayCircle className="h-4 w-4" />}
+        手动运行
+      </Button>
+      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: 先写运行日志失败测试，锁定详情重拉与辅助文案**
+
+```tsx
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AutomationRunLog } from "./automation-run-log";
+
+describe("AutomationRunLog realtime helpers", () => {
+  it("shows helper text and reloads detail when reloadToken changes", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          run: {
+            id: "run-1",
+            automationId: "aut-1",
+            status: "RUNNING",
+            triggerSource: "MANUAL",
+            triggerPayload: {},
+            contextSnapshot: {},
+            startedAt: "2026-04-23T00:00:00.000Z",
+            finishedAt: null,
+            durationMs: null,
+            errorCode: null,
+            errorMessage: null,
+            createdAt: "2026-04-23T00:00:00.000Z",
+          },
+          steps: [],
+        },
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { rerender } = render(
+      <AutomationRunLog
+        items={[
+          {
+            id: "run-1",
+            automationId: "aut-1",
+            status: "RUNNING",
+            triggerSource: "MANUAL",
+            triggerPayload: {},
+            contextSnapshot: {},
+            startedAt: "2026-04-23T00:00:00.000Z",
+            finishedAt: null,
+            durationMs: null,
+            errorCode: null,
+            errorMessage: null,
+            createdAt: "2026-04-23T00:00:00.000Z",
+          },
+        ]}
+        helperText="实时连接已断开"
+        detailReloadToken={0}
+      />
+    );
+
+    expect(screen.getByText("实时连接已断开")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "详情" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(
+      <AutomationRunLog
+        items={[
+          {
+            id: "run-1",
+            automationId: "aut-1",
+            status: "RUNNING",
+            triggerSource: "MANUAL",
+            triggerPayload: {},
+            contextSnapshot: {},
+            startedAt: "2026-04-23T00:00:00.000Z",
+            finishedAt: null,
+            durationMs: null,
+            errorCode: null,
+            errorMessage: null,
+            createdAt: "2026-04-23T00:00:00.000Z",
+          },
+        ]}
+        helperText="实时连接已断开"
+        detailReloadToken={1}
+      />
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+```
+
+- [ ] **Step 5: 运行测试，确认先红**
+
+Run: `pnpm vitest run "src/components/automations/automation-run-log.test.tsx" "src/components/automations/automation-run-actions.test.tsx"`
+Expected: FAIL，`AutomationRunLog` 还没有 `helperText` 和 `detailReloadToken`。
+
+- [ ] **Step 6: 改造运行日志组件，支持辅助文案与详情重拉 token**
+
+```tsx
+type AutomationRunLogProps = {
+  items: AutomationRunItem[];
+  helperText?: string;
+  detailReloadToken?: number;
+};
+
+export function AutomationRunLog({
+  items,
+  helperText,
+  detailReloadToken = 0,
+}: AutomationRunLogProps) {
+  const [expandedRunId, setExpandedRunId] = useState<string | null>(null);
+  const [detailMap, setDetailMap] = useState<Record<string, AutomationRunDetail | undefined>>({});
+  const [loadingRunId, setLoadingRunId] = useState<string | null>(null);
+  const [errorMap, setErrorMap] = useState<Record<string, string | undefined>>({});
+
+  const loadRunDetail = useCallback(async (runId: string, force = false) => {
+    if (!force && (detailMap[runId] || loadingRunId === runId)) {
+      return;
+    }
+
+    setLoadingRunId(runId);
+    setErrorMap((prev) => ({ ...prev, [runId]: undefined }));
+
+    try {
+      const response = await fetch(`/api/automations/runs/${runId}`);
+      const payload = (await response.json()) as
+        | { success: true; data: AutomationRunDetail }
+        | { error?: { message?: string } };
+
+      if (!response.ok) {
+        const message = "error" in payload ? payload.error?.message : undefined;
+        setErrorMap((prev) => ({ ...prev, [runId]: message ?? "获取运行详情失败" }));
+        return;
+      }
+
+      if ("success" in payload && payload.success) {
+        setDetailMap((prev) => ({ ...prev, [runId]: payload.data }));
+      }
+    } catch {
+      setErrorMap((prev) => ({ ...prev, [runId]: "获取运行详情失败" }));
+    } finally {
+      setLoadingRunId(null);
+    }
+  }, [detailMap, loadingRunId]);
+
+  useEffect(() => {
+    if (!expandedRunId) {
+      return;
+    }
+
+    void loadRunDetail(expandedRunId, true);
+  }, [detailReloadToken, expandedRunId, loadRunDetail]);
+
+  async function handleToggle(runId: string) {
+    if (expandedRunId === runId) {
+      setExpandedRunId(null);
+      return;
+    }
+
+    setExpandedRunId(runId);
+    await loadRunDetail(runId);
+  }
+
+  return (
+    <Card className="bg-card/90">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base font-[520]">最近运行</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {helperText ? (
+          <p className="mb-3 text-xs text-muted-foreground">{helperText}</p>
+        ) : null}
+        {/* keep existing list rendering */}
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 7: 回跑组件测试，确认转绿**
+
+Run:
+- `pnpm vitest run "src/components/automations/automation-run-actions.test.tsx"`
+- `pnpm vitest run "src/components/automations/automation-run-log.test.tsx"`
+
+Expected: PASS，按钮与日志组件都通过。
+
+- [ ] **Step 8: 提交本任务**
+
+```bash
+git add "src/components/automations/automation-run-actions.tsx" \
+  "src/components/automations/automation-run-actions.test.tsx" \
+  "src/components/automations/automation-run-log.tsx" \
+  "src/components/automations/automation-run-log.test.tsx"
+git commit -m "feat(automation): update run UI for realtime feedback"
+```
+
+---
+
+### Task 5: 将实时步骤事件接到详情页，并完成回归验证
+
+**Files:**
+- Modify: `src/components/automations/automation-detail-live.tsx`
+- Modify: `src/components/automations/automation-run-log.test.tsx`
+- Verify: `src/lib/services/automation-run.service.test.ts`
+- Verify: `src/app/api/automations/[id]/realtime/route.test.ts`
+- Verify: `src/hooks/use-automation-run-realtime.test.ts`
+- Verify: `src/components/automations/automation-run-actions.test.tsx`
+- Verify: `src/components/automations/automation-run-log.test.tsx`
+
+- [ ] **Step 1: 先写详情页状态容器失败测试，固定 step 事件触发详情重拉 token**
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AutomationDetailLive } from "./automation-detail-live";
+
+vi.mock("@/hooks/use-automation-run-realtime", () => ({
+  useAutomationRunRealtime: vi.fn(),
+}));
+
+vi.mock("@/components/automations/automation-run-log", () => ({
+  AutomationRunLog: ({
+    detailReloadToken,
+  }: {
+    detailReloadToken?: number;
+  }) => <div data-testid="detail-reload-token">{detailReloadToken}</div>,
+}));
+
+describe("AutomationDetailLive", () => {
+  it("increments detail reload token when a step update arrives", async () => {
+    const useAutomationRunRealtimeMock = (await import("@/hooks/use-automation-run-realtime"))
+      .useAutomationRunRealtime as unknown as ReturnType<typeof vi.fn>;
+
+    let onRunStepUpdated: ((event: { runId: string; stepId: string; status: "SUCCEEDED" | "FAILED" }) => void) | undefined;
+    useAutomationRunRealtimeMock.mockImplementation((options: { onRunStepUpdated?: typeof onRunStepUpdated }) => {
+      onRunStepUpdated = options.onRunStepUpdated;
+      return { isConnected: true };
+    });
+
+    render(
+      <AutomationDetailLive
+        automationId="aut-1"
+        initialRuns={[
+          {
+            id: "run-1",
+            automationId: "aut-1",
+            status: "RUNNING",
+            triggerSource: "MANUAL",
+            triggerPayload: {},
+            contextSnapshot: {},
+            startedAt: "2026-04-23T00:00:00.000Z",
+            finishedAt: null,
+            durationMs: null,
+            errorCode: null,
+            errorMessage: null,
+            createdAt: "2026-04-23T00:00:00.000Z",
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByTestId("detail-reload-token")).toHaveTextContent("0");
+    onRunStepUpdated?.({ runId: "run-1", stepId: "step-1", status: "SUCCEEDED" });
+    expect(screen.getByTestId("detail-reload-token")).toHaveTextContent("1");
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试，确认先红**
+
+Run: `pnpm vitest run "src/components/automations/automation-run-log.test.tsx"`
+Expected: FAIL，`AutomationDetailLive` 还未管理 `detailReloadToken`。
+
+- [ ] **Step 3: 让详情页状态容器维护详情刷新 token**
+
+```tsx
+const [detailReloadToken, setDetailReloadToken] = useState(0);
+
+const handleRunUpdated = useCallback((run: AutomationRunItem) => {
+  setRuns((current) => upsertRun(current, run));
+  if (run.status === "SUCCEEDED" || run.status === "FAILED") {
+    setDetailReloadToken((current) => current + 1);
+  }
+  // keep existing toast logic
+}, []);
+
+useAutomationRunRealtime({
+  automationId,
+  onRunCreated: (run) => setRuns((current) => upsertRun(current, run)),
+  onRunUpdated: handleRunUpdated,
+  onRunStepUpdated: () => {
+    setDetailReloadToken((current) => current + 1);
+  },
+});
+
+return (
+  <div className="space-y-4">
+    <AutomationRunActions automationId={automationId} />
+    <AutomationRunLog
+      items={runs}
+      helperText={helperText}
+      detailReloadToken={detailReloadToken}
+    />
+  </div>
+);
+```
+
+- [ ] **Step 4: 跑模块回归，确保自动化详情页行为收敛**
+
+Run:
+- `pnpm vitest run "src/lib/services/automation-run.service.test.ts" "src/lib/services/automation-realtime.service.test.ts"`
+- `pnpm vitest run "src/app/api/automations/[id]/realtime/route.test.ts" "src/app/api/automations/[id]/run/route.test.ts"`
+- `pnpm vitest run "src/hooks/use-automation-run-realtime.test.ts" "src/components/automations/automation-run-actions.test.tsx" "src/components/automations/automation-run-log.test.tsx"`
+
+Expected: PASS，自动化模块的服务、路由、Hook、组件测试全部通过。
+
+- [ ] **Step 5: 运行 lint 和类型检查**
+
+Run:
+- `pnpm eslint "src/types/automation-realtime.ts" "src/lib/services/automation-realtime.service.ts" "src/lib/services/automation-run.service.ts" "src/app/api/automations/[id]/realtime/route.ts" "src/hooks/use-automation-run-realtime.ts" "src/components/automations/automation-detail-live.tsx" "src/components/automations/automation-run-actions.tsx" "src/components/automations/automation-run-log.tsx"`
+- `npx tsc --noEmit`
+
+Expected:
+- ESLint 无报错
+- TypeScript 无报错
+
+- [ ] **Step 6: 手工验证页面行为**
+
+Run: `npm run dev`
+Expected:
+- 打开 `/automations/<id>`
+- 点击“手动运行”后立即看到成功提示
+- 列表中出现新的 `PENDING` / `RUNNING` 记录
+- 运行结束后 badge 自动切到 `SUCCEEDED` 或 `FAILED`
+- 展开详情时，在步骤推进后详情会自动刷新
+
+- [ ] **Step 7: 提交本任务**
+
+```bash
+git add "src/components/automations/automation-detail-live.tsx" \
+  "src/components/automations/automation-run-log.test.tsx"
+git commit -m "feat(automation): refresh run detail on realtime step updates"
+```
+
+---
+
+## Self-Review
+
+### Spec coverage
+
+- SSE 实时链路：Task 1, Task 2
+- 详情页自动更新：Task 3, Task 4, Task 5
+- 手动触发即时反馈：Task 4
+- 失败与完成提示：Task 3, Task 4
+- 展开详情自动刷新：Task 4, Task 5
+
+没有遗漏项。
+
+### Placeholder scan
+
+- 已检查全文，没有 `TODO`、`TBD`、`implement later` 一类占位词
+- 所有代码步骤都提供了明确代码块
+- 所有验证步骤都有具体命令
+
+### Type consistency
+
+- SSE 事件文件统一使用 `AutomationRealtimeEvent`
+- Hook 统一分发 `onRunCreated` / `onRunUpdated` / `onRunStepUpdated`
+- 详情页状态容器统一使用 `detailReloadToken`
+
+命名一致，没有前后漂移。

--- a/docs/superpowers/specs/2026-04-23-automation-run-realtime-design.md
+++ b/docs/superpowers/specs/2026-04-23-automation-run-realtime-design.md
@@ -1,0 +1,578 @@
+# Issue #138 自动化运行实时反馈设计
+
+## 背景
+
+`#118` 已经交付自动化定义、运行队列、运行日志和手动触发入口，`#137` 补齐了“更新关联记录”动作能力。当前自动化详情页仍然是静态查看模式：
+
+- 手动触发调用 `/api/automations/[id]/run` 后，只返回 `runId`
+- 前端通过 `router.refresh()` 被动刷新页面
+- 运行日志列表在页面首次渲染后不再自动更新
+- 用户无法实时看到 `PENDING -> RUNNING -> SUCCEEDED | FAILED` 的状态变化
+
+这会直接导致两个体验问题：
+
+1. 用户点击“手动运行”后，页面反馈弱，容易误判为没有生效
+2. 自动化运行完成或失败后，用户必须手动刷新才能看到结果
+
+`#138` 的目标是为“自动化详情页”补上最小闭环的实时反馈链路，而不是建设全站通知中心。
+
+## 范围
+
+本期必须支持：
+
+- 自动化详情页建立实时订阅链路
+- 手动触发后，页面立即给出运行已创建反馈
+- 最新运行状态在详情页内自动更新
+- 最新运行记录自动插入日志列表顶部
+- 运行成功和失败给出即时前端提示
+- 已展开的运行详情在步骤变化后能自动刷新
+
+本期明确不做：
+
+- 全站通知中心联动
+- 自动化结果写入 `Notification` 并驱动未读数变化
+- 邮件、IM、Webhook 之外的外部推送
+- 跨页面、跨模块的全局自动化状态广播
+- 自动化列表页实时刷新
+
+## 设计原则
+
+- 只解决自动化详情页当前缺口，不顺手扩成通用通知系统
+- 实时链路复用现有数据表 SSE 的技术路线，避免引入第二种前后端协议
+- 运行状态变更必须以服务端状态为准，前端只做增量合并，不自行推测最终结果
+- 前端实时联动必须容忍 SSE 中断，断链后仍可通过手动刷新恢复
+
+## 方案对比
+
+### 方案 A：前端短轮询
+
+做法：
+
+- 手动触发后启动 `setInterval`
+- 周期请求 `/api/automations/[id]/runs`
+- 直到最新 run 进入终态停止轮询
+
+优点：
+
+- 实现简单
+- 后端几乎不用改
+
+缺点：
+
+- 不是真实时
+- 轮询会重复拉取整个列表
+- 很难优雅支持“已展开 run 详情增量刷新”
+- 只能覆盖“手动触发后”的场景，无法自然覆盖事件触发或定时触发带来的新运行
+
+结论：
+
+- 可作为兜底思路，不作为本期主方案
+
+### 方案 B：自动化专用 SSE
+
+做法：
+
+- 新增自动化详情页专用 SSE 路由 `/api/automations/[id]/realtime`
+- 自动化运行状态变化时发布事件
+- 前端使用 `EventSource` 订阅并增量更新运行列表
+
+优点：
+
+- 与现有数据表 realtime 技术栈一致
+- 实时性好
+- 事件语义清晰，适配运行创建、状态更新、步骤更新
+- 能自然覆盖手动触发、事件触发、定时触发三种来源
+
+缺点：
+
+- 需要新增自动化实时事件模型和订阅路由
+- 需要在运行服务里补发布逻辑
+
+结论：
+
+- 这是本期推荐方案
+
+### 方案 C：复用站内通知中心
+
+做法：
+
+- 自动化完成或失败时写入 `Notification`
+- 前端通过通知中心展示结果
+
+优点：
+
+- 复用已有通知持久化模型
+
+缺点：
+
+- 通知适合“消息”，不适合表达连续状态流
+- 不能自然表达 `PENDING -> RUNNING -> SUCCEEDED`
+- 会把本期范围扩大到通知中心交互设计
+
+结论：
+
+- 不采用
+
+## 最终方案
+
+采用方案 B：自动化专用 SSE + 自动化详情页增量更新。
+
+整体路径如下：
+
+1. 用户打开自动化详情页
+2. 前端对当前 `automationId` 建立 SSE 连接
+3. 手动触发时，接口立即返回 `runId`
+4. 后端创建 `AutomationRun`、开始执行、步骤更新、结束执行时发布实时事件
+5. 前端订阅到事件后更新运行列表和提示状态
+6. 若当前展开的运行详情受影响，则重新拉取该 run 的详情
+
+## 架构设计
+
+系统增加三个部分：
+
+1. 自动化实时事件类型
+2. 自动化 SSE 订阅 API
+3. 自动化详情页实时 Hook
+
+沿用现有数据表 realtime 的模式：
+
+- 后端仍基于 `ReadableStream + text/event-stream`
+- 服务层继续以状态变更为中心
+- 前端继续使用 `EventSource`
+
+但自动化事件与数据表事件解耦，不混入 `src/types/realtime.ts` 当前的数据表事件模型里，避免不同业务域的事件 union 持续膨胀。
+
+## 事件模型
+
+新增文件：
+
+- `src/types/automation-realtime.ts`
+
+定义事件：
+
+```ts
+type AutomationRealtimeEvent =
+  | {
+      type: "automation_run_created";
+      automationId: string;
+      run: AutomationRunItem;
+    }
+  | {
+      type: "automation_run_updated";
+      automationId: string;
+      run: AutomationRunItem;
+    }
+  | {
+      type: "automation_run_step_updated";
+      automationId: string;
+      runId: string;
+      stepId: string;
+      status: AutomationRunStepStatus;
+    };
+```
+
+说明：
+
+- `automation_run_created`
+  - 新 run 已落库，可直接插入列表顶部
+- `automation_run_updated`
+  - run 主状态变化，例如 `RUNNING`、`SUCCEEDED`、`FAILED`
+  - 使用完整 `AutomationRunItem` 作为 payload，前端无需再做字段级拼装
+- `automation_run_step_updated`
+  - 只表达某个步骤状态发生变化
+  - 前端收到后，如果该 run 正在展开详情，则重新请求 `/api/automations/runs/[runId]`
+
+本期不额外设计“步骤完整对象”事件，原因：
+
+- 运行详情面板当前本来就是按需拉取
+- 只为单个展开 run 做 detail refetch 更简单
+- 避免把步骤详情和主列表状态绑成一个更重的实时载荷
+
+## 后端设计
+
+### 1. 自动化实时发布服务
+
+新增：
+
+- `src/lib/services/automation-realtime.service.ts`
+
+职责：
+
+- 按 `automationId` 维护内存监听器集合
+- 懒加载 PostgreSQL `LISTEN/NOTIFY`
+- 发布和订阅自动化运行事件
+
+为什么不直接复用 `src/lib/services/realtime-notify.service.ts`：
+
+- 当前实现的 topic 语义是 `tableId`
+- 当前事件模型严格绑定 `RealtimeEvent`
+- 若直接硬改为“全局泛型 pub/sub”，会把本期范围扩到已有数据表实时链路重构
+
+本期采取更稳妥的做法：
+
+- 复制现有 realtime 实现模式
+- 但独立为自动化域服务
+- 等未来确实出现第三个实时业务域，再抽象共享底层
+
+这符合 YAGNI，也能保证 `#138` 的交付风险最小。
+
+### 2. SSE 路由
+
+新增路由：
+
+- `src/app/api/automations/[id]/realtime/route.ts`
+
+行为：
+
+- 校验登录态
+- 校验自动化是否属于当前用户
+- 建立 `EventSource` 连接
+- 订阅当前 `automationId` 的实时事件
+- 输出：
+  - `connected`
+  - `heartbeat`
+  - `AutomationRealtimeEvent`
+
+返回头保持与数据表 realtime 一致：
+
+- `Content-Type: text/event-stream`
+- `Cache-Control: no-cache, no-transform`
+- `Connection: keep-alive`
+- `X-Accel-Buffering: no`
+
+### 3. 运行服务发布点
+
+在以下服务方法中补事件发布：
+
+- `createAutomationRun`
+  - 发布 `automation_run_created`
+- `markAutomationRunStarted`
+  - 发布 `automation_run_updated`
+- `markAutomationRunSucceeded`
+  - 发布 `automation_run_updated`
+- `markAutomationRunFailed`
+  - 发布 `automation_run_updated`
+- `markAutomationRunStepSucceeded`
+  - 发布 `automation_run_step_updated`
+- `markAutomationRunStepFailed`
+  - 发布 `automation_run_step_updated`
+
+这里有一个关键约束：
+
+- 发布事件必须在数据库更新成功之后进行
+- 事件 payload 需要包含更新后的 run 状态
+
+因此，`markAutomationRunStarted / Succeeded / Failed` 需要在 update 后重新拿到最新 row，或直接让 Prisma `update` 返回必要字段，再映射为 `AutomationRunItem`。
+
+### 4. 权限边界
+
+自动化实时订阅只允许自动化创建者访问：
+
+- 与现有 `getAutomation`、`listAutomationRuns` 的权限模型一致
+- 不在本期扩展团队共享或管理员旁路查看
+
+## 前端设计
+
+### 1. 新增 Hook
+
+新增：
+
+- `src/hooks/use-automation-run-realtime.ts`
+
+输入：
+
+```ts
+{
+  automationId: string;
+  enabled?: boolean;
+  onRunCreated?: (run: AutomationRunItem) => void;
+  onRunUpdated?: (run: AutomationRunItem) => void;
+  onRunStepUpdated?: (event: { runId: string; stepId: string; status: AutomationRunStepStatus }) => void;
+}
+```
+
+输出：
+
+```ts
+{
+  isConnected: boolean;
+}
+```
+
+职责：
+
+- 建立和关闭 SSE
+- 解析事件
+- 向组件回调分发
+- 暴露连接状态，便于页面展示“实时连接中 / 已断开”
+
+### 2. 自动化详情页状态提升
+
+当前 `AutomationDetailPage` 是服务端组件，直接把 `runItems` 传给 `AutomationRunLog`。
+
+本期调整为：
+
+- 保留服务端首屏拉取，保证 SEO 与首次渲染可用
+- 新增一个客户端包装组件，例如：
+  - `src/components/automations/automation-detail-live.tsx`
+
+该组件负责：
+
+- 接收服务端初始 `runItems`
+- 在客户端维护 `runs` 状态
+- 建立 `useAutomationRunRealtime`
+- 将实时更新后的 `runs` 传给 `AutomationRunLog`
+- 为 `AutomationRunActions` 提供 `onRunQueued` 之类的回调
+
+这样可以避免直接把 `AutomationRunLog` 的实时状态管理继续堆大。
+
+### 3. 手动触发交互
+
+`AutomationRunActions` 改造目标：
+
+- 手动触发成功后立即提示：
+  - `已创建运行任务 <runId>`
+- 使用 `toast.success` / `toast.error` 作为主反馈
+- 保留页内文案作为次级反馈或改为单一 `toast`，二选一中推荐 `toast`
+- 不再依赖 `router.refresh()` 作为主要状态刷新手段
+
+具体行为：
+
+- 调用 `/api/automations/[id]/run`
+- 拿到 `runId`
+- 立即调用 `onRunQueued(runId)`，给页面一个“本地已创建”的短反馈
+- 真正的 run 列表插入以 SSE 的 `automation_run_created` 为准
+
+为什么不在前端收到 `runId` 后直接乐观插入一条伪 run：
+
+- 当前接口只返回 `runId`，不返回完整 run 对象
+- 伪造一条 run 会带来时间、状态、triggerPayload 等字段不一致问题
+- 让 SSE 作为唯一事实来源更稳妥
+
+### 4. 运行日志列表联动
+
+`AutomationRunLog` 需要支持两类变化：
+
+#### 新运行插入
+
+- 收到 `automation_run_created`
+- 若列表中不存在该 `run.id`，插入顶部
+- 若列表已有该 `run.id`，执行覆盖更新
+
+#### 主状态更新
+
+- 收到 `automation_run_updated`
+- 按 `run.id` 替换对应项
+- 若状态从非终态进入终态：
+  - `SUCCEEDED` 显示成功提示
+  - `FAILED` 显示失败提示
+
+### 5. 已展开详情刷新
+
+当前 `AutomationRunLog` 内部维护：
+
+- `expandedRunId`
+- `detailMap`
+
+本期保持这个结构，不额外上提详情状态。
+
+新增逻辑：
+
+- 收到 `automation_run_step_updated`
+- 如果 `expandedRunId === event.runId`
+  - 清空该 `runId` 的 detail cache
+  - 触发一次重新拉取详情
+
+收到 `automation_run_updated` 时：
+
+- 如果当前展开的 run 状态变化为 `FAILED` 或 `SUCCEEDED`
+  - 同样触发一次详情重新拉取
+
+这样可以保证：
+
+- 列表是增量实时更新的
+- 详情仍然走现有详情接口
+- 不需要实时同步整个 step 列表
+
+## UI 行为定义
+
+### 连接状态
+
+自动化详情页可选展示一个低优先级状态提示：
+
+- 已连接：不显式提示，保持安静
+- 已断开：展示一行弱提示，例如“实时连接已断开，状态可能不是最新”
+
+本期不做自动重连 UI 控件，`EventSource` 的浏览器默认重连足够。
+
+### 手动触发
+
+- 点击后按钮进入 pending
+- 接口成功：`toast.success("已创建运行任务")`
+- 接口失败：`toast.error("触发自动化失败")`
+
+### 运行完成提示
+
+- `RUNNING -> SUCCEEDED`
+  - `toast.success("自动化运行成功")`
+- `RUNNING -> FAILED`
+  - `toast.error(errorMessage ?? "自动化运行失败")`
+
+为避免重复提示，客户端只对“当前页面会话期间首次观察到的状态跃迁”弹提示，不对首屏已有终态 run 补弹。
+
+## 数据流
+
+### 手动触发场景
+
+```text
+用户点击手动运行
+  -> POST /api/automations/[id]/run
+  -> createAutomationRun()
+  -> publish automation_run_created
+  -> enqueue queue job
+  -> 前端 SSE 收到 created，插入日志列表
+  -> markAutomationRunStarted()
+  -> publish automation_run_updated(status=RUNNING)
+  -> 执行动作步骤
+  -> markAutomationRunStepSucceeded/Failed()
+  -> publish automation_run_step_updated
+  -> markAutomationRunSucceeded/Failed()
+  -> publish automation_run_updated(status=SUCCEEDED|FAILED)
+```
+
+### 页面更新场景
+
+```text
+AutomationDetailLive
+  -> useAutomationRunRealtime
+  -> runs state updated
+  -> AutomationRunLog re-render
+  -> 若展开 run 被步骤事件命中，重新 fetch /api/automations/runs/[runId]
+```
+
+## 错误处理
+
+### SSE 连接失败
+
+- Hook 将 `isConnected` 设为 `false`
+- 页面显示弱提示
+- 用户仍可手动刷新页面恢复
+
+### 事件解析失败
+
+- 忽略单条异常事件
+- 不中断整条连接
+
+### 详情刷新失败
+
+- 保留 `AutomationRunLog` 现有错误态
+- 不影响主列表继续实时更新
+
+### 服务端发布失败
+
+- 不影响 run 落库和执行
+- 只损失当前实时可见性
+- 用户刷新页面后仍能看到最终结果
+
+这意味着：实时事件是增强能力，不是运行正确性的依赖项。
+
+## 测试策略
+
+### 服务层测试
+
+新增测试：
+
+- `src/lib/services/automation-realtime.service.test.ts`
+  - 订阅 / 发布 / 取消订阅
+- `src/lib/services/automation-run.service.test.ts`
+  - 创建 run 时发布 `automation_run_created`
+  - run 状态更新时发布 `automation_run_updated`
+  - step 状态更新时发布 `automation_run_step_updated`
+
+### 路由测试
+
+新增：
+
+- `src/app/api/automations/[id]/realtime/route.test.ts`
+
+覆盖：
+
+- 未登录返回 `401`
+- 非自动化所有者返回 `404`
+- 建立 SSE 时写出 `connected`
+
+### 前端测试
+
+新增：
+
+- `src/hooks/use-automation-run-realtime.test.ts`
+  - 正确解析 `created / updated / step_updated`
+- `src/components/automations/automation-run-actions.test.tsx`
+  - 手动触发成功后提示成功
+  - 手动触发失败后提示错误
+- `src/components/automations/automation-run-log.test.tsx`
+  - 收到 run created 时插入新记录
+  - 收到 run updated 时更新 badge
+  - 收到 step updated 且当前 run 已展开时，触发详情刷新
+
+### 验证命令
+
+```bash
+pnpm vitest run "src/lib/services/automation-run.service.test.ts" "src/app/api/automations/[id]/realtime/route.test.ts" "src/components/automations"
+pnpm eslint "src/components/automations" "src/hooks/use-automation-run-realtime.ts" "src/app/api/automations/[id]/realtime/route.ts" "src/lib/services/automation-realtime.service.ts" "src/lib/services/automation-run.service.ts"
+npx tsc --noEmit
+```
+
+## 实施顺序
+
+1. 定义自动化实时事件类型
+2. 新增自动化 realtime service 与 SSE route
+3. 在 automation-run service 中补发布点
+4. 新增客户端实时 hook
+5. 增加自动化详情页客户端包装组件
+6. 改造 `AutomationRunActions`
+7. 改造 `AutomationRunLog` 的实时增量更新能力
+8. 补齐测试并跑通 lint / typecheck
+
+## 风险与取舍
+
+### 风险 1：重复发布或重复提示
+
+原因：
+
+- SSE 重连后，客户端可能重新收到后续状态事件
+
+控制方式：
+
+- 运行列表按 `run.id` 覆盖更新，不按数组 append
+- 提示逻辑基于“前一个状态 -> 新状态”的跃迁判断
+
+### 风险 2：详情刷新过于频繁
+
+原因：
+
+- 每次步骤事件都可能触发详情请求
+
+控制方式：
+
+- 只对当前展开的 `runId` 刷新详情
+- 本期动作链是串行执行，步骤频率有限，可接受
+
+### 风险 3：新增第二套 realtime service
+
+原因：
+
+- 自动化和数据表各有一个 realtime 服务
+
+取舍：
+
+- 当前两个业务域的 topic 和 payload 差异足够大
+- 立即抽象底层泛型 pub/sub 会扩大改动面
+- 先独立实现，后续若再出现第三类实时业务，再统一抽象
+
+## 验收标准
+
+- 手动触发后，前端能实时看到状态从 `PENDING/RUNNING` 变为 `SUCCEEDED/FAILED`
+- 自动化详情页无需手动刷新即可看到新运行记录
+- 失败场景下用户能收到即时反馈
+- SSE 断开不影响运行正确性，刷新页面后仍能看到真实状态

--- a/src/app/(dashboard)/automations/[id]/page.tsx
+++ b/src/app/(dashboard)/automations/[id]/page.tsx
@@ -2,8 +2,7 @@ import { notFound } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { AutomationEditor } from "@/components/automations/automation-editor";
-import { AutomationRunLog } from "@/components/automations/automation-run-log";
-import { AutomationRunActions } from "@/components/automations/automation-run-actions";
+import { AutomationDetailLive } from "@/components/automations/automation-detail-live";
 import { getAutomation } from "@/lib/services/automation.service";
 import type { AutomationRunItem } from "@/types/automation";
 
@@ -56,7 +55,10 @@ export default async function AutomationDetailPage({
           编辑触发器、条件分支和动作执行顺序。当前为第一期受限画布模式。
         </p>
         <div className="mt-4">
-          <AutomationRunActions automationId={result.data.id} />
+          <AutomationDetailLive
+            automationId={result.data.id}
+            initialRuns={runItems}
+          />
         </div>
       </div>
 
@@ -69,8 +71,6 @@ export default async function AutomationDetailPage({
         initialTableId={result.data.tableId}
         initialValue={result.data.definition}
       />
-
-      <AutomationRunLog items={runItems} />
     </div>
   );
 }

--- a/src/app/api/automations/[id]/realtime/route.test.ts
+++ b/src/app/api/automations/[id]/realtime/route.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authMock = vi.fn();
+const getAutomationMock = vi.fn();
+const subscribeToAutomationMock = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  auth: authMock,
+}));
+
+vi.mock("@/lib/services/automation.service", () => ({
+  getAutomation: getAutomationMock,
+}));
+
+vi.mock("@/lib/services/automation-realtime.service", () => ({
+  subscribeToAutomation: subscribeToAutomationMock,
+}));
+
+describe("api/automations/[id]/realtime route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    authMock.mockResolvedValue(null);
+    const { GET } = await import("./route");
+
+    const response = await GET({ signal: new AbortController().signal } as never, {
+      params: Promise.resolve({ id: "aut-1" }),
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("streams a connected event for an owned automation", async () => {
+    authMock.mockResolvedValue({ user: { id: "user-1" } });
+    getAutomationMock.mockResolvedValue({
+      success: true,
+      data: { id: "aut-1", name: "同步作者信息" },
+    });
+    subscribeToAutomationMock.mockReturnValue(() => undefined);
+    const { GET } = await import("./route");
+    const controller = new AbortController();
+
+    const response = await GET({ signal: controller.signal } as never, {
+      params: Promise.resolve({ id: "aut-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toContain("text/event-stream");
+  });
+});

--- a/src/app/api/automations/[id]/realtime/route.ts
+++ b/src/app/api/automations/[id]/realtime/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest } from "next/server";
+import { auth } from "@/lib/auth";
+import { getAutomation } from "@/lib/services/automation.service";
+import { subscribeToAutomation } from "@/lib/services/automation-realtime.service";
+import type { AutomationRealtimeEvent } from "@/types/automation-realtime";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const { id: automationId } = await params;
+  const automation = await getAutomation(automationId, session.user.id);
+  if (!automation.success) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(
+        encoder.encode(
+          `data: ${JSON.stringify({ type: "connected", automationId })}\n\n`
+        )
+      );
+
+      const unsubscribe = subscribeToAutomation(
+        automationId,
+        (event: AutomationRealtimeEvent) => {
+          try {
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+          } catch {
+            // stream already closed
+          }
+        }
+      );
+
+      const heartbeat = setInterval(() => {
+        try {
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({ type: "heartbeat", ts: Date.now() })}\n\n`
+            )
+          );
+        } catch {
+          clearInterval(heartbeat);
+        }
+      }, 30000);
+
+      request.signal.addEventListener("abort", () => {
+        unsubscribe();
+        clearInterval(heartbeat);
+        try {
+          controller.close();
+        } catch {
+          // already closed
+        }
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/src/app/api/automations/route.test.ts
+++ b/src/app/api/automations/route.test.ts
@@ -103,4 +103,47 @@ describe("api/automations route", () => {
     });
     expect(body.success).toBe(true);
   });
+
+  it("POST 应接受空描述创建自动化", async () => {
+    authMock.mockResolvedValue({ user: { id: "user-1" } });
+    createAutomationMock.mockResolvedValue({
+      success: true,
+      data: { id: "aut-1", name: "新自动化" },
+    });
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      new Request("http://localhost/api/automations", {
+        method: "POST",
+        body: JSON.stringify({
+          tableId: "tbl-1",
+          name: "新自动化",
+          description: null,
+          enabled: true,
+          triggerType: "manual",
+          definition: {
+            version: 1,
+            canvas: {
+              nodes: [{ id: "trigger-1", type: "trigger", x: 0, y: 0 }],
+              edges: [],
+            },
+            trigger: { type: "manual" },
+            condition: null,
+            thenActions: [],
+            elseActions: [],
+          },
+        }),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }) as never
+    );
+
+    expect(response.status).toBe(201);
+    expect(createAutomationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({ description: null }),
+      })
+    );
+  });
 });

--- a/src/components/automations/automation-detail-live.test.tsx
+++ b/src/components/automations/automation-detail-live.test.tsx
@@ -1,0 +1,75 @@
+import { act, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AutomationDetailLive } from "@/components/automations/automation-detail-live";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/components/automations/automation-run-actions", () => ({
+  AutomationRunActions: ({ automationId }: { automationId: string }) => (
+    <div data-testid="run-actions">{automationId}</div>
+  ),
+}));
+
+vi.mock("@/components/automations/automation-run-log", () => ({
+  AutomationRunLog: ({
+    detailReloadToken,
+  }: {
+    detailReloadToken?: number;
+  }) => <div data-testid="detail-reload-token">{detailReloadToken ?? 0}</div>,
+}));
+
+const useAutomationRunRealtimeMock = vi.fn();
+
+vi.mock("@/hooks/use-automation-run-realtime", () => ({
+  useAutomationRunRealtime: (options: unknown) => useAutomationRunRealtimeMock(options),
+}));
+
+describe("AutomationDetailLive", () => {
+  it("increments detail reload token when a step update arrives", () => {
+    let onRunStepUpdated:
+      | ((event: { runId: string; stepId: string; status: "SUCCEEDED" | "FAILED" }) => void)
+      | undefined;
+
+    useAutomationRunRealtimeMock.mockImplementation(
+      (options: {
+        onRunStepUpdated?: typeof onRunStepUpdated;
+      }) => {
+        onRunStepUpdated = options.onRunStepUpdated;
+        return { isConnected: true };
+      }
+    );
+
+    render(
+      <AutomationDetailLive
+        automationId="aut-1"
+        initialRuns={[
+          {
+            id: "run-1",
+            automationId: "aut-1",
+            status: "RUNNING",
+            triggerSource: "MANUAL",
+            triggerPayload: {},
+            contextSnapshot: {},
+            startedAt: "2026-04-23T00:00:00.000Z",
+            finishedAt: null,
+            durationMs: null,
+            errorCode: null,
+            errorMessage: null,
+            createdAt: "2026-04-23T00:00:00.000Z",
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByTestId("detail-reload-token")).toHaveTextContent("0");
+    act(() => {
+      onRunStepUpdated?.({ runId: "run-1", stepId: "step-1", status: "SUCCEEDED" });
+    });
+    expect(screen.getByTestId("detail-reload-token")).toHaveTextContent("1");
+  });
+});

--- a/src/components/automations/automation-detail-live.tsx
+++ b/src/components/automations/automation-detail-live.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { AutomationRunActions } from "@/components/automations/automation-run-actions";
+import { AutomationRunLog } from "@/components/automations/automation-run-log";
+import { useAutomationRunRealtime } from "@/hooks/use-automation-run-realtime";
+import type { AutomationRunItem } from "@/types/automation";
+
+type AutomationDetailLiveProps = {
+  automationId: string;
+  initialRuns: AutomationRunItem[];
+};
+
+function upsertRun(items: AutomationRunItem[], nextRun: AutomationRunItem): AutomationRunItem[] {
+  const existingIndex = items.findIndex((item) => item.id === nextRun.id);
+  if (existingIndex === -1) {
+    return [nextRun, ...items].slice(0, 10);
+  }
+
+  const nextItems = [...items];
+  nextItems[existingIndex] = nextRun;
+  return nextItems;
+}
+
+export function AutomationDetailLive({
+  automationId,
+  initialRuns,
+}: AutomationDetailLiveProps) {
+  const [runs, setRuns] = useState(initialRuns);
+  const seenTerminalRef = useRef(new Set<string>());
+  const [connectionHint, setConnectionHint] = useState<string | null>(null);
+
+  const handleRunUpdated = useCallback((run: AutomationRunItem) => {
+    setRuns((current) => upsertRun(current, run));
+
+    const isTerminal = run.status === "SUCCEEDED" || run.status === "FAILED";
+    if (!isTerminal || seenTerminalRef.current.has(run.id)) {
+      return;
+    }
+
+    seenTerminalRef.current.add(run.id);
+    if (run.status === "SUCCEEDED") {
+      toast.success("自动化运行成功");
+      return;
+    }
+
+    toast.error(run.errorMessage ?? "自动化运行失败");
+  }, []);
+
+  const realtime = useAutomationRunRealtime({
+    automationId,
+    onRunCreated: (run) => setRuns((current) => upsertRun(current, run)),
+    onRunUpdated: handleRunUpdated,
+  });
+
+  useEffect(() => {
+    if (realtime.isConnected) {
+      setConnectionHint(null);
+      return;
+    }
+
+    setConnectionHint("实时连接已断开，状态可能不是最新。");
+  }, [realtime.isConnected]);
+
+  return (
+    <div className="space-y-4">
+      <AutomationRunActions automationId={automationId} />
+      {connectionHint ? (
+        <p className="text-xs text-muted-foreground">{connectionHint}</p>
+      ) : null}
+      <AutomationRunLog items={runs} />
+    </div>
+  );
+}

--- a/src/components/automations/automation-detail-live.tsx
+++ b/src/components/automations/automation-detail-live.tsx
@@ -30,12 +30,18 @@ export function AutomationDetailLive({
   const [runs, setRuns] = useState(initialRuns);
   const seenTerminalRef = useRef(new Set<string>());
   const [connectionHint, setConnectionHint] = useState<string | null>(null);
+  const [detailReloadToken, setDetailReloadToken] = useState(0);
 
   const handleRunUpdated = useCallback((run: AutomationRunItem) => {
     setRuns((current) => upsertRun(current, run));
 
     const isTerminal = run.status === "SUCCEEDED" || run.status === "FAILED";
-    if (!isTerminal || seenTerminalRef.current.has(run.id)) {
+    if (!isTerminal) {
+      return;
+    }
+
+    setDetailReloadToken((current) => current + 1);
+    if (seenTerminalRef.current.has(run.id)) {
       return;
     }
 
@@ -52,6 +58,9 @@ export function AutomationDetailLive({
     automationId,
     onRunCreated: (run) => setRuns((current) => upsertRun(current, run)),
     onRunUpdated: handleRunUpdated,
+    onRunStepUpdated: () => {
+      setDetailReloadToken((current) => current + 1);
+    },
   });
 
   useEffect(() => {
@@ -66,10 +75,11 @@ export function AutomationDetailLive({
   return (
     <div className="space-y-4">
       <AutomationRunActions automationId={automationId} />
-      {connectionHint ? (
-        <p className="text-xs text-muted-foreground">{connectionHint}</p>
-      ) : null}
-      <AutomationRunLog items={runs} />
+      <AutomationRunLog
+        items={runs}
+        helperText={connectionHint ?? undefined}
+        detailReloadToken={detailReloadToken}
+      />
     </div>
   );
 }

--- a/src/components/automations/automation-run-actions.test.tsx
+++ b/src/components/automations/automation-run-actions.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AutomationRunActions } from "@/components/automations/automation-run-actions";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("AutomationRunActions", () => {
+  it("calls onRunQueued after a successful manual run", async () => {
+    const onRunQueued = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          success: true,
+          data: { runId: "run-1" },
+        }),
+      })
+    );
+
+    render(<AutomationRunActions automationId="aut-1" onRunQueued={onRunQueued} />);
+    fireEvent.click(screen.getByRole("button", { name: "手动运行" }));
+
+    await waitFor(() => {
+      expect(onRunQueued).toHaveBeenCalledWith("run-1");
+    });
+  });
+});

--- a/src/components/automations/automation-run-actions.tsx
+++ b/src/components/automations/automation-run-actions.tsx
@@ -1,19 +1,25 @@
 "use client";
 
-import { useState, useTransition } from "react";
-import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { Loader2, PlayCircle } from "lucide-react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 
-export function AutomationRunActions({ automationId }: { automationId: string }) {
-  const router = useRouter();
-  const [pending, startTransition] = useTransition();
+type AutomationRunActionsProps = {
+  automationId: string;
+  onRunQueued?: (runId: string) => void;
+};
+
+export function AutomationRunActions({
+  automationId,
+  onRunQueued,
+}: AutomationRunActionsProps) {
+  const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   async function handleRun() {
+    setPending(true);
     setError(null);
-    setSuccessMessage(null);
 
     try {
       const response = await fetch(`/api/automations/${automationId}/run`, {
@@ -30,17 +36,19 @@ export function AutomationRunActions({ automationId }: { automationId: string })
       if (!response.ok) {
         const message = "error" in payload ? payload.error?.message : undefined;
         setError(message ?? "触发自动化失败");
+        toast.error(message ?? "触发自动化失败");
         return;
       }
 
       if ("success" in payload && payload.success) {
-        setSuccessMessage(`已创建运行任务 ${payload.data.runId}`);
+        onRunQueued?.(payload.data.runId);
+        toast.success(`已创建运行任务 ${payload.data.runId}`);
       }
-      startTransition(() => {
-        router.refresh();
-      });
     } catch {
       setError("触发自动化失败");
+      toast.error("触发自动化失败");
+    } finally {
+      setPending(false);
     }
   }
 
@@ -51,7 +59,6 @@ export function AutomationRunActions({ automationId }: { automationId: string })
         手动运行
       </Button>
       {error ? <p className="text-xs text-destructive">{error}</p> : null}
-      {successMessage ? <p className="text-xs text-emerald-600 dark:text-emerald-300">{successMessage}</p> : null}
     </div>
   );
 }

--- a/src/components/automations/automation-run-log.test.tsx
+++ b/src/components/automations/automation-run-log.test.tsx
@@ -82,4 +82,88 @@ describe("AutomationRunLog", () => {
     expect(screen.getByText("status")).toBeInTheDocument();
     expect(screen.getByText(/pending → failed/)).toBeInTheDocument();
   });
+
+  it("shows helper text and reloads detail when reloadToken changes", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          run: {
+            id: "run-1",
+            automationId: "aut-1",
+            status: "RUNNING",
+            triggerSource: "MANUAL",
+            triggerPayload: {},
+            contextSnapshot: {},
+            startedAt: "2026-04-23T00:00:00.000Z",
+            finishedAt: null,
+            durationMs: null,
+            errorCode: null,
+            errorMessage: null,
+            createdAt: "2026-04-23T00:00:00.000Z",
+          },
+          steps: [],
+        },
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { rerender } = render(
+      <AutomationRunLog
+        items={[
+          {
+            id: "run-1",
+            automationId: "aut-1",
+            status: "RUNNING",
+            triggerSource: "MANUAL",
+            triggerPayload: {},
+            contextSnapshot: {},
+            startedAt: "2026-04-23T00:00:00.000Z",
+            finishedAt: null,
+            durationMs: null,
+            errorCode: null,
+            errorMessage: null,
+            createdAt: "2026-04-23T00:00:00.000Z",
+          },
+        ]}
+        helperText="实时连接已断开"
+        detailReloadToken={0}
+      />
+    );
+
+    expect(screen.getByText("实时连接已断开")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "详情" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(
+      <AutomationRunLog
+        items={[
+          {
+            id: "run-1",
+            automationId: "aut-1",
+            status: "RUNNING",
+            triggerSource: "MANUAL",
+            triggerPayload: {},
+            contextSnapshot: {},
+            startedAt: "2026-04-23T00:00:00.000Z",
+            finishedAt: null,
+            durationMs: null,
+            errorCode: null,
+            errorMessage: null,
+            createdAt: "2026-04-23T00:00:00.000Z",
+          },
+        ]}
+        helperText="实时连接已断开"
+        detailReloadToken={1}
+      />
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/src/components/automations/automation-run-log.tsx
+++ b/src/components/automations/automation-run-log.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ChevronDown, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -109,20 +109,35 @@ function StepStatusBadge({ status }: { status: AutomationRunStepItem["status"] }
   return <Badge variant={variant}>{status}</Badge>;
 }
 
-export function AutomationRunLog({ items }: { items: AutomationRunItem[] }) {
+type AutomationRunLogProps = {
+  items: AutomationRunItem[];
+  helperText?: string;
+  detailReloadToken?: number;
+};
+
+export function AutomationRunLog({
+  items,
+  helperText,
+  detailReloadToken = 0,
+}: AutomationRunLogProps) {
   const [expandedRunId, setExpandedRunId] = useState<string | null>(null);
   const [detailMap, setDetailMap] = useState<Record<string, AutomationRunDetail | undefined>>({});
   const [loadingRunId, setLoadingRunId] = useState<string | null>(null);
   const [errorMap, setErrorMap] = useState<Record<string, string | undefined>>({});
+  const detailMapRef = useRef(detailMap);
+  const loadingRunIdRef = useRef(loadingRunId);
+  const lastReloadTokenRef = useRef(detailReloadToken);
 
-  async function handleToggle(runId: string) {
-    if (expandedRunId === runId) {
-      setExpandedRunId(null);
-      return;
-    }
+  useEffect(() => {
+    detailMapRef.current = detailMap;
+  }, [detailMap]);
 
-    setExpandedRunId(runId);
-    if (detailMap[runId] || loadingRunId === runId) {
+  useEffect(() => {
+    loadingRunIdRef.current = loadingRunId;
+  }, [loadingRunId]);
+
+  const loadRunDetail = useCallback(async (runId: string, force = false) => {
+    if (!force && (detailMapRef.current[runId] || loadingRunIdRef.current === runId)) {
       return;
     }
 
@@ -148,6 +163,25 @@ export function AutomationRunLog({ items }: { items: AutomationRunItem[] }) {
     } finally {
       setLoadingRunId(null);
     }
+  }, []);
+
+  useEffect(() => {
+    if (!expandedRunId || lastReloadTokenRef.current === detailReloadToken) {
+      return;
+    }
+
+    lastReloadTokenRef.current = detailReloadToken;
+    void loadRunDetail(expandedRunId, true);
+  }, [detailReloadToken, expandedRunId, loadRunDetail]);
+
+  async function handleToggle(runId: string) {
+    if (expandedRunId === runId) {
+      setExpandedRunId(null);
+      return;
+    }
+
+    setExpandedRunId(runId);
+    await loadRunDetail(runId);
   }
 
   return (
@@ -156,6 +190,9 @@ export function AutomationRunLog({ items }: { items: AutomationRunItem[] }) {
         <CardTitle className="text-base font-[520]">最近运行</CardTitle>
       </CardHeader>
       <CardContent>
+        {helperText ? (
+          <p className="mb-3 text-xs text-muted-foreground">{helperText}</p>
+        ) : null}
         {items.length === 0 ? (
           <div className="rounded-xl border border-dashed border-border/70 bg-background/50 px-4 py-10 text-center text-sm text-muted-foreground">
             还没有运行记录。执行手动触发或等待数据变更后，这里会展示每次运行状态。

--- a/src/hooks/use-automation-run-realtime.test.ts
+++ b/src/hooks/use-automation-run-realtime.test.ts
@@ -1,0 +1,58 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useAutomationRunRealtime } from "@/hooks/use-automation-run-realtime";
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  onopen: (() => void) | null = null;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  onerror: (() => void) | null = null;
+  close = vi.fn();
+
+  constructor(public url: string) {
+    MockEventSource.instances.push(this);
+  }
+}
+
+describe("useAutomationRunRealtime", () => {
+  it("creates an EventSource and forwards run update events", () => {
+    vi.stubGlobal("EventSource", MockEventSource as unknown as typeof EventSource);
+    const onRunUpdated = vi.fn();
+
+    renderHook(() =>
+      useAutomationRunRealtime({
+        automationId: "aut-1",
+        onRunUpdated,
+      })
+    );
+
+    const instance = MockEventSource.instances[0];
+    instance.onmessage?.(
+      new MessageEvent("message", {
+        data: JSON.stringify({
+          type: "automation_run_updated",
+          automationId: "aut-1",
+          run: {
+            id: "run-1",
+            automationId: "aut-1",
+            status: "RUNNING",
+            triggerSource: "MANUAL",
+            triggerPayload: {},
+            contextSnapshot: {},
+            startedAt: "2026-04-23T00:00:00.000Z",
+            finishedAt: null,
+            durationMs: null,
+            errorCode: null,
+            errorMessage: null,
+            createdAt: "2026-04-23T00:00:00.000Z",
+          },
+        }),
+      })
+    );
+
+    expect(onRunUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "run-1", status: "RUNNING" })
+    );
+  });
+});

--- a/src/hooks/use-automation-run-realtime.ts
+++ b/src/hooks/use-automation-run-realtime.ts
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type {
+  AutomationRealtimeEvent,
+  AutomationRealtimeStreamEvent,
+} from "@/types/automation-realtime";
+import type { AutomationRunItem, AutomationRunStepStatus } from "@/types/automation";
+
+interface UseAutomationRunRealtimeOptions {
+  automationId: string;
+  enabled?: boolean;
+  onRunCreated?: (run: AutomationRunItem) => void;
+  onRunUpdated?: (run: AutomationRunItem) => void;
+  onRunStepUpdated?: (event: {
+    runId: string;
+    stepId: string;
+    status: AutomationRunStepStatus;
+  }) => void;
+}
+
+export function useAutomationRunRealtime({
+  automationId,
+  enabled = true,
+  onRunCreated,
+  onRunUpdated,
+  onRunStepUpdated,
+}: UseAutomationRunRealtimeOptions) {
+  const [isConnected, setIsConnected] = useState(false);
+  const callbacksRef = useRef({ onRunCreated, onRunUpdated, onRunStepUpdated });
+
+  useEffect(() => {
+    callbacksRef.current = { onRunCreated, onRunUpdated, onRunStepUpdated };
+  }, [onRunCreated, onRunUpdated, onRunStepUpdated]);
+
+  useEffect(() => {
+    if (!enabled || !automationId) {
+      return;
+    }
+
+    const eventSource = new EventSource(`/api/automations/${automationId}/realtime`);
+
+    eventSource.onopen = () => {
+      setIsConnected(true);
+    };
+
+    eventSource.onmessage = (event) => {
+      try {
+        const payload = JSON.parse(event.data) as AutomationRealtimeStreamEvent;
+        if (payload.type === "connected" || payload.type === "heartbeat") {
+          return;
+        }
+
+        const realtimeEvent = payload as AutomationRealtimeEvent;
+        if (realtimeEvent.type === "automation_run_created") {
+          callbacksRef.current.onRunCreated?.(realtimeEvent.run);
+          return;
+        }
+
+        if (realtimeEvent.type === "automation_run_updated") {
+          callbacksRef.current.onRunUpdated?.(realtimeEvent.run);
+          return;
+        }
+
+        callbacksRef.current.onRunStepUpdated?.({
+          runId: realtimeEvent.runId,
+          stepId: realtimeEvent.stepId,
+          status: realtimeEvent.status,
+        });
+      } catch {
+        // ignore malformed events
+      }
+    };
+
+    eventSource.onerror = () => {
+      setIsConnected(false);
+    };
+
+    return () => {
+      eventSource.close();
+      setIsConnected(false);
+    };
+  }, [automationId, enabled]);
+
+  return { isConnected };
+}

--- a/src/lib/services/automation-realtime.service.test.ts
+++ b/src/lib/services/automation-realtime.service.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { poolQueryMock } = vi.hoisted(() => ({
+  poolQueryMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  pool: {
+    query: poolQueryMock,
+  },
+}));
+
+describe("automation-realtime.service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("publishes an automation run update event through pg_notify", async () => {
+    const { publishAutomationRealtimeEvent } = await import(
+      "@/lib/services/automation-realtime.service"
+    );
+
+    await publishAutomationRealtimeEvent({
+      type: "automation_run_updated",
+      automationId: "aut-1",
+      run: {
+        id: "run-1",
+        automationId: "aut-1",
+        status: "RUNNING",
+        triggerSource: "MANUAL",
+        triggerPayload: {},
+        contextSnapshot: {},
+        startedAt: "2026-04-23T00:00:00.000Z",
+        finishedAt: null,
+        durationMs: null,
+        errorCode: null,
+        errorMessage: null,
+        createdAt: "2026-04-23T00:00:00.000Z",
+      },
+    });
+
+    expect(poolQueryMock).toHaveBeenCalledWith(expect.stringContaining("pg_notify"), [
+      "automation_run_events",
+      expect.stringContaining("\"automationId\":\"aut-1\""),
+    ]);
+  });
+
+  it("subscribes and unsubscribes listeners by automationId", async () => {
+    const { broadcastToAutomation, subscribeToAutomation } = await import(
+      "@/lib/services/automation-realtime.service"
+    );
+
+    const listener = vi.fn();
+    const unsubscribe = subscribeToAutomation("aut-1", listener);
+
+    broadcastToAutomation("aut-1", {
+      type: "automation_run_created",
+      automationId: "aut-1",
+      run: {
+        id: "run-1",
+        automationId: "aut-1",
+        status: "PENDING",
+        triggerSource: "MANUAL",
+        triggerPayload: {},
+        contextSnapshot: {},
+        startedAt: null,
+        finishedAt: null,
+        durationMs: null,
+        errorCode: null,
+        errorMessage: null,
+        createdAt: "2026-04-23T00:00:00.000Z",
+      },
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    broadcastToAutomation("aut-1", {
+      type: "automation_run_step_updated",
+      automationId: "aut-1",
+      runId: "run-1",
+      stepId: "step-1",
+      status: "SUCCEEDED",
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/services/automation-realtime.service.test.ts
+++ b/src/lib/services/automation-realtime.service.test.ts
@@ -10,6 +10,15 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
+vi.mock("pg", () => ({
+  Client: class MockClient {
+    connect = vi.fn().mockResolvedValue(undefined);
+    query = vi.fn().mockResolvedValue(undefined);
+    on = vi.fn();
+    end = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
 describe("automation-realtime.service", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/lib/services/automation-realtime.service.ts
+++ b/src/lib/services/automation-realtime.service.ts
@@ -1,0 +1,129 @@
+import { Client } from "pg";
+import { pool } from "@/lib/db";
+import type { AutomationRealtimeEvent } from "@/types/automation-realtime";
+
+type AutomationRealtimeListener = (event: AutomationRealtimeEvent) => void;
+
+const CHANNEL = "automation_run_events";
+const listeners = new Map<string, Set<AutomationRealtimeListener>>();
+let listenClient: Client | null = null;
+let initPromise: Promise<void> | null = null;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+function scheduleReconnect(): void {
+  if (reconnectTimer || listeners.size === 0) {
+    return;
+  }
+
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    void ensureListening();
+  }, 3000);
+}
+
+async function ensureListening(): Promise<void> {
+  if (listenClient) {
+    return;
+  }
+
+  if (initPromise) {
+    await initPromise;
+    return;
+  }
+
+  initPromise = (async () => {
+    const client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+    await client.query(`LISTEN ${CHANNEL}`);
+
+    client.on("notification", (msg) => {
+      if (!msg.payload) {
+        return;
+      }
+
+      try {
+        const event = JSON.parse(msg.payload) as AutomationRealtimeEvent;
+        const scopedListeners = listeners.get(event.automationId);
+        if (!scopedListeners) {
+          return;
+        }
+
+        for (const listener of scopedListeners) {
+          listener(event);
+        }
+      } catch {
+        // ignore malformed events
+      }
+    });
+
+    client.on("error", () => {
+      listenClient = null;
+      initPromise = null;
+      scheduleReconnect();
+    });
+
+    client.on("end", () => {
+      listenClient = null;
+      initPromise = null;
+      scheduleReconnect();
+    });
+
+    listenClient = client;
+  })();
+
+  await initPromise;
+}
+
+export async function publishAutomationRealtimeEvent(
+  event: AutomationRealtimeEvent
+): Promise<void> {
+  await pool.query(`SELECT pg_notify($1, $2)`, [CHANNEL, JSON.stringify(event)]);
+}
+
+export function subscribeToAutomation(
+  automationId: string,
+  listener: AutomationRealtimeListener
+): () => void {
+  if (!listeners.has(automationId)) {
+    listeners.set(automationId, new Set());
+  }
+
+  listeners.get(automationId)?.add(listener);
+  void ensureListening();
+
+  return () => {
+    const scopedListeners = listeners.get(automationId);
+    if (!scopedListeners) {
+      return;
+    }
+
+    scopedListeners.delete(listener);
+    if (scopedListeners.size === 0) {
+      listeners.delete(automationId);
+    }
+  };
+}
+
+export function broadcastToAutomation(
+  automationId: string,
+  event: AutomationRealtimeEvent
+): void {
+  const scopedListeners = listeners.get(automationId);
+  if (!scopedListeners) {
+    return;
+  }
+
+  for (const listener of scopedListeners) {
+    listener(event);
+  }
+}
+
+export function shutdownAutomationRealtime(): void {
+  if (listenClient) {
+    void listenClient.end();
+    listenClient = null;
+    initPromise = null;
+  }
+
+  listeners.clear();
+}

--- a/src/lib/services/automation-run.service.test.ts
+++ b/src/lib/services/automation-run.service.test.ts
@@ -8,10 +8,11 @@ import {
   getAutomationRunDetail,
   listAutomationRuns,
   markAutomationRunStarted,
+  markAutomationRunStepFailed,
   markAutomationRunSucceeded,
 } from "@/lib/services/automation-run.service";
 
-const { dbMock } = vi.hoisted(() => ({
+const { dbMock, publishAutomationRealtimeEventMock } = vi.hoisted(() => ({
   dbMock: {
     automation: {
       findFirst: vi.fn(),
@@ -29,10 +30,15 @@ const { dbMock } = vi.hoisted(() => ({
       update: vi.fn(),
     },
   },
+  publishAutomationRealtimeEventMock: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({
   db: dbMock,
+}));
+
+vi.mock("@/lib/services/automation-realtime.service", () => ({
+  publishAutomationRealtimeEvent: publishAutomationRealtimeEventMock,
 }));
 
 describe("automation-run.service", () => {
@@ -42,7 +48,22 @@ describe("automation-run.service", () => {
   });
 
   it("creates a pending automation run", async () => {
-    dbMock.automationRun.create.mockResolvedValue({ id: "run-1" });
+    dbMock.automationRun.create.mockResolvedValue({
+      id: "run-1",
+      automationId: "aut-1",
+      status: "PENDING",
+      triggerSource: "MANUAL",
+      triggerPayload: { source: "manual" },
+      contextSnapshot: {
+        tableId: "tbl-1",
+      },
+      startedAt: null,
+      finishedAt: null,
+      durationMs: null,
+      errorCode: null,
+      errorMessage: null,
+      createdAt: new Date("2026-04-22T00:00:00.000Z"),
+    });
 
     const result = await createAutomationRun({
       automationId: "aut-1",
@@ -74,12 +95,46 @@ describe("automation-run.service", () => {
           actor: { id: "user-1" },
         },
       },
-      select: { id: true },
+      select: expect.any(Object),
     });
+    expect(publishAutomationRealtimeEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "automation_run_created",
+        automationId: "aut-1",
+      })
+    );
   });
 
   it("marks a run started and then succeeded", async () => {
-    dbMock.automationRun.update.mockResolvedValue({ id: "run-1" });
+    dbMock.automationRun.update
+      .mockResolvedValueOnce({
+        id: "run-1",
+        automationId: "aut-1",
+        status: "RUNNING",
+        triggerSource: "MANUAL",
+        triggerPayload: {},
+        contextSnapshot: {},
+        startedAt: new Date("2026-04-22T00:00:00.000Z"),
+        finishedAt: null,
+        durationMs: null,
+        errorCode: null,
+        errorMessage: null,
+        createdAt: new Date("2026-04-22T00:00:00.000Z"),
+      })
+      .mockResolvedValueOnce({
+        id: "run-1",
+        automationId: "aut-1",
+        status: "SUCCEEDED",
+        triggerSource: "MANUAL",
+        triggerPayload: {},
+        contextSnapshot: {},
+        startedAt: new Date("2026-04-22T00:00:00.000Z"),
+        finishedAt: new Date("2026-04-22T00:00:01.000Z"),
+        durationMs: 1000,
+        errorCode: null,
+        errorMessage: null,
+        createdAt: new Date("2026-04-22T00:00:00.000Z"),
+      });
     dbMock.automationRun.findUnique.mockResolvedValue({
       startedAt: new Date("2026-04-22T00:00:00.000Z"),
     });
@@ -95,6 +150,7 @@ describe("automation-run.service", () => {
         status: "RUNNING",
         startedAt: expect.any(Date),
       },
+      select: expect.any(Object),
     });
     expect(dbMock.automationRun.update).toHaveBeenNthCalledWith(2, {
       where: { id: "run-1" },
@@ -103,6 +159,48 @@ describe("automation-run.service", () => {
         finishedAt: expect.any(Date),
         durationMs: expect.any(Number),
       },
+      select: expect.any(Object),
+    });
+    expect(publishAutomationRealtimeEventMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        type: "automation_run_updated",
+        automationId: "aut-1",
+        run: expect.objectContaining({ id: "run-1", status: "RUNNING" }),
+      })
+    );
+    expect(publishAutomationRealtimeEventMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        type: "automation_run_updated",
+        automationId: "aut-1",
+        run: expect.objectContaining({ id: "run-1", status: "SUCCEEDED" }),
+      })
+    );
+  });
+
+  it("publishes a step update after marking a step failed", async () => {
+    dbMock.automationRunStep.update.mockResolvedValue({
+      id: "step-1",
+      runId: "run-1",
+      status: "FAILED",
+      run: {
+        automationId: "aut-1",
+      },
+    });
+
+    const result = await markAutomationRunStepFailed("step-1", {
+      code: "ACTION_EXECUTION_FAILED",
+      message: "Webhook returned 500",
+    });
+
+    expect(result.success).toBe(true);
+    expect(publishAutomationRealtimeEventMock).toHaveBeenCalledWith({
+      type: "automation_run_step_updated",
+      automationId: "aut-1",
+      runId: "run-1",
+      stepId: "step-1",
+      status: "FAILED",
     });
   });
 
@@ -200,8 +298,55 @@ describe("automation-dispatcher.service", () => {
   });
 
   it("creates a pending run before execution", async () => {
-    dbMock.automationRun.create.mockResolvedValue({ id: "run-1" });
-    dbMock.automationRun.update.mockResolvedValue({ id: "run-1" });
+    dbMock.automationRun.create.mockResolvedValue({
+      id: "run-1",
+      automationId: "aut-1",
+      status: "PENDING",
+      triggerSource: "MANUAL",
+      triggerPayload: { source: "manual" },
+      contextSnapshot: {
+        tableId: "tbl-1",
+      },
+      startedAt: null,
+      finishedAt: null,
+      durationMs: null,
+      errorCode: null,
+      errorMessage: null,
+      createdAt: new Date("2026-04-22T00:00:00.000Z"),
+    });
+    dbMock.automationRun.update
+      .mockResolvedValueOnce({
+        id: "run-1",
+        automationId: "aut-1",
+        status: "RUNNING",
+        triggerSource: "MANUAL",
+        triggerPayload: { source: "manual" },
+        contextSnapshot: {
+          tableId: "tbl-1",
+        },
+        startedAt: new Date("2026-04-22T00:00:00.000Z"),
+        finishedAt: null,
+        durationMs: null,
+        errorCode: null,
+        errorMessage: null,
+        createdAt: new Date("2026-04-22T00:00:00.000Z"),
+      })
+      .mockResolvedValueOnce({
+        id: "run-1",
+        automationId: "aut-1",
+        status: "SUCCEEDED",
+        triggerSource: "MANUAL",
+        triggerPayload: { source: "manual" },
+        contextSnapshot: {
+          tableId: "tbl-1",
+        },
+        startedAt: new Date("2026-04-22T00:00:00.000Z"),
+        finishedAt: new Date("2026-04-22T00:00:01.000Z"),
+        durationMs: 1000,
+        errorCode: null,
+        errorMessage: null,
+        createdAt: new Date("2026-04-22T00:00:00.000Z"),
+      });
     dbMock.automationRun.findUnique.mockResolvedValue({
       startedAt: new Date("2026-04-22T00:00:00.000Z"),
     });
@@ -248,7 +393,7 @@ describe("automation-dispatcher.service", () => {
           actor: { id: "user-1" },
         },
       },
-      select: { id: true },
+      select: expect.any(Object),
     });
 
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -260,6 +405,7 @@ describe("automation-dispatcher.service", () => {
         status: "RUNNING",
         startedAt: expect.any(Date),
       },
+      select: expect.any(Object),
     });
     expect(dbMock.automationRun.update).toHaveBeenNthCalledWith(2, {
       where: { id: "run-1" },
@@ -268,6 +414,7 @@ describe("automation-dispatcher.service", () => {
         finishedAt: expect.any(Date),
         durationMs: expect.any(Number),
       },
+      select: expect.any(Object),
     });
   });
 
@@ -279,14 +426,49 @@ describe("automation-dispatcher.service", () => {
         status: 500,
       })
     );
-    dbMock.automationRun.update.mockResolvedValue({ id: "run-1" });
+    dbMock.automationRun.update
+      .mockResolvedValueOnce({
+        id: "run-1",
+        automationId: "aut-1",
+        status: "RUNNING",
+        triggerSource: "MANUAL",
+        triggerPayload: {},
+        contextSnapshot: {},
+        startedAt: new Date("2026-04-22T00:00:00.000Z"),
+        finishedAt: null,
+        durationMs: null,
+        errorCode: null,
+        errorMessage: null,
+        createdAt: new Date("2026-04-22T00:00:00.000Z"),
+      })
+      .mockResolvedValueOnce({
+        id: "run-1",
+        automationId: "aut-1",
+        status: "FAILED",
+        triggerSource: "MANUAL",
+        triggerPayload: {},
+        contextSnapshot: {},
+        startedAt: new Date("2026-04-22T00:00:00.000Z"),
+        finishedAt: new Date("2026-04-22T00:00:01.000Z"),
+        durationMs: 1000,
+        errorCode: "WEBHOOK_FAILED",
+        errorMessage: "Webhook returned 500",
+        createdAt: new Date("2026-04-22T00:00:00.000Z"),
+      });
     dbMock.automationRun.findUnique.mockResolvedValue({
       startedAt: new Date("2026-04-22T00:00:00.000Z"),
     });
     dbMock.automationRunStep.create
       .mockResolvedValueOnce({ id: "step-1" })
       .mockResolvedValueOnce({ id: "step-2" });
-    dbMock.automationRunStep.update.mockResolvedValue({ id: "step-1" });
+    dbMock.automationRunStep.update.mockResolvedValue({
+      id: "step-1",
+      runId: "run-1",
+      status: "FAILED",
+      run: {
+        automationId: "aut-1",
+      },
+    });
 
     const result = await executeQueuedAutomationRun({
       runId: "run-1",
@@ -354,6 +536,7 @@ describe("automation-dispatcher.service", () => {
         errorMessage: "Webhook returned 500",
         finishedAt: expect.any(Date),
       },
+      select: expect.any(Object),
     });
     expect(dbMock.automationRunStep.create).toHaveBeenNthCalledWith(2, {
       data: {
@@ -379,6 +562,7 @@ describe("automation-dispatcher.service", () => {
         errorCode: "WEBHOOK_FAILED",
         errorMessage: "Webhook returned 500",
       },
+      select: expect.any(Object),
     });
   });
 });

--- a/src/lib/services/automation-run.service.ts
+++ b/src/lib/services/automation-run.service.ts
@@ -1,5 +1,6 @@
 import { Prisma } from "@/generated/prisma/client";
 import { db } from "@/lib/db";
+import { publishAutomationRealtimeEvent } from "@/lib/services/automation-realtime.service";
 import type {
   AutomationActionNode,
   AutomationRunItem,
@@ -9,6 +10,21 @@ import type {
   EnqueueAutomationRunInput,
 } from "@/types/automation";
 import type { ServiceResult } from "@/types/data-table";
+
+const automationRunSelect = {
+  id: true,
+  automationId: true,
+  status: true,
+  triggerSource: true,
+  triggerPayload: true,
+  contextSnapshot: true,
+  startedAt: true,
+  finishedAt: true,
+  durationMs: true,
+  errorCode: true,
+  errorMessage: true,
+  createdAt: true,
+} as const;
 
 function toJsonValue(value: unknown): Prisma.InputJsonValue {
   return JSON.parse(JSON.stringify(value)) as Prisma.InputJsonValue;
@@ -81,6 +97,27 @@ function mapAutomationRunStepItem(row: {
   };
 }
 
+async function publishRunUpdated(row: {
+  id: string;
+  automationId: string;
+  status: string;
+  triggerSource: string;
+  triggerPayload: unknown;
+  contextSnapshot: unknown;
+  startedAt: Date | null;
+  finishedAt: Date | null;
+  durationMs: number | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+  createdAt: Date;
+}) {
+  await publishAutomationRealtimeEvent({
+    type: "automation_run_updated",
+    automationId: row.automationId,
+    run: mapAutomationRunItem(row),
+  });
+}
+
 export async function createAutomationRunStep(input: {
   runId: string;
   nodeId: string;
@@ -123,10 +160,16 @@ export async function createAutomationRun(
         triggerPayload: toJsonValue(input.triggerPayload),
         contextSnapshot: toJsonValue(input.contextSnapshot),
       },
-      select: { id: true },
+      select: automationRunSelect,
     });
 
-    return { success: true, data: created };
+    await publishAutomationRealtimeEvent({
+      type: "automation_run_created",
+      automationId: created.automationId,
+      run: mapAutomationRunItem(created),
+    });
+
+    return { success: true, data: { id: created.id } };
   } catch (error) {
     const message = error instanceof Error ? error.message : "创建自动化运行记录失败";
     return { success: false, error: { code: "CREATE_RUN_FAILED", message } };
@@ -135,14 +178,16 @@ export async function createAutomationRun(
 
 export async function markAutomationRunStarted(runId: string): Promise<ServiceResult<null>> {
   try {
-    await db.automationRun.update({
+    const updated = await db.automationRun.update({
       where: { id: runId },
       data: {
         status: "RUNNING",
         startedAt: new Date(),
       },
+      select: automationRunSelect,
     });
 
+    await publishRunUpdated(updated);
     return { success: true, data: null };
   } catch (error) {
     const message = error instanceof Error ? error.message : "标记自动化运行开始失败";
@@ -158,15 +203,17 @@ export async function markAutomationRunSucceeded(runId: string): Promise<Service
     });
     const finishedAt = new Date();
 
-    await db.automationRun.update({
+    const updated = await db.automationRun.update({
       where: { id: runId },
       data: {
         status: "SUCCEEDED",
         finishedAt,
         durationMs: computeDurationMs(existing?.startedAt ?? null, finishedAt),
       },
+      select: automationRunSelect,
     });
 
+    await publishRunUpdated(updated);
     return { success: true, data: null };
   } catch (error) {
     const message = error instanceof Error ? error.message : "标记自动化运行成功失败";
@@ -185,7 +232,7 @@ export async function markAutomationRunFailed(
     });
     const finishedAt = new Date();
 
-    await db.automationRun.update({
+    const updated = await db.automationRun.update({
       where: { id: runId },
       data: {
         status: "FAILED",
@@ -194,8 +241,10 @@ export async function markAutomationRunFailed(
         errorCode: error.code ?? "RUN_FAILED",
         errorMessage: error.message,
       },
+      select: automationRunSelect,
     });
 
+    await publishRunUpdated(updated);
     return { success: true, data: null };
   } catch (updateError) {
     const message = updateError instanceof Error ? updateError.message : "标记自动化运行失败失败";
@@ -209,15 +258,32 @@ export async function markAutomationRunStepSucceeded(
 ): Promise<ServiceResult<null>> {
   try {
     const finishedAt = new Date();
-    await db.automationRunStep.update({
+    const updated = await db.automationRunStep.update({
       where: { id: stepId },
       data: {
         status: "SUCCEEDED",
         output: toJsonValue(output),
         finishedAt,
       },
+      select: {
+        id: true,
+        runId: true,
+        status: true,
+        run: {
+          select: {
+            automationId: true,
+          },
+        },
+      },
     });
 
+    await publishAutomationRealtimeEvent({
+      type: "automation_run_step_updated",
+      automationId: updated.run.automationId,
+      runId: updated.runId,
+      stepId: updated.id,
+      status: updated.status as AutomationRunStepStatus,
+    });
     return { success: true, data: null };
   } catch (error) {
     const message = error instanceof Error ? error.message : "标记自动化步骤成功失败";
@@ -231,7 +297,7 @@ export async function markAutomationRunStepFailed(
 ): Promise<ServiceResult<null>> {
   try {
     const finishedAt = new Date();
-    await db.automationRunStep.update({
+    const updated = await db.automationRunStep.update({
       where: { id: stepId },
       data: {
         status: "FAILED",
@@ -239,8 +305,25 @@ export async function markAutomationRunStepFailed(
         errorMessage: error.message,
         finishedAt,
       },
+      select: {
+        id: true,
+        runId: true,
+        status: true,
+        run: {
+          select: {
+            automationId: true,
+          },
+        },
+      },
     });
 
+    await publishAutomationRealtimeEvent({
+      type: "automation_run_step_updated",
+      automationId: updated.run.automationId,
+      runId: updated.runId,
+      stepId: updated.id,
+      status: updated.status as AutomationRunStepStatus,
+    });
     return { success: true, data: null };
   } catch (updateError) {
     const message = updateError instanceof Error ? updateError.message : "标记自动化步骤失败失败";

--- a/src/types/automation-realtime.ts
+++ b/src/types/automation-realtime.ts
@@ -1,0 +1,41 @@
+import type { AutomationRunItem, AutomationRunStepStatus } from "@/types/automation";
+
+export type AutomationRealtimeConnectedEvent = {
+  type: "connected";
+  automationId: string;
+};
+
+export type AutomationRealtimeHeartbeatEvent = {
+  type: "heartbeat";
+  ts: number;
+};
+
+export type AutomationRunCreatedEvent = {
+  type: "automation_run_created";
+  automationId: string;
+  run: AutomationRunItem;
+};
+
+export type AutomationRunUpdatedEvent = {
+  type: "automation_run_updated";
+  automationId: string;
+  run: AutomationRunItem;
+};
+
+export type AutomationRunStepUpdatedEvent = {
+  type: "automation_run_step_updated";
+  automationId: string;
+  runId: string;
+  stepId: string;
+  status: AutomationRunStepStatus;
+};
+
+export type AutomationRealtimeEvent =
+  | AutomationRunCreatedEvent
+  | AutomationRunUpdatedEvent
+  | AutomationRunStepUpdatedEvent;
+
+export type AutomationRealtimeStreamEvent =
+  | AutomationRealtimeConnectedEvent
+  | AutomationRealtimeHeartbeatEvent
+  | AutomationRealtimeEvent;

--- a/src/validators/automation.ts
+++ b/src/validators/automation.ts
@@ -116,7 +116,7 @@ export const automationDefinitionSchema = z.object({
 
 export const createAutomationSchema = z.object({
   name: z.string().trim().min(1, "自动化名称不能为空"),
-  description: z.string().trim().max(1000).optional(),
+  description: z.string().trim().max(1000).nullable().optional(),
   enabled: z.boolean().default(true),
   triggerType: automationTriggerTypeSchema,
   definition: automationDefinitionSchema,


### PR DESCRIPTION
## Summary
- 为自动化详情页新增 SSE 实时通道和自动化域实时事件模型
- 在 automation run / step 状态变更时发布实时事件，并让详情页增量更新运行列表与展开详情
- 改造手动运行按钮和运行日志，支持即时反馈、断链提示和详情重拉

## Test plan
- [x] `pnpm vitest run \"src/lib/services/automation-run.service.test.ts\" \"src/lib/services/automation-realtime.service.test.ts\" \"src/app/api/automations/[id]/realtime/route.test.ts\" \"src/app/api/automations/[id]/run/route.test.ts\" \"src/hooks/use-automation-run-realtime.test.ts\" \"src/components/automations/automation-run-actions.test.tsx\" \"src/components/automations/automation-run-log.test.tsx\" \"src/components/automations/automation-detail-live.test.tsx\"`
- [x] `pnpm eslint \"src/types/automation-realtime.ts\" \"src/lib/services/automation-realtime.service.ts\" \"src/lib/services/automation-realtime.service.test.ts\" \"src/lib/services/automation-run.service.ts\" \"src/lib/services/automation-run.service.test.ts\" \"src/app/api/automations/[id]/realtime/route.ts\" \"src/app/api/automations/[id]/realtime/route.test.ts\" \"src/hooks/use-automation-run-realtime.ts\" \"src/hooks/use-automation-run-realtime.test.ts\" \"src/components/automations/automation-detail-live.tsx\" \"src/components/automations/automation-detail-live.test.tsx\" \"src/components/automations/automation-run-actions.tsx\" \"src/components/automations/automation-run-actions.test.tsx\" \"src/components/automations/automation-run-log.tsx\" \"src/components/automations/automation-run-log.test.tsx\" \"src/app/(dashboard)/automations/[id]/page.tsx\"`
- [x] `npx tsc --noEmit`

Closes #138