### PR TITLE
[Fix] 数据表导出 Excel 对齐当前视图并修复关联字段显示

### DIFF
--- a/src/app/api/data-tables/[id]/export/route.ts
+++ b/src/app/api/data-tables/[id]/export/route.ts
@@ -25,7 +25,13 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
   }
 
   const table = tableResult.data;
-  const result = await exportToExcel(tableId);
+  const { searchParams } = new URL(_request.url);
+  const visibleFields = searchParams.getAll("visibleField");
+  const fieldOrder = searchParams.getAll("fieldOrder");
+  const result = await exportToExcel(tableId, {
+    visibleFields: visibleFields.length > 0 ? visibleFields : undefined,
+    fieldOrder: fieldOrder.length > 0 ? fieldOrder : undefined,
+  });
 
   if (!result.success) {
     return NextResponse.json(

--- a/src/components/data/record-table.tsx
+++ b/src/components/data/record-table.tsx
@@ -350,6 +350,22 @@ export function RecordTable({
     [currentConfig.viewOptions, setViewOptions]
   );
 
+  const handleExportExcel = useCallback(() => {
+    const searchParams = new URLSearchParams();
+
+    currentConfig.visibleFields.forEach((fieldKey) => {
+      searchParams.append("visibleField", fieldKey);
+    });
+
+    currentConfig.fieldOrder.forEach((fieldKey) => {
+      searchParams.append("fieldOrder", fieldKey);
+    });
+
+    const query = searchParams.toString();
+    const exportUrl = `/api/data-tables/${tableId}/export${query ? `?${query}` : ""}`;
+    window.open(exportUrl);
+  }, [currentConfig.fieldOrder, currentConfig.visibleFields, tableId]);
+
   // ── Row reorder ────────────────────────────────────────────────────────
   const reorderRecords = useCallback(
     async (orderedIds: string[]) => {
@@ -616,7 +632,7 @@ export function RecordTable({
             />
             <DropdownMenuContent align="end">
               <DropdownMenuItem
-                onClick={() => window.open(`/api/data-tables/${tableId}/export`)}
+                onClick={handleExportExcel}
               >
                 导出 Excel
               </DropdownMenuItem>

--- a/src/lib/format-cell-text.test.ts
+++ b/src/lib/format-cell-text.test.ts
@@ -1,0 +1,59 @@
+import { FieldType } from "@/generated/prisma/enums";
+import { describe, expect, it } from "vitest";
+import { formatCellText } from "@/lib/format-cell-text";
+import type { DataFieldItem } from "@/types/data-table";
+
+function buildField(partial: Partial<DataFieldItem>): DataFieldItem {
+  return {
+    id: partial.id ?? "field-1",
+    key: partial.key ?? "title",
+    label: partial.label ?? "标题",
+    type: partial.type ?? FieldType.TEXT,
+    required: partial.required ?? false,
+    sortOrder: partial.sortOrder ?? 0,
+    ...partial,
+  };
+}
+
+describe("formatCellText", () => {
+  it("formats relation arrays as comma-separated display text", () => {
+    const field = buildField({
+      key: "authors",
+      label: "作者",
+      type: FieldType.RELATION,
+    });
+
+    expect(
+      formatCellText(field, [
+        { id: "author-1", displayValue: "张三" },
+        { id: "author-2", display: "李四" },
+        { id: "author-3" },
+      ])
+    ).toBe("张三, 李四, author-3");
+  });
+
+  it("formats relation subtable values in sort order", () => {
+    const field = buildField({
+      key: "paperAuthors",
+      label: "作者",
+      type: FieldType.RELATION_SUBTABLE,
+    });
+
+    expect(
+      formatCellText(field, [
+        { targetRecordId: "author-2", displayValue: "李四", attributes: {}, sortOrder: 1 },
+        { targetRecordId: "author-1", displayValue: "张三", attributes: {}, sortOrder: 0 },
+      ])
+    ).toBe("张三, 李四");
+  });
+
+  it("formats multiselect values with spaces after commas", () => {
+    const field = buildField({
+      key: "tags",
+      label: "标签",
+      type: FieldType.MULTISELECT,
+    });
+
+    expect(formatCellText(field, ["A", "B", "C"])).toBe("A, B, C");
+  });
+});

--- a/src/lib/format-cell-text.ts
+++ b/src/lib/format-cell-text.ts
@@ -1,0 +1,144 @@
+import { FieldType } from "@/generated/prisma/enums";
+import type { DataFieldItem, RelationSubtableValueItem } from "@/types/data-table";
+
+function isEmptyCell(value: unknown): boolean {
+  return value === null || value === undefined || value === "";
+}
+
+function formatDateValue(value: unknown): string {
+  try {
+    const date = new Date(value as string);
+    return date.toLocaleDateString("zh-CN");
+  } catch {
+    return String(value);
+  }
+}
+
+function isRelationSubtableItem(item: unknown): item is RelationSubtableValueItem {
+  return item !== null && typeof item === "object" && "targetRecordId" in item;
+}
+
+function getRelationSubtableItems(value: unknown): RelationSubtableValueItem[] {
+  const items = Array.isArray(value) ? value : [value];
+  return items
+    .filter(isRelationSubtableItem)
+    .sort((left, right) => left.sortOrder - right.sortOrder);
+}
+
+function formatRelationDisplayValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  if (typeof value === "object" && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>;
+    return String(record.display ?? record.displayValue ?? record.id ?? "");
+  }
+
+  return String(value);
+}
+
+function formatRelationArrayValue(items: unknown[]): string {
+  const displayValues = items
+    .map((item) => formatRelationDisplayValue(item))
+    .filter((item) => item.length > 0);
+
+  return displayValues.join(", ");
+}
+
+export function extractRichTextPlainText(value: unknown): string {
+  if (!value) return "";
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return richTextDocToText(parsed);
+    } catch {
+      return value.length > 100 ? value.slice(0, 100) + "..." : value;
+    }
+  }
+  if (typeof value === "object") {
+    const text = richTextDocToText(value as Record<string, unknown>);
+    return text.length > 100 ? text.slice(0, 100) + "..." : text;
+  }
+  return String(value);
+}
+
+function richTextDocToText(doc: Record<string, unknown>): string {
+  if (!doc?.content || !Array.isArray(doc.content)) return "";
+  return (doc.content as Array<Record<string, unknown>>)
+    .map((node) => richTextNodeToText(node))
+    .join(" ")
+    .trim();
+}
+
+function richTextNodeToText(node: Record<string, unknown>): string {
+  if (node.type === "text") return (node.text as string) || "";
+  if (!node.content || !Array.isArray(node.content)) return "";
+  return (node.content as Array<Record<string, unknown>>)
+    .map((childNode) => richTextNodeToText(childNode))
+    .join("");
+}
+
+export function formatCellText(field: DataFieldItem, value: unknown): string {
+  if (isEmptyCell(value)) {
+    return "";
+  }
+
+  switch (field.type) {
+    case FieldType.MULTISELECT:
+      return Array.isArray(value) ? value.map((item) => String(item)).join(", ") : String(value);
+    case FieldType.DATE:
+      return formatDateValue(value);
+    case FieldType.RELATION:
+      return Array.isArray(value)
+        ? formatRelationArrayValue(value)
+        : formatRelationDisplayValue(value);
+    case FieldType.RELATION_SUBTABLE:
+      return getRelationSubtableItems(value)
+        .map((item) => String(item.displayValue ?? item.targetRecordId))
+        .join(", ");
+    case FieldType.URL:
+    case FieldType.BOOLEAN:
+    case FieldType.AUTO_NUMBER:
+    case FieldType.SYSTEM_TIMESTAMP:
+    case FieldType.SYSTEM_USER:
+    case FieldType.FORMULA:
+    case FieldType.COUNT:
+    case FieldType.LOOKUP:
+    case FieldType.ROLLUP:
+    case FieldType.RICH_TEXT:
+      return extractRichTextPlainText(value);
+    case FieldType.RATING:
+      return `${Number(value)}/${(field.options as Record<string, unknown>)?.ratingMax ?? 5}`;
+    case FieldType.CURRENCY: {
+      const code = (field.options as Record<string, unknown>)?.currencyCode as string ?? "CNY";
+      const decimals =
+        (field.options as Record<string, unknown>)?.currencyDecimals as number ?? 2;
+      const symbol = { CNY: "\u00a5", USD: "$", EUR: "\u20ac" }[code] ?? code;
+      return `${symbol}${Number(value).toLocaleString(undefined, {
+        minimumFractionDigits: decimals,
+        maximumFractionDigits: decimals,
+      })}`;
+    }
+    case FieldType.PERCENTAGE: {
+      const decimals =
+        (field.options as Record<string, unknown>)?.percentageDecimals as number ?? 0;
+      return `${(Number(value) * 100).toFixed(decimals)}%`;
+    }
+    case FieldType.DURATION: {
+      const format = (field.options as Record<string, unknown>)?.durationFormat as string ?? "hh:mm";
+      const totalSeconds = Math.round(Number(value));
+      const hours = Math.floor(totalSeconds / 3600);
+      const minutes = Math.floor((totalSeconds % 3600) / 60);
+      const seconds = totalSeconds % 60;
+      const pad = (num: number) => String(num).padStart(2, "0");
+      if (format === "hh:mm:ss") return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+      if (format === "mm:ss") return `${pad(Math.floor(totalSeconds / 60))}:${pad(seconds)}`;
+      return `${pad(hours)}:${pad(minutes)}`;
+    }
+    default:
+      return String(value);
+  }
+}
+
+export { formatDateValue, isEmptyCell };

--- a/src/lib/format-cell.tsx
+++ b/src/lib/format-cell.tsx
@@ -4,6 +4,12 @@ import type { ReactNode } from "react";
 import type { DataFieldItem, RelationSubtableValueItem } from "@/types/data-table";
 import { parseSelectOptions, SELECT_COLORS } from "@/types/data-table";
 import { FileIcon } from "lucide-react";
+import {
+  extractRichTextPlainText,
+  formatCellText,
+  formatDateValue,
+  isEmptyCell,
+} from "@/lib/format-cell-text";
 
 type ColorPair = { bg: string; fg: string };
 
@@ -30,19 +36,6 @@ function getSelectColor(value: string, colorMap: Map<string, ColorPair>): ColorP
   for (let i = 0; i < value.length; i++) hash = value.charCodeAt(i) + ((hash << 5) - hash);
   const preset = SELECT_COLORS[Math.abs(hash) % SELECT_COLORS.length];
   return { bg: preset.bg, fg: preset.fg };
-}
-
-function isEmptyCell(value: unknown): boolean {
-  return value === null || value === undefined || value === "";
-}
-
-function formatDateValue(value: unknown): string {
-  try {
-    const date = new Date(value as string);
-    return date.toLocaleDateString("zh-CN");
-  } catch {
-    return String(value);
-  }
 }
 
 function isRelationSubtableItem(
@@ -305,86 +298,4 @@ export function formatCellValue(
   }
 }
 
-export function formatCellText(field: DataFieldItem, value: unknown): string {
-  if (isEmptyCell(value)) {
-    return "";
-  }
-
-  switch (field.type) {
-    case FieldType.DATE:
-      return formatDateValue(value);
-    case FieldType.RELATION: {
-      const obj = value as Record<string, unknown> | null;
-      return String(obj?.display ?? obj?.displayValue ?? value);
-    }
-    case FieldType.URL:
-    case FieldType.BOOLEAN:
-    case FieldType.AUTO_NUMBER:
-    case FieldType.SYSTEM_TIMESTAMP:
-    case FieldType.SYSTEM_USER:
-    case FieldType.FORMULA:
-    case FieldType.COUNT:
-    case FieldType.LOOKUP:
-    case FieldType.ROLLUP:
-    case FieldType.RICH_TEXT:
-      return extractRichTextPlainText(value);
-    case FieldType.RATING:
-      return `${Number(value)}/${(field.options as Record<string, unknown>)?.ratingMax ?? 5}`;
-    case FieldType.CURRENCY: {
-      const code = (field.options as Record<string, unknown>)?.currencyCode as string ?? "CNY";
-      const dec = (field.options as Record<string, unknown>)?.currencyDecimals as number ?? 2;
-      const symbol = { CNY: "\u00a5", USD: "$", EUR: "\u20ac" }[code] ?? code;
-      return `${symbol}${Number(value).toLocaleString(undefined, { minimumFractionDigits: dec, maximumFractionDigits: dec })}`;
-    }
-    case FieldType.PERCENTAGE: {
-      const dec = (field.options as Record<string, unknown>)?.percentageDecimals as number ?? 0;
-      return `${(Number(value) * 100).toFixed(dec)}%`;
-    }
-    case FieldType.DURATION: {
-      const fmt = (field.options as Record<string, unknown>)?.durationFormat as string ?? "hh:mm";
-      const totalSec = Math.round(Number(value));
-      const h = Math.floor(totalSec / 3600);
-      const m = Math.floor((totalSec % 3600) / 60);
-      const s = totalSec % 60;
-      const pad = (n: number) => String(n).padStart(2, "0");
-      if (fmt === "hh:mm:ss") return `${pad(h)}:${pad(m)}:${pad(s)}`;
-      if (fmt === "mm:ss") return `${pad(Math.floor(totalSec / 60))}:${pad(s)}`;
-      return `${pad(h)}:${pad(m)}`;
-    }
-    default:
-      return String(value);
-  }
-}
-
-function extractRichTextPlainText(value: unknown): string {
-  if (!value) return "";
-  if (typeof value === "string") {
-    try {
-      const parsed = JSON.parse(value);
-      return richTextDocToText(parsed);
-    } catch {
-      return value.length > 100 ? value.slice(0, 100) + "..." : value;
-    }
-  }
-  if (typeof value === "object") {
-    const text = richTextDocToText(value as Record<string, unknown>);
-    return text.length > 100 ? text.slice(0, 100) + "..." : text;
-  }
-  return String(value);
-}
-
-function richTextDocToText(doc: Record<string, unknown>): string {
-  if (!doc?.content || !Array.isArray(doc.content)) return "";
-  return (doc.content as Array<Record<string, unknown>>)
-    .map((node) => richTextNodeToText(node))
-    .join(" ")
-    .trim();
-}
-
-function richTextNodeToText(node: Record<string, unknown>): string {
-  if (node.type === "text") return (node.text as string) || "";
-  if (!node.content || !Array.isArray(node.content)) return "";
-  return (node.content as Array<Record<string, unknown>>)
-    .map((n) => richTextNodeToText(n))
-    .join("");
-}
+export { formatCellText };

--- a/src/lib/services/export.service.test.ts
+++ b/src/lib/services/export.service.test.ts
@@ -1,0 +1,95 @@
+import * as XLSX from "xlsx";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FieldType } from "@/generated/prisma/enums";
+import { exportToExcel } from "@/lib/services/export.service";
+import type { DataFieldItem } from "@/types/data-table";
+
+const { getTableMock, findManyMock } = vi.hoisted(() => ({
+  getTableMock: vi.fn(),
+  findManyMock: vi.fn(),
+}));
+
+vi.mock("@/lib/services/data-table.service", () => ({
+  getTable: getTableMock,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    dataRecord: {
+      findMany: findManyMock,
+    },
+  },
+}));
+
+function buildField(partial: Partial<DataFieldItem>): DataFieldItem {
+  return {
+    id: partial.id ?? `field-${partial.key ?? "title"}`,
+    key: partial.key ?? "title",
+    label: partial.label ?? "标题",
+    type: partial.type ?? FieldType.TEXT,
+    required: partial.required ?? false,
+    sortOrder: partial.sortOrder ?? 0,
+    ...partial,
+  };
+}
+
+describe("exportToExcel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exports rows using visible field order and relation display text", async () => {
+    getTableMock.mockResolvedValue({
+      success: true,
+      data: {
+        id: "table-1",
+        name: "论文",
+        description: null,
+        icon: null,
+        businessKeys: [],
+        fields: [
+          buildField({ key: "title", label: "标题", type: FieldType.TEXT, sortOrder: 0 }),
+          buildField({ key: "authors", label: "作者", type: FieldType.RELATION, sortOrder: 1 }),
+          buildField({ key: "status", label: "状态", type: FieldType.SELECT, sortOrder: 2 }),
+        ],
+      },
+    });
+    findManyMock.mockResolvedValue([
+      {
+        id: "rec-1",
+        data: {
+          title: "论文 A",
+          authors: [
+            { id: "author-1", displayValue: "张三" },
+            { id: "author-2", displayValue: "李四" },
+          ],
+          status: "已发布",
+        },
+        createdAt: new Date("2026-04-24T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-24T00:00:00.000Z"),
+      },
+    ]);
+
+    const result = await exportToExcel("table-1", {
+      visibleFields: ["authors", "title"],
+      fieldOrder: ["authors", "status", "title"],
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error("expected success");
+    }
+
+    const workbook = XLSX.read(result.data, { type: "buffer" });
+    const worksheet = workbook.Sheets["论文"];
+    const rows = XLSX.utils.sheet_to_json<(string | number)[]>(worksheet, {
+      header: 1,
+      raw: false,
+    });
+
+    expect(rows).toEqual([
+      ["作者", "标题"],
+      ["张三, 李四", "论文 A"],
+    ]);
+  });
+});

--- a/src/lib/services/export.service.ts
+++ b/src/lib/services/export.service.ts
@@ -1,6 +1,7 @@
 import * as XLSX from "xlsx";
 import { db } from "@/lib/db";
 import { getTable } from "./data-table.service";
+import { formatCellText } from "@/lib/format-cell-text";
 import type { ServiceResult, DataFieldItem, ExportBundle, BundleField, BundleTable } from "@/types/data-table";
 
 // ── Shared Types ──
@@ -60,6 +61,27 @@ export async function getTableExportData(
   };
 }
 
+export interface ExcelExportOptions {
+  visibleFields?: string[];
+  fieldOrder?: string[];
+}
+
+function getOrderedExportFields(
+  fields: DataFieldItem[],
+  options?: ExcelExportOptions
+): DataFieldItem[] {
+  const fieldMap = new Map(fields.map((field) => [field.key, field]));
+  const visibleKeys = options?.visibleFields ?? fields.map((field) => field.key);
+  const orderKeys = options?.fieldOrder ?? fields.map((field) => field.key);
+  const visibleSet = new Set(visibleKeys);
+  const orderedKeys = orderKeys.filter((key) => visibleSet.has(key) && fieldMap.has(key));
+  const remainingKeys = visibleKeys.filter((key) => !orderedKeys.includes(key) && fieldMap.has(key));
+
+  return [...orderedKeys, ...remainingKeys]
+    .map((key) => fieldMap.get(key))
+    .filter((field): field is DataFieldItem => field !== undefined);
+}
+
 // ── Legacy Record Export ──
 
 export function exportRecordToExcel(
@@ -114,7 +136,8 @@ export function exportRecordToExcel(
 // ── Excel Export ──
 
 export async function exportToExcel(
-  tableId: string
+  tableId: string,
+  options?: ExcelExportOptions
 ): Promise<ServiceResult<Buffer>> {
   try {
     const dataResult = await getTableExportData(tableId);
@@ -123,17 +146,12 @@ export async function exportToExcel(
     }
 
     const { table, fields, records } = dataResult.data;
+    const exportFields = getOrderedExportFields(fields, options);
 
-    const headers = fields.map((f) => f.label);
+    const headers = exportFields.map((field) => field.label);
     const rows = records.map((record) => {
       const data = record.data;
-      return fields.map((f) => {
-        const value = data[f.key];
-        if (f.type === "MULTISELECT" && Array.isArray(value)) {
-          return value.join(", ");
-        }
-        return value ?? "";
-      });
+      return exportFields.map((field) => formatCellText(field, data[field.key]));
     });
 
     const worksheet = XLSX.utils.aoa_to_sheet([headers, ...rows]);


### PR DESCRIPTION
## Summary
- 导出 Excel 时优先使用当前表格视图的 `visibleFields` 和 `fieldOrder`
- 新增纯文本单元格格式化工具，统一导出与查找替换的显示值逻辑
- 修复关联字段和关系子表导出为 `[object Object]` 的问题，改为导出实际显示文本
- 表格页导出按钮改为携带当前视图配置到导出接口

## Test plan
- [x] `npm run test:run -- \"src/lib/format-cell-text.test.ts\" \"src/lib/services/export.service.test.ts\"`
- [x] `npm run lint -- \"src/lib/format-cell-text.ts\" \"src/lib/format-cell-text.test.ts\" \"src/lib/format-cell.tsx\" \"src/lib/services/export.service.ts\" \"src/lib/services/export.service.test.ts\" \"src/app/api/data-tables/[id]/export/route.ts\" \"src/components/data/record-table.tsx\"`
- [x] `npx tsc --noEmit`
- [x] `npm run build`

Closes #147