### PR TITLE
[Fix] 日历点击日期创建后打开记录编辑

### DIFF
--- a/src/components/data/dynamic-record-form.tsx
+++ b/src/components/data/dynamic-record-form.tsx
@@ -29,6 +29,7 @@ interface DynamicRecordFormProps {
   fields: DataFieldItem[];
   initialData?: DataRecordItem | null;
   onSubmit: (data: Record<string, unknown>) => Promise<void>;
+  onCancel?: () => void;
   submitLabel?: string;
 }
 
@@ -130,6 +131,7 @@ export function DynamicRecordForm({
   fields,
   initialData,
   onSubmit,
+  onCancel,
   submitLabel = "保存",
 }: DynamicRecordFormProps) {
   const router = useRouter();
@@ -500,7 +502,7 @@ export function DynamicRecordForm({
         <Button
           type="button"
           variant="outline"
-          onClick={() => router.back()}
+          onClick={onCancel ?? (() => router.back())}
           disabled={isSubmitting}
         >
           取消

--- a/src/components/data/record-detail-drawer.test.tsx
+++ b/src/components/data/record-detail-drawer.test.tsx
@@ -7,9 +7,21 @@ import type { DataFieldItem, DataRecordItem } from "@/types/data-table";
 vi.mock("@/components/ui/sheet", () => ({
   Sheet: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
     open ? <div>{children}</div> : null,
-  SheetContent: ({ children }: { children: React.ReactNode }) => <section>{children}</section>,
+  SheetContent: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => <section className={className}>{children}</section>,
   SheetHeader: ({ children }: { children: React.ReactNode }) => <header>{children}</header>,
-  SheetTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  SheetTitle: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => <h2 className={className}>{children}</h2>,
 }));
 
 vi.mock("next/navigation", () => ({
@@ -99,5 +111,35 @@ describe("RecordDetailDrawer", () => {
     );
     expect(screen.getByText("记录详情")).toBeInTheDocument();
     expect(screen.getByText("补填标题")).toBeInTheDocument();
+  });
+
+  it("编辑态抽屉应使用主题色，避免浅色主题文字不可见", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(record), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    render(
+      <RecordDetailDrawer
+        open
+        onOpenChange={vi.fn()}
+        recordId="record-new"
+        tableId="table-1"
+        fields={fields}
+        isAdmin
+        initialMode="edit"
+      />
+    );
+
+    const title = await screen.findByRole("heading", { name: "编辑记录" });
+    const sheet = title.closest("section");
+
+    expect(sheet).toHaveClass("bg-card", "text-card-foreground");
+    expect(sheet?.className).not.toContain("bg-[#191a1b]");
+    expect(title).toHaveClass("text-foreground");
+    expect(title.className).not.toContain("text-[#f7f8f8]");
   });
 });

--- a/src/components/data/record-detail-drawer.test.tsx
+++ b/src/components/data/record-detail-drawer.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RecordDetailDrawer } from "@/components/data/record-detail-drawer";
+import { FieldType } from "@/generated/prisma/enums";
+import type { DataFieldItem, DataRecordItem } from "@/types/data-table";
+
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  SheetContent: ({ children }: { children: React.ReactNode }) => <section>{children}</section>,
+  SheetHeader: ({ children }: { children: React.ReactNode }) => <header>{children}</header>,
+  SheetTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    back: vi.fn(),
+  }),
+}));
+
+const fields: DataFieldItem[] = [
+  {
+    id: "field-title",
+    key: "title",
+    label: "标题",
+    type: FieldType.TEXT,
+    required: false,
+    sortOrder: 0,
+  },
+];
+
+const record: DataRecordItem = {
+  id: "record-new",
+  tableId: "table-1",
+  data: { title: "" },
+  createdAt: new Date("2026-04-23T00:00:00.000Z"),
+  updatedAt: new Date("2026-04-23T00:00:00.000Z"),
+  createdByName: "管理员",
+  updatedByName: null,
+};
+
+describe("RecordDetailDrawer", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("初始编辑态保存后应停留在抽屉内并通知外层刷新", async () => {
+    const updatedRecord: DataRecordItem = {
+      ...record,
+      data: { title: "补填标题" },
+    };
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(record), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(updatedRecord), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+    const onRecordSaved = vi.fn();
+
+    render(
+      <RecordDetailDrawer
+        open
+        onOpenChange={vi.fn()}
+        recordId="record-new"
+        tableId="table-1"
+        fields={fields}
+        isAdmin
+        initialMode="edit"
+        onRecordSaved={onRecordSaved}
+      />
+    );
+
+    fireEvent.change(await screen.findByPlaceholderText("输入标题"), {
+      target: { value: "补填标题" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "保存修改" }));
+
+    await waitFor(() => {
+      expect(onRecordSaved).toHaveBeenCalledOnce();
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "/api/data-tables/table-1/records/record-new",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ data: { title: "补填标题" } }),
+      })
+    );
+    expect(screen.getByText("记录详情")).toBeInTheDocument();
+    expect(screen.getByText("补填标题")).toBeInTheDocument();
+  });
+});

--- a/src/components/data/record-detail-drawer.tsx
+++ b/src/components/data/record-detail-drawer.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { Pencil, Trash2, History, ChevronLeft, ChevronRight, MessageSquare } from "lucide-react";
-import { Button, LinkButton } from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -20,6 +20,9 @@ import { FieldTypeIcon } from "./field-type-icon";
 import { CommentPanel } from "./comment-panel";
 import { FieldType } from "@/generated/prisma/enums";
 import { RichTextPreview } from "./rich-text-cell-editor";
+import { DynamicRecordForm } from "./dynamic-record-form";
+
+type RecordDetailMode = "view" | "edit";
 
 export interface RecordDetailDrawerProps {
   open: boolean;
@@ -32,6 +35,8 @@ export interface RecordDetailDrawerProps {
   onDelete?: (recordId: string) => void;
   recordIds?: string[];
   onNavigate?: (recordId: string) => void;
+  initialMode?: RecordDetailMode;
+  onRecordSaved?: () => void;
 }
 
 function formatDateTime(value: string | Date): string {
@@ -45,7 +50,19 @@ function formatChangeValue(value: unknown): string {
 }
 
 export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
-  const { open, onOpenChange, recordId, tableId, fields, isAdmin, onDelete, recordIds, onNavigate } =
+  const {
+    open,
+    onOpenChange,
+    recordId,
+    tableId,
+    fields,
+    isAdmin,
+    onDelete,
+    recordIds,
+    onNavigate,
+    initialMode = "view",
+    onRecordSaved,
+  } =
     props;
 
   const currentIndex = recordId && recordIds ? recordIds.indexOf(recordId) : -1;
@@ -55,6 +72,7 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
   const [record, setRecord] = useState<DataRecordItem | null>(null);
   const [loading, setLoading] = useState(false);
   const [activeTab, setActiveTab] = useState("fields");
+  const [mode, setMode] = useState<RecordDetailMode>(initialMode);
 
   // History state
   const [historyEntries, setHistoryEntries] = useState<ChangeHistoryEntry[]>([]);
@@ -113,6 +131,12 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
     };
   }, [open, recordId, tableId]);
 
+  useEffect(() => {
+    if (open && recordId) {
+      setMode(initialMode);
+    }
+  }, [initialMode, open, recordId]);
+
   const loadHistory = useCallback(async (page: number, append = false) => {
     if (!recordId) return;
     setHistoryLoading(true);
@@ -156,6 +180,7 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
   // Reset tab when drawer closes
   useEffect(() => {
     if (!open) {
+      setMode("view");
       setActiveTab("fields");
       setHistoryEntries([]);
       setHistoryTotal(0);
@@ -176,8 +201,32 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
     if (!recordIds || !onNavigate || currentIndex < 0) return;
     const nextIndex = currentIndex + direction;
     if (nextIndex < 0 || nextIndex >= recordIds.length) return;
+    setMode("view");
     onNavigate(recordIds[nextIndex]);
   }, [recordIds, onNavigate, currentIndex]);
+
+  const handleSave = useCallback(async (data: Record<string, unknown>) => {
+    if (!record) return;
+
+    const response = await fetch(
+      `/api/data-tables/${tableId}/records/${record.id}`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ data }),
+      }
+    );
+
+    if (!response.ok) {
+      const payload = (await response.json().catch(() => ({}))) as { error?: string };
+      throw new Error(payload.error ?? "保存失败");
+    }
+
+    const updatedRecord = (await response.json()) as DataRecordItem;
+    setRecord(updatedRecord);
+    setMode("view");
+    onRecordSaved?.();
+  }, [onRecordSaved, record, tableId]);
 
   // Keyboard navigation
   useEffect(() => {
@@ -212,7 +261,9 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
           <div className="space-y-4">
             <SheetHeader className="border-b border-[rgb(255_255_255_/_0.08)]">
               <div className="flex items-center justify-between">
-                <SheetTitle className="text-lg font-[510] text-[#f7f8f8]">记录详情</SheetTitle>
+                <SheetTitle className="text-lg font-[510] text-[#f7f8f8]">
+                  {mode === "edit" ? "编辑记录" : "记录详情"}
+                </SheetTitle>
                 {recordIds && recordIds.length > 0 && currentIndex >= 0 && (
                   <div className="flex items-center gap-1 relative z-10">
                     <Button
@@ -241,6 +292,18 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
               </div>
             </SheetHeader>
 
+            {mode === "edit" ? (
+              <div className="px-4 pb-4 pt-4">
+                <DynamicRecordForm
+                  tableId={tableId}
+                  fields={fields}
+                  initialData={record}
+                  onSubmit={handleSave}
+                  onCancel={() => setMode("view")}
+                  submitLabel="保存修改"
+                />
+              </div>
+            ) : (
             <Tabs value={activeTab} onValueChange={setActiveTab}>
               <TabsList className="mx-4">
                 <TabsTrigger value="fields">字段</TabsTrigger>
@@ -257,14 +320,14 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
               <TabsContent value="fields" className="space-y-6 px-4 pb-4 pt-4">
                 {isAdmin && (
                   <div className="flex flex-wrap gap-2">
-                    <LinkButton
+                    <Button
                       variant="outline"
                       size="sm"
-                      href={`/data/${tableId}/${record.id}/edit`}
+                      onClick={() => setMode("edit")}
                     >
                       <Pencil className="h-4 w-4" />
                       编辑
-                    </LinkButton>
+                    </Button>
                     <Button
                       variant="destructive"
                       size="sm"
@@ -398,6 +461,7 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
                 )}
               </TabsContent>
             </Tabs>
+            )}
           </div>
         )}
       </SheetContent>

--- a/src/components/data/record-detail-drawer.tsx
+++ b/src/components/data/record-detail-drawer.tsx
@@ -248,20 +248,20 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="right" className="w-full overflow-y-auto border-[rgb(255_255_255_/_0.08)] bg-[#191a1b] sm:max-w-md">
+      <SheetContent side="right" className="w-full overflow-y-auto border-border bg-card text-card-foreground sm:max-w-md">
         {loading ? (
           <div className="flex min-h-full items-center justify-center py-12">
             <Spinner className="size-6" />
           </div>
         ) : !record ? (
-          <div className="flex min-h-full items-center justify-center py-12 text-sm text-[#8a8f98]">
+          <div className="flex min-h-full items-center justify-center py-12 text-sm text-muted-foreground">
             记录不存在
           </div>
         ) : (
           <div className="space-y-4">
-            <SheetHeader className="border-b border-[rgb(255_255_255_/_0.08)]">
+            <SheetHeader className="border-b border-border">
               <div className="flex items-center justify-between">
-                <SheetTitle className="text-lg font-[510] text-[#f7f8f8]">
+                <SheetTitle className="text-lg font-[510] text-foreground">
                   {mode === "edit" ? "编辑记录" : "记录详情"}
                 </SheetTitle>
                 {recordIds && recordIds.length > 0 && currentIndex >= 0 && (
@@ -275,7 +275,7 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
                     >
                       <ChevronLeft className="h-4 w-4" />
                     </Button>
-                    <span className="min-w-[3rem] text-center text-xs tabular-nums text-[#8a8f98]">
+                    <span className="min-w-[3rem] text-center text-xs tabular-nums text-muted-foreground">
                       {currentIndex + 1} / {recordIds.length}
                     </span>
                     <Button
@@ -341,12 +341,12 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
 
                 <div className="space-y-4">
                   {fields.map((field) => (
-                    <div key={field.id} className="space-y-1.5 rounded-md border border-[rgb(255_255_255_/_0.06)] bg-[rgb(255_255_255_/_0.02)] p-2.5">
-                      <div className="flex items-center gap-1 text-xs font-[510] text-[#8a8f98]">
+                    <div key={field.id} className="space-y-1.5 rounded-md border border-border bg-background/70 p-2.5">
+                      <div className="flex items-center gap-1 text-xs font-[510] text-muted-foreground">
                         <FieldTypeIcon type={field.type} />
                         {field.label}
                       </div>
-                      <div className="break-words text-sm text-[#d0d6e0]">
+                      <div className="break-words text-sm text-foreground">
                         {field.type === FieldType.RICH_TEXT
                           ? <RichTextPreview value={record.data[field.key]} />
                           : formatCellValue(field, record.data[field.key])}
@@ -355,23 +355,23 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
                   ))}
                 </div>
 
-                <Separator className="bg-[rgb(255_255_255_/_0.08)]" />
+                <Separator />
 
                 <div className="space-y-3">
-                  <div className="text-xs font-[510] text-[#8a8f98]">
+                  <div className="text-xs font-[510] text-muted-foreground">
                     元信息
                   </div>
-                  <div className="grid gap-2 text-sm text-[#d0d6e0]">
+                  <div className="grid gap-2 text-sm text-foreground">
                     <div className="grid grid-cols-[88px_1fr] gap-2">
-                      <span className="text-[#8a8f98]">创建人</span>
+                      <span className="text-muted-foreground">创建人</span>
                       <span>{record.createdByName || "-"}</span>
                     </div>
                     <div className="grid grid-cols-[88px_1fr] gap-2">
-                      <span className="text-[#8a8f98]">创建时间</span>
+                      <span className="text-muted-foreground">创建时间</span>
                       <span>{formatDateTime(record.createdAt)}</span>
                     </div>
                     <div className="grid grid-cols-[88px_1fr] gap-2">
-                      <span className="text-[#8a8f98]">更新时间</span>
+                      <span className="text-muted-foreground">更新时间</span>
                       <span>{formatDateTime(record.updatedAt)}</span>
                     </div>
                   </div>
@@ -392,7 +392,7 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
                     onChange={(e) => setStartDate(e.target.value)}
                     className="h-7 text-xs"
                   />
-                  <span className="shrink-0 text-[#8a8f98]">至</span>
+                  <span className="shrink-0 text-muted-foreground">至</span>
                   <Input
                     type="date"
                     value={endDate}
@@ -414,7 +414,7 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
                     <Spinner className="size-5" />
                   </div>
                 ) : historyEntries.length === 0 ? (
-                  <div className="py-12 text-center text-sm text-[#8a8f98]">
+                  <div className="py-12 text-center text-sm text-muted-foreground">
                     暂无变更记录
                   </div>
                 ) : (
@@ -424,14 +424,14 @@ export function RecordDetailDrawer(props: RecordDetailDrawerProps) {
                         <div key={entry.id} className="flex gap-3 text-sm">
                           <div className="flex flex-col items-center">
                             <div className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-[#7170ff]" />
-                            <div className="w-px flex-1 bg-[rgb(255_255_255_/_0.08)]" />
+                            <div className="w-px flex-1 bg-border" />
                           </div>
                           <div className="flex-1 pb-4">
-                            <div className="text-xs text-[#8a8f98]">
+                            <div className="text-xs text-muted-foreground">
                               {formatDateTime(entry.changedAt)} · {entry.changedByName}
                             </div>
-                            <div className="mt-1 text-[#d0d6e0]">
-                              <span className="font-[510] text-[#f7f8f8]">{entry.fieldLabel}</span>
+                            <div className="mt-1 text-foreground">
+                              <span className="font-[510] text-foreground">{entry.fieldLabel}</span>
                               {" : "}
                               <span className="text-red-300/80 line-through">
                                 {formatChangeValue(entry.oldValue)}

--- a/src/components/data/record-table.tsx
+++ b/src/components/data/record-table.tsx
@@ -44,7 +44,9 @@ interface RecordTableProps {
   fields: DataFieldItem[];
   isAdmin: boolean;
   onOpenDetail?: (recordId: string) => void;
+  onOpenEdit?: (recordId: string) => void;
   onRecordIdsChange?: (ids: string[]) => void;
+  refreshSignal?: number;
 }
 
 // ─── Fallback view when no saved view is selected ────────────────────────────
@@ -74,7 +76,9 @@ export function RecordTable({
   fields,
   isAdmin,
   onOpenDetail,
+  onOpenEdit,
   onRecordIdsChange,
+  refreshSignal,
 }: RecordTableProps) {
   const router = useRouter();
   const [viewType, setViewType] = useState<ViewType>("GRID");
@@ -83,6 +87,7 @@ export function RecordTable({
   const [quickFormatValue, setQuickFormatValue] = useState<string | undefined>();
   const [showActivity, setShowActivity] = useState(false);
   const lastSyncedRecordIdsRef = useRef<string[]>([]);
+  const lastRefreshSignalRef = useRef(refreshSignal);
   const {
     records,
     totalCount,
@@ -123,6 +128,15 @@ export function RecordTable({
     onLockLost,
     cursorPositions,
   } = useTableData({ tableId, fields });
+
+  useEffect(() => {
+    if (refreshSignal === undefined || lastRefreshSignalRef.current === refreshSignal) {
+      return;
+    }
+
+    lastRefreshSignalRef.current = refreshSignal;
+    refresh();
+  }, [refresh, refreshSignal]);
 
   // Sync record IDs to parent for drawer navigation
   useEffect(() => {
@@ -484,6 +498,7 @@ export function RecordTable({
             tableId={tableId}
             onPatchRecord={handlePatchRecord}
             onOpenRecord={onOpenDetail ?? (() => {})}
+            onOpenCreatedRecord={onOpenEdit ?? onOpenDetail ?? (() => {})}
             onRecordCreated={refresh}
             onViewOptionsChange={setViewOptions}
           />

--- a/src/components/data/save-view-dialog.test.tsx
+++ b/src/components/data/save-view-dialog.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SaveViewDialog } from "@/components/data/save-view-dialog";
+import type { DataViewConfig } from "@/types/data-table";
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <section aria-label="保存视图窗口" className={className}>
+      {children}
+    </section>
+  ),
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <footer>{children}</footer>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <header>{children}</header>,
+  DialogTitle: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => <h2 className={className}>{children}</h2>,
+}));
+
+const config: DataViewConfig = {
+  filters: [],
+  sortBy: [],
+  visibleFields: ["title"],
+  fieldOrder: ["title"],
+  groupBy: null,
+  viewOptions: {},
+};
+
+describe("SaveViewDialog", () => {
+  it("应使用主题色，避免浅色主题文字不可见", () => {
+    render(
+      <SaveViewDialog
+        open
+        onOpenChange={vi.fn()}
+        tableId="table-1"
+        currentConfig={config}
+        viewType="GRID"
+        onSaved={vi.fn()}
+      />
+    );
+
+    const dialog = screen.getByLabelText("保存视图窗口");
+    const title = screen.getByRole("heading", { name: "保存视图" });
+
+    expect(dialog).toHaveClass("bg-card", "text-card-foreground");
+    expect(dialog.className).not.toContain("bg-[#191a1b]");
+    expect(title).toHaveClass("text-foreground");
+    expect(screen.getByText("1 个可见字段")).toHaveClass("text-muted-foreground");
+  });
+});

--- a/src/components/data/save-view-dialog.test.tsx
+++ b/src/components/data/save-view-dialog.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SaveViewDialog } from "@/components/data/save-view-dialog";
 import type { DataViewConfig } from "@/types/data-table";
 
@@ -38,6 +38,14 @@ const config: DataViewConfig = {
 };
 
 describe("SaveViewDialog", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("应使用主题色，避免浅色主题文字不可见", () => {
     render(
       <SaveViewDialog
@@ -57,5 +65,45 @@ describe("SaveViewDialog", () => {
     expect(dialog.className).not.toContain("bg-[#191a1b]");
     expect(title).toHaveClass("text-foreground");
     expect(screen.getByText("1 个可见字段")).toHaveClass("text-muted-foreground");
+  });
+
+  it("保存日历视图时应提交 CALENDAR 类型", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: { id: "view-calendar" } }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    const onSaved = vi.fn();
+    const onOpenChange = vi.fn();
+
+    render(
+      <SaveViewDialog
+        open
+        onOpenChange={onOpenChange}
+        tableId="table-1"
+        currentConfig={config}
+        viewType="CALENDAR"
+        onSaved={onSaved}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("输入视图名称"), {
+      target: { value: "日历视图" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    await waitFor(() => {
+      expect(onSaved).toHaveBeenCalledWith("view-calendar");
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/data-tables/table-1/views",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining("\"type\":\"CALENDAR\""),
+      })
+    );
   });
 });

--- a/src/components/data/save-view-dialog.tsx
+++ b/src/components/data/save-view-dialog.tsx
@@ -101,9 +101,9 @@ export function SaveViewDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="border-[rgb(255_255_255_/_0.08)] bg-[#191a1b] text-[#f7f8f8]">
+      <DialogContent className="border-border bg-card text-card-foreground">
         <DialogHeader>
-          <DialogTitle className="font-[510] tracking-[-0.13px]">保存视图</DialogTitle>
+          <DialogTitle className="font-[510] tracking-[-0.13px] text-foreground">保存视图</DialogTitle>
         </DialogHeader>
 
         <div className="flex flex-col gap-4">
@@ -122,17 +122,17 @@ export function SaveViewDialog({
             />
           </div>
 
-          <Separator className="bg-[rgb(255_255_255_/_0.08)]" />
+          <Separator />
 
           {/* Config summary */}
-          <div className="flex flex-col gap-1.5 rounded-md border border-[rgb(255_255_255_/_0.06)] bg-[rgb(255_255_255_/_0.02)] p-2.5 text-sm">
-            <span className="text-[#8a8f98]">
+          <div className="flex flex-col gap-1.5 rounded-md border border-border bg-background/70 p-2.5 text-sm">
+            <span className="text-muted-foreground">
               {currentConfig.filters.length} 个筛选条件
             </span>
-            <span className="text-[#8a8f98]">
+            <span className="text-muted-foreground">
               排序: {sortSummary}
             </span>
-            <span className="text-[#8a8f98]">
+            <span className="text-muted-foreground">
               {currentConfig.visibleFields.length} 个可见字段
             </span>
           </div>

--- a/src/components/data/table-detail-content.tsx
+++ b/src/components/data/table-detail-content.tsx
@@ -26,6 +26,8 @@ export function TableDetailContent({ tableId, table, isAdmin }: TableDetailConte
   const searchParams = useSearchParams();
   const [detailRecordId, setDetailRecordId] = useState<string | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
+  const [detailMode, setDetailMode] = useState<"view" | "edit">("view");
+  const [recordRefreshSignal, setRecordRefreshSignal] = useState(0);
   const [recordIds, setRecordIds] = useState<string[]>([]);
 
   // Auto-open record detail from search params
@@ -33,6 +35,7 @@ export function TableDetailContent({ tableId, table, isAdmin }: TableDetailConte
     const rid = searchParams.get("recordId");
     if (rid) {
       setDetailRecordId(rid);
+      setDetailMode("view");
       setDetailOpen(true);
     }
   }, [searchParams]);
@@ -194,9 +197,16 @@ export function TableDetailContent({ tableId, table, isAdmin }: TableDetailConte
         isAdmin={isAdmin}
         onOpenDetail={(recordId) => {
           setDetailRecordId(recordId);
+          setDetailMode("view");
+          setDetailOpen(true);
+        }}
+        onOpenEdit={(recordId) => {
+          setDetailRecordId(recordId);
+          setDetailMode("edit");
           setDetailOpen(true);
         }}
         onRecordIdsChange={setRecordIds}
+        refreshSignal={recordRefreshSignal}
       />
 
       <RecordDetailDrawer
@@ -205,6 +215,7 @@ export function TableDetailContent({ tableId, table, isAdmin }: TableDetailConte
           if (!open) {
             setDetailOpen(false);
             setDetailRecordId(null);
+            setDetailMode("view");
           }
         }}
         recordId={detailRecordId}
@@ -212,7 +223,14 @@ export function TableDetailContent({ tableId, table, isAdmin }: TableDetailConte
         fields={table.fields}
         isAdmin={isAdmin}
         recordIds={recordIds}
-        onNavigate={(id) => setDetailRecordId(id)}
+        initialMode={detailMode}
+        onNavigate={(id) => {
+          setDetailMode("view");
+          setDetailRecordId(id);
+        }}
+        onRecordSaved={() => {
+          setRecordRefreshSignal((current) => current + 1);
+        }}
       />
 
       <Sheet open={aiOpen} onOpenChange={handleAiClose}>

--- a/src/components/data/views/calendar/calendar-view.test.tsx
+++ b/src/components/data/views/calendar/calendar-view.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CalendarView } from "@/components/data/views/calendar/calendar-view";
+import { FieldType, ViewType } from "@/generated/prisma/enums";
+import type { DataFieldItem, DataViewItem } from "@/types/data-table";
+
+vi.mock("@dnd-kit/react", () => ({
+  DragDropProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DragOverlay: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  useDraggable: () => ({ ref: vi.fn(), isDragging: false }),
+  useDroppable: () => ({ ref: vi.fn(), isDropTarget: false }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+const fields: DataFieldItem[] = [
+  {
+    id: "field-date",
+    key: "dueDate",
+    label: "日期",
+    type: FieldType.DATE,
+    required: false,
+    sortOrder: 0,
+  },
+  {
+    id: "field-title",
+    key: "title",
+    label: "标题",
+    type: FieldType.TEXT,
+    required: false,
+    sortOrder: 1,
+  },
+];
+
+const view: DataViewItem = {
+  id: "view-1",
+  tableId: "table-1",
+  name: "日历",
+  type: ViewType.CALENDAR,
+  isDefault: false,
+  filters: [],
+  sortBy: [],
+  visibleFields: [],
+  fieldOrder: [],
+  groupBy: null,
+  viewOptions: {
+    startDateField: "dueDate",
+    labelField: "title",
+  },
+  createdAt: new Date("2026-04-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+};
+
+describe("CalendarView", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("点击空白日期创建记录后应打开新记录编辑界面", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ id: "record-new" }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    const onOpenRecord = vi.fn();
+    const onRecordCreated = vi.fn();
+    const now = new Date();
+    const expectedDate = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-15`;
+
+    render(
+      <CalendarView
+        fields={fields}
+        records={[]}
+        view={view}
+        tableId="table-1"
+        isAdmin
+        onPatchRecord={vi.fn()}
+        onOpenRecord={onOpenRecord}
+        onRecordCreated={onRecordCreated}
+      />
+    );
+
+    fireEvent.click(screen.getByText("15"));
+
+    await waitFor(() => {
+      expect(onOpenRecord).toHaveBeenCalledWith("record-new");
+    });
+    expect(onRecordCreated).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/data-tables/table-1/records",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ data: { dueDate: expectedDate } }),
+      })
+    );
+  });
+});

--- a/src/components/data/views/calendar/calendar-view.test.tsx
+++ b/src/components/data/views/calendar/calendar-view.test.tsx
@@ -64,7 +64,7 @@ describe("CalendarView", () => {
     vi.unstubAllGlobals();
   });
 
-  it("点击空白日期创建记录后应打开新记录编辑界面", async () => {
+  it("点击空白日期创建记录后应以编辑态打开新记录", async () => {
     const fetchMock = vi.mocked(fetch);
     fetchMock.mockResolvedValue(
       new Response(JSON.stringify({ id: "record-new" }), {
@@ -73,6 +73,7 @@ describe("CalendarView", () => {
       })
     );
     const onOpenRecord = vi.fn();
+    const onOpenCreatedRecord = vi.fn();
     const onRecordCreated = vi.fn();
     const now = new Date();
     const expectedDate = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-15`;
@@ -86,6 +87,7 @@ describe("CalendarView", () => {
         isAdmin
         onPatchRecord={vi.fn()}
         onOpenRecord={onOpenRecord}
+        onOpenCreatedRecord={onOpenCreatedRecord}
         onRecordCreated={onRecordCreated}
       />
     );
@@ -93,8 +95,9 @@ describe("CalendarView", () => {
     fireEvent.click(screen.getByText("15"));
 
     await waitFor(() => {
-      expect(onOpenRecord).toHaveBeenCalledWith("record-new");
+      expect(onOpenCreatedRecord).toHaveBeenCalledWith("record-new");
     });
+    expect(onOpenRecord).not.toHaveBeenCalled();
     expect(onRecordCreated).toHaveBeenCalledOnce();
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/data-tables/table-1/records",

--- a/src/components/data/views/calendar/calendar-view.tsx
+++ b/src/components/data/views/calendar/calendar-view.tsx
@@ -16,6 +16,7 @@ interface CalendarViewProps {
   tableId: string;
   onPatchRecord: (recordId: string, fieldKey: string, value: unknown) => Promise<void>;
   onOpenRecord: (recordId: string) => void;
+  onOpenCreatedRecord?: (recordId: string) => void;
   onRecordCreated?: () => void;
   onViewOptionsChange?: (options: Record<string, unknown>) => void;
 }
@@ -62,6 +63,7 @@ export function CalendarView({
   isAdmin,
   onPatchRecord,
   onOpenRecord,
+  onOpenCreatedRecord,
   onRecordCreated,
   onViewOptionsChange,
 }: CalendarViewProps) {
@@ -206,7 +208,7 @@ export function CalendarView({
                 : null;
           onRecordCreated?.();
           if (newRecordId) {
-            onOpenRecord(newRecordId);
+            (onOpenCreatedRecord ?? onOpenRecord)(newRecordId);
           }
         } else {
           const data = await res.json().catch(() => ({}));
@@ -218,7 +220,7 @@ export function CalendarView({
         creatingRef.current = false;
       }
     },
-    [isAdmin, dateField, tableId, onRecordCreated, onOpenRecord]
+    [isAdmin, dateField, tableId, onRecordCreated, onOpenCreatedRecord, onOpenRecord]
   );
 
   const today = toLocalDateString(new Date());

--- a/src/components/data/views/calendar/calendar-view.tsx
+++ b/src/components/data/views/calendar/calendar-view.tsx
@@ -195,7 +195,19 @@ export function CalendarView({
           body: JSON.stringify({ data: { [dateField]: dateStr } }),
         });
         if (res.ok) {
+          const data = (await res.json().catch(() => null)) as
+            | { id?: unknown; data?: { id?: unknown } }
+            | null;
+          const newRecordId =
+            typeof data?.id === "string"
+              ? data.id
+              : typeof data?.data?.id === "string"
+                ? data.data.id
+                : null;
           onRecordCreated?.();
+          if (newRecordId) {
+            onOpenRecord(newRecordId);
+          }
         } else {
           const data = await res.json().catch(() => ({}));
           toast.error(data.error ?? "创建失败");
@@ -206,7 +218,7 @@ export function CalendarView({
         creatingRef.current = false;
       }
     },
-    [isAdmin, dateField, tableId, onRecordCreated]
+    [isAdmin, dateField, tableId, onRecordCreated, onOpenRecord]
   );
 
   const today = toLocalDateString(new Date());

--- a/src/validators/data-table.test.ts
+++ b/src/validators/data-table.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { viewTypeNameSchema } from "@/validators/data-table";
+
+describe("viewTypeNameSchema", () => {
+  it("应允许保存日历视图类型", () => {
+    expect(viewTypeNameSchema.parse("CALENDAR")).toBe("CALENDAR");
+  });
+});

--- a/src/validators/data-table.ts
+++ b/src/validators/data-table.ts
@@ -183,7 +183,7 @@ export type JsonImportOptionsInput = z.infer<typeof jsonImportOptionsSchema>;
 
 // ========== View Schemas ==========
 
-export const viewTypeNameSchema = z.enum(["GRID", "KANBAN", "GALLERY", "TIMELINE", "FORM"]);
+export const viewTypeNameSchema = z.enum(["GRID", "KANBAN", "GALLERY", "TIMELINE", "FORM", "CALENDAR"]);
 
 export const patchFieldSchema = z.object({
   fieldKey: z.string().regex(/^[a-z][a-z0-9_]*$/),


### PR DESCRIPTION
## Summary
- 日历视图点击空白日期创建记录后，解析创建接口返回的新记录 ID
- 创建成功后打开右侧记录抽屉并直接进入编辑态，而不是只显示详情或跳转到编辑页
- 记录保存后回到抽屉详情态，并刷新后方数据表/日历视图，保留当前日历上下文
- 详情抽屉的“编辑”按钮改为抽屉内编辑，避免离开当前视图
- 增加组件回归测试覆盖日期点击创建后的编辑态打开、抽屉内保存和刷新通知

## Test plan
- [x] npm run test:run -- src/components/data/views/calendar/calendar-view.test.tsx src/components/data/record-detail-drawer.test.tsx
- [x] npm run lint -- src/components/data/views/calendar/calendar-view.tsx src/components/data/views/calendar/calendar-view.test.tsx src/components/data/record-detail-drawer.tsx src/components/data/record-detail-drawer.test.tsx src/components/data/record-table.tsx src/components/data/table-detail-content.tsx src/components/data/dynamic-record-form.tsx
- [x] npx tsc --noEmit

Closes #140