### PR TITLE
fix(agent2): clear completed stream status

### DIFF
--- a/src/components/agent2/chat-area.test.tsx
+++ b/src/components/agent2/chat-area.test.tsx
@@ -3,7 +3,7 @@ import { createContext, useContext, useState, type FormEvent, type ReactNode } f
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ChatArea } from "./chat-area"
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input"
-import type { FileUIPart } from "ai"
+import type { FileUIPart, UIMessage } from "ai"
 
 const {
   sendMessageMock,
@@ -13,6 +13,7 @@ const {
   fetchMock,
   uploadAgent2FilesMock,
   buildAttachmentMessageTextMock,
+  messagePartsMock,
   mockState,
 } = vi.hoisted(() => ({
   sendMessageMock: vi.fn(),
@@ -22,8 +23,11 @@ const {
   fetchMock: vi.fn(),
   uploadAgent2FilesMock: vi.fn(),
   buildAttachmentMessageTextMock: vi.fn(),
+  messagePartsMock: vi.fn(() => null),
   mockState: {
     selectedFiles: [] as FileUIPart[],
+    chatMessages: [] as UIMessage[],
+    chatStatus: "ready" as "submitted" | "streaming" | "ready" | "error",
   },
 }))
 const PromptInputControllerContext = createContext<{
@@ -34,8 +38,8 @@ const openFileDialogMock = vi.fn()
 
 vi.mock("@ai-sdk/react", () => ({
   useChat: vi.fn(() => ({
-    messages: [],
-    status: "ready",
+    messages: mockState.chatMessages,
+    status: mockState.chatStatus,
     sendMessage: sendMessageMock,
     stop: stopMock,
     error: undefined,
@@ -77,7 +81,7 @@ vi.mock("@/components/ai-elements/message", () => ({
 }))
 
 vi.mock("./message-parts", () => ({
-  MessageParts: () => null,
+  MessageParts: messagePartsMock,
 }))
 
 vi.mock("@/components/ai-elements/attachments", () => ({
@@ -203,6 +207,8 @@ describe("ChatArea", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockState.selectedFiles = []
+    mockState.chatMessages = []
+    mockState.chatStatus = "ready"
     openFileDialogMock.mockReset()
     fetchMock.mockReset()
     fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
@@ -306,6 +312,103 @@ describe("ChatArea", () => {
     })
   })
 
+  it("应将 useChat 顶层状态传给消息渲染组件", async () => {
+    mockState.chatMessages = [
+      {
+        id: "msg-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "历史回答", state: "streaming" }],
+      },
+    ]
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === "/api/agent2/settings") {
+        return {
+          json: async () => ({
+            success: true,
+            data: { defaultModel: "MiniMax-M2.5" },
+          }),
+        }
+      }
+
+      if (url === "/api/agent2/conversations/conv-1") {
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            data: {
+              id: "conv-1",
+              messages: mockState.chatMessages,
+            },
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    render(
+      <ChatArea
+        conversationId="conv-1"
+        onToggleSidebar={vi.fn()}
+        sidebarCollapsed={false}
+      />
+    )
+
+    await waitFor(() => {
+      expect(messagePartsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chatStatus: "ready",
+          message: expect.objectContaining({ id: "msg-1" }),
+        }),
+        undefined
+      )
+    })
+  })
+
+  it("生成新回复时只有最新 assistant 消息保持流式状态", async () => {
+    mockState.chatStatus = "streaming"
+    mockState.chatMessages = [
+      {
+        id: "msg-old",
+        role: "assistant",
+        parts: [{ type: "text", text: "旧回答", state: "streaming" }],
+      },
+      {
+        id: "msg-new",
+        role: "assistant",
+        parts: [{ type: "text", text: "新回答", state: "streaming" }],
+      },
+    ]
+
+    render(
+      <ChatArea
+        conversationId="conv-1"
+        onToggleSidebar={vi.fn()}
+        sidebarCollapsed={false}
+      />
+    )
+
+    await waitFor(() => {
+      expect(messagePartsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chatStatus: "ready",
+          message: expect.objectContaining({ id: "msg-old" }),
+        }),
+        undefined
+      )
+      expect(messagePartsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chatStatus: "streaming",
+          message: expect.objectContaining({ id: "msg-new" }),
+        }),
+        undefined
+      )
+    })
+  })
+
   it("历史消息加载完成前应禁止发送，避免覆盖新消息", async () => {
     let resolveConversation: ((value: unknown) => void) | null = null
 
@@ -324,6 +427,24 @@ describe("ChatArea", () => {
       if (url === "/api/agent2/conversations/conv-1") {
         return new Promise((resolve) => {
           resolveConversation = resolve
+        })
+      }
+
+      if (url === "/api/agent2/suggestions") {
+        return Promise.resolve({
+          json: async () => ({
+            success: true,
+            data: [],
+          }),
+        })
+      }
+
+      if (url === "/api/agent2/models") {
+        return Promise.resolve({
+          json: async () => ({
+            success: true,
+            data: [],
+          }),
         })
       }
 

--- a/src/components/agent2/chat-area.tsx
+++ b/src/components/agent2/chat-area.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useChat } from "@ai-sdk/react"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { DefaultChatTransport, type FileUIPart, type UIMessage } from "ai"
 
 // AI Elements
@@ -231,6 +231,10 @@ export function ChatArea({ conversationId, onToggleSidebar, sidebarCollapsed, on
   }, [conversationId, setMessages])
 
   const historyLoaded = loadedConversationId === conversationId
+  const latestAssistantMessageId = useMemo(
+    () => [...messages].reverse().find((message) => message.role === "assistant")?.id,
+    [messages]
+  )
 
   const handleSubmit = useCallback(
     ({ text, files }: PromptInputMessage) => {
@@ -322,6 +326,7 @@ export function ChatArea({ conversationId, onToggleSidebar, sidebarCollapsed, on
                 <MessageContent>
                   <MessageParts
                     message={message}
+                    chatStatus={message.id === latestAssistantMessageId ? status : "ready"}
                     onToolConfirm={({ toolCallId, toolName, result }) => {
                       addToolOutput({
                         tool: toolName as "dynamic",

--- a/src/components/agent2/message-parts.test.tsx
+++ b/src/components/agent2/message-parts.test.tsx
@@ -118,6 +118,31 @@ describe("MessageParts", () => {
     )
   })
 
+  it("chat 已结束时应忽略残留的 part streaming 状态", () => {
+    const message: UIMessage = {
+      id: "msg-completed",
+      role: "assistant",
+      parts: [
+        {
+          type: "text",
+          text: "回答已完成",
+          state: "streaming",
+        },
+      ],
+    }
+
+    render(<MessageParts message={message} chatStatus="ready" />)
+
+    expect(screen.getByTestId("assistant-stream-state")).toHaveAttribute(
+      "data-status",
+      "正在生成回复"
+    )
+    expect(screen.getByTestId("assistant-stream-state")).toHaveAttribute(
+      "data-streaming",
+      "false"
+    )
+  })
+
   it("应将 tool-generateChart 的结果交给 ChartRenderer 渲染", () => {
     const message: UIMessage = {
       id: "msg-1",

--- a/src/components/agent2/message-parts.tsx
+++ b/src/components/agent2/message-parts.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import type { UIMessage, DynamicToolUIPart, FileUIPart, ToolUIPart } from "ai"
+import type { ChatStatus, UIMessage, DynamicToolUIPart, FileUIPart, ToolUIPart } from "ai"
 import { MessageResponse } from "@/components/ai-elements/message"
 import { Reasoning, ReasoningTrigger, ReasoningContent } from "@/components/ai-elements/reasoning"
 import { Tool, ToolHeader, ToolContent, ToolInput, ToolOutput } from "@/components/ai-elements/tool"
@@ -42,6 +42,7 @@ interface ConfirmToolOutput {
 
 interface MessagePartsProps {
   message: UIMessage
+  chatStatus?: ChatStatus
   onToolConfirm?: (params: {
     toolCallId: string
     toolName: string
@@ -73,7 +74,7 @@ function getToolProgressLabel(toolName: string) {
   }
 }
 
-function getMessageProgress(message: UIMessage) {
+function getMessageProgress(message: UIMessage, chatStatus?: ChatStatus) {
   if (message.role !== "assistant" || !message.parts || message.parts.length === 0) {
     return null
   }
@@ -143,15 +144,17 @@ function getMessageProgress(message: UIMessage) {
     return null
   }
 
+  const effectiveStreaming = chatStatus ? chatStatus === "streaming" && isStreaming : isStreaming
+
   return {
     status: timeline[timeline.length - 1],
     timeline,
-    isStreaming,
+    isStreaming: effectiveStreaming,
     hasContent: hasVisibleText,
   }
 }
 
-export function MessageParts({ message, onToolConfirm }: MessagePartsProps) {
+export function MessageParts({ message, chatStatus, onToolConfirm }: MessagePartsProps) {
   const [confirmState, setConfirmState] = useState<ConfirmState>({
     open: false,
     toolName: "",
@@ -188,7 +191,7 @@ export function MessageParts({ message, onToolConfirm }: MessagePartsProps) {
   }>
   const reasoningText = reasoningParts.map((p) => p.text).join("")
   const isReasoningStreaming = reasoningParts.some((p) => p.state === "streaming")
-  const messageProgress = getMessageProgress(message)
+  const messageProgress = getMessageProgress(message, chatStatus)
 
   return (
     <>

--- a/src/components/ai-chat/assistant-stream-state.test.tsx
+++ b/src/components/ai-chat/assistant-stream-state.test.tsx
@@ -17,6 +17,7 @@ describe("AssistantStreamState", () => {
     expect(screen.getByText("3 个步骤")).toBeInTheDocument();
     expect(screen.getByText("正在分析问题")).toBeInTheDocument();
     expect(screen.getByText("正在查询数据")).toBeInTheDocument();
+    expect(screen.getByTestId("assistant-stream-summary-status")).toHaveTextContent("正在生成回复");
     expect(screen.getAllByText("正在生成回复").length).toBeGreaterThan(0);
   });
 
@@ -30,8 +31,9 @@ describe("AssistantStreamState", () => {
       />
     );
 
-    expect(screen.getByText("已完成")).toBeInTheDocument();
+    expect(screen.getByTestId("assistant-stream-summary-status")).toHaveTextContent("已完成");
     expect(screen.getByText("2 个步骤")).toBeInTheDocument();
+    expect(screen.getAllByText("正在生成回复")).toHaveLength(1);
   });
 
   it("停止后应展示停止态", () => {

--- a/src/components/ai-chat/assistant-stream-state.tsx
+++ b/src/components/ai-chat/assistant-stream-state.tsx
@@ -60,8 +60,12 @@ export function AssistantStreamState({
     return null;
   }
 
-  const resolvedStatus = status ?? "正在回复";
-  const isStopped = resolvedStatus.includes("停止");
+  const isStopped = (status ?? "").includes("停止");
+  const resolvedStatus = isStopped
+    ? status ?? "已停止生成"
+    : isStreaming
+      ? status ?? "正在回复"
+      : "已完成";
   const summaryTone = isStopped
     ? "bg-amber-50 text-amber-700 ring-amber-100"
     : isStreaming
@@ -92,18 +96,16 @@ export function AssistantStreamState({
             />
             <span className={`relative inline-flex h-2 w-2 rounded-full ${summaryDotTone}`} />
           </span>
-          <span>{resolvedStatus}</span>
+          <span data-testid="assistant-stream-summary-status">{resolvedStatus}</span>
         </span>
         <span className="text-zinc-400">
           {timeline.length > 1 ? `${timeline.length} 个步骤` : "查看过程"}
         </span>
-        {!isStreaming ? (
+        {!isStreaming && isStopped ? (
           <span
-            className={`inline-flex items-center rounded-full px-1.5 py-0.5 ${
-              isStopped ? "bg-amber-100 text-amber-700" : "bg-emerald-100 text-emerald-700"
-            }`}
+            className="inline-flex items-center rounded-full bg-amber-100 px-1.5 py-0.5 text-amber-700"
           >
-            {isStopped ? "已停止" : "已完成"}
+            已停止
           </span>
         ) : null}
         {isStreaming && hasContent ? (


### PR DESCRIPTION
## Summary
- pass the AI SDK chat status into Agent v2 message rendering
- force completed/error chat states to render assistant progress as completed even if a message part keeps stale state: streaming
- limit live streaming state to the latest assistant message so old messages do not reanimate during a new response
- add regression tests for completed streams and latest-message streaming behavior

## Verification
- npm run test:run -- src/components/agent2/message-parts.test.tsx src/components/agent2/chat-area.test.tsx
- npm run lint -- src/components/agent2/message-parts.tsx src/components/agent2/chat-area.tsx src/components/agent2/message-parts.test.tsx src/components/agent2/chat-area.test.tsx
- npx tsc --noEmit
- npm run build

Closes #134