### PR TITLE
feat(editor-ai): AI assistant sidebar for report editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,83 +1,66 @@
-# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+/build
+.claude/*
+!.claude/skills/
+.claude/skills/**/__pycache__/
+/coverage
+.data/
+# debug
+debug_*.py
+# Debug scripts
 # dependencies
+docs/deploy.md
+.DS_Store
+.env*
+# env files (can opt-in for committing if needed)
+!.env.offline.example
+# git worktrees
+.gstack/
+# Local agent/runtime state
+# Local debug screenshots
+# misc
+/.next/
+next-env.d.ts
+# next.js
 /node_modules
-/.pnp
+npm-debug.log*
+/out/
+/output
+*.pem
+# Playwright browser automation logs
+.playwright-cli/
+.playwright-mcp/
 .pnp.*
+/.pnp
+.pnpm-debug.log*
+# production
+public/uploads/documents/*
+!public/uploads/documents/.gitkeep
+public/uploads/report-templates/*.docx
+public/uploads/templates/*
+!public/uploads/templates/.gitkeep
+*.pyc
+__pycache__/
+# Python
+python-service/.venv/
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+/sidebar-test.png
+/src/generated/prisma
+.superpowers/
+# testing
+test-results/
+/tool-error.png
+*.tsbuildinfo
+# typescript
+# uploads (keep .gitkeep files)
+# vercel
+.vercel
+verify_*.py
+.worktrees/
 .yarn/*
+yarn-debug.log*
+yarn-error.log*
 !.yarn/patches
 !.yarn/plugins
 !.yarn/releases
 !.yarn/versions
-
-# testing
-/coverage
-
-# next.js
-/.next/
-/out/
-
-# production
-/build
-/output
-
-# misc
-.DS_Store
-*.pem
-
-# debug
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-.pnpm-debug.log*
-
-# env files (can opt-in for committing if needed)
-.env*
-!.env.offline.example
-
-# vercel
-.vercel
-
-# typescript
-*.tsbuildinfo
-next-env.d.ts
-
-/src/generated/prisma
-
-# uploads (keep .gitkeep files)
-public/uploads/templates/*
-public/uploads/documents/*
-public/uploads/report-templates/*.docx
-!public/uploads/templates/.gitkeep
-!public/uploads/documents/.gitkeep
-
-# git worktrees
-.worktrees/
-
-# Python
-python-service/.venv/
-__pycache__/
-*.pyc
-
-# Playwright browser automation logs
-.playwright-cli/
-.playwright-mcp/
-.gstack/
-
-# Local agent/runtime state
-.claude/*
-!.claude/skills/
-.claude/skills/**/__pycache__/
-.superpowers/
-.superpowers/
-.data/
-test-results/
-
-# Local debug screenshots
-/sidebar-test.png
-/tool-error.png
-docs/deploy.md
-
-# Debug scripts
-debug_*.py
-verify_*.py

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,6 +55,7 @@ model User {
   updatedAutomations            Automation[]       @relation("AutomationUpdatedBy")
   reportTemplates               ReportTemplate[]
   reportDrafts                  ReportDraft[]
+  editorAIActions               EditorAIAction[]
 }
 
 enum TemplateStatus {
@@ -975,4 +976,27 @@ model ReportDraft {
   collaboratorIds String[]        @default([])
   createdAt      DateTime        @default(now())
   updatedAt      DateTime        @updatedAt
+}
+
+// ========== Editor AI Actions ==========
+
+model EditorAIAction {
+  id          String   @id @default(cuid())
+  name        String
+  icon        String?
+  prompt      String
+  category    String   @default("general")
+  scope       String   @default("selection")
+  sortOrder   Int      @default(0)
+  isBuiltIn   Boolean  @default(false)
+  enabled     Boolean  @default(true)
+
+  userId      String?
+  user        User?    @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([userId])
+  @@index([category])
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -66,6 +66,31 @@ async function main() {
   });
 
   console.log({ admin, user, editor, viewer });
+
+  // Seed Editor AI Actions
+  const existingActions = await prisma.editorAIAction.count({
+    where: { isBuiltIn: true },
+  });
+  if (existingActions === 0) {
+    const builtInActions = [
+      { name: "润色", icon: "✨", prompt: "请润色以下文本，改善表达流畅度和文字质量，但保持原意不变：\n\n{{selection}}\n\n上下文：\n{{context}}", category: "writing", scope: "selection", sortOrder: 1 },
+      { name: "缩写", icon: "📝", prompt: "请将以下文本精简缩写，保留核心要点，去除冗余表述：\n\n{{selection}}\n\n上下文：\n{{context}}", category: "writing", scope: "selection", sortOrder: 2 },
+      { name: "扩写", icon: "📖", prompt: "请扩写以下文本，增加细节、论证和具体描述，使内容更加丰富：\n\n{{selection}}\n\n上下文：\n{{context}}", category: "writing", scope: "selection", sortOrder: 3 },
+      { name: "翻译为英文", icon: "🌐", prompt: "请将以下文本翻译为英文：\n\n{{selection}}", category: "translation", scope: "selection", sortOrder: 4 },
+      { name: "翻译为中文", icon: "🌐", prompt: "Please translate the following text to Chinese:\n\n{{selection}}", category: "translation", scope: "selection", sortOrder: 5 },
+      { name: "纠错", icon: "🎯", prompt: "请检查以下文本中的语法、拼写、标点错误并修正，列出修改内容：\n\n{{selection}}", category: "writing", scope: "selection", sortOrder: 6 },
+      { name: "正式语气", icon: "💼", prompt: "请将以下文本改写为正式、专业的语气，使用更规范的措辞：\n\n{{selection}}\n\n上下文：\n{{context}}", category: "writing", scope: "selection", sortOrder: 7 },
+      { name: "轻松语气", icon: "😊", prompt: "请将以下文本改写为轻松自然的语气，使其更加亲切易读：\n\n{{selection}}\n\n上下文：\n{{context}}", category: "writing", scope: "selection", sortOrder: 8 },
+    ];
+
+    for (const action of builtInActions) {
+      await prisma.editorAIAction.create({
+        data: { ...action, isBuiltIn: true, enabled: true, userId: null },
+      });
+    }
+    console.log(`Seeded ${builtInActions.length} built-in editor AI actions`);
+  }
+
   console.log("Seeding completed.");
 }
 

--- a/src/app/(dashboard)/about/page.tsx
+++ b/src/app/(dashboard)/about/page.tsx
@@ -1,0 +1,62 @@
+import { auth } from "@/lib/auth";
+import { AppLogo } from "@/components/layout/app-logo";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { ExternalLink, Globe, Mail } from "lucide-react";
+
+export default async function AboutPage() {
+  await auth();
+  const version = process.env.NEXT_PUBLIC_APP_VERSION ?? "unknown";
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <div className="flex flex-col items-center gap-4 rounded-xl border border-border bg-card p-8">
+        <AppLogo className="h-16 w-auto" priority />
+        <h1 className="text-2xl font-[510] tracking-tight text-foreground">
+          IDRL 填表系统
+        </h1>
+        <p className="text-sm text-muted-foreground">v{version}</p>
+        <p className="text-center text-sm text-muted-foreground">
+          基于模板驱动的文档自动化生成平台。上传 Word 模板，配置占位符，填写表单即可一键生成文档。
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">开发团队</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex items-center gap-3 text-sm">
+            <Globe className="h-4 w-4 text-muted-foreground" />
+            <span className="text-muted-foreground">IDRL Lab</span>
+          </div>
+          <div className="flex items-center gap-3 text-sm">
+            <Mail className="h-4 w-4 text-muted-foreground" />
+            <span className="text-muted-foreground">idrl@example.com</span>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">相关链接</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <a
+            href="https://github.com/zweien/docx-template-system"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-3 text-sm text-secondary-foreground transition-colors hover:text-foreground"
+          >
+            <ExternalLink className="h-4 w-4 text-muted-foreground" />
+            GitHub 仓库
+          </a>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/admin/editor-ai/page.tsx
+++ b/src/app/(dashboard)/admin/editor-ai/page.tsx
@@ -1,0 +1,610 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import {
+  Plus,
+  Pencil,
+  Trash2,
+  Loader2,
+  Sparkles,
+  Power,
+  PowerOff,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+import { toast } from "sonner";
+import type { EditorAIActionItem } from "@/types/editor-ai";
+
+type Scope = "selection" | "paragraph" | "document";
+type Category = "general" | "writing" | "translation" | "analysis";
+
+const CATEGORY_LABELS: Record<Category, string> = {
+  general: "通用",
+  writing: "写作",
+  translation: "翻译",
+  analysis: "分析",
+};
+
+const SCOPE_LABELS: Record<Scope, string> = {
+  selection: "选区",
+  paragraph: "段落",
+  document: "文档",
+};
+
+interface FormData {
+  name: string;
+  icon: string;
+  prompt: string;
+  category: Category;
+  scope: Scope;
+}
+
+const emptyForm: FormData = {
+  name: "",
+  icon: "",
+  prompt: "",
+  category: "general",
+  scope: "selection",
+};
+
+export default function EditorAIAdminPage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+
+  const [actions, setActions] = useState<EditorAIActionItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // Create/Edit dialog
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingAction, setEditingAction] = useState<EditorAIActionItem | null>(null);
+  const [formLoading, setFormLoading] = useState(false);
+  const [formData, setFormData] = useState<FormData>({ ...emptyForm });
+
+  // Delete dialog
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [deletingAction, setDeletingAction] = useState<EditorAIActionItem | null>(null);
+  const [deleteLoading, setDeleteLoading] = useState(false);
+
+  // Toggle loading state
+  const [togglingId, setTogglingId] = useState<string | null>(null);
+
+  // Redirect non-admins
+  useEffect(() => {
+    if (status === "unauthenticated") {
+      router.push("/login");
+    } else if (status === "authenticated" && session?.user?.role !== "ADMIN") {
+      router.push("/");
+    }
+  }, [status, session, router]);
+
+  const fetchActions = useCallback(async () => {
+    if (status !== "authenticated" || session?.user?.role !== "ADMIN") return;
+
+    setLoading(true);
+    try {
+      const res = await fetch("/api/editor-ai/actions?admin=true");
+      const data = await res.json();
+
+      if (data.success) {
+        setActions(data.data);
+      } else {
+        toast.error("获取 AI 操作列表失败");
+      }
+    } catch (error) {
+      console.error("获取 AI 操作列表失败:", error);
+      toast.error("获取 AI 操作列表失败");
+    } finally {
+      setLoading(false);
+    }
+  }, [status, session]);
+
+  useEffect(() => {
+    fetchActions();
+  }, [fetchActions]);
+
+  const openCreateDialog = () => {
+    setEditingAction(null);
+    setFormData({ ...emptyForm });
+    setDialogOpen(true);
+  };
+
+  const openEditDialog = (action: EditorAIActionItem) => {
+    setEditingAction(action);
+    setFormData({
+      name: action.name,
+      icon: action.icon ?? "",
+      prompt: action.prompt,
+      category: action.category as Category,
+      scope: action.scope,
+    });
+    setDialogOpen(true);
+  };
+
+  const handleSubmit = async () => {
+    if (!formData.name.trim() || !formData.prompt.trim()) {
+      toast.error("名称和提示词不能为空");
+      return;
+    }
+
+    setFormLoading(true);
+    try {
+      const isEdit = !!editingAction;
+      const url = isEdit
+        ? `/api/editor-ai/actions/${editingAction.id}`
+        : "/api/editor-ai/actions?admin=true";
+      const method = isEdit ? "PATCH" : "POST";
+
+      const body: Record<string, unknown> = {
+        name: formData.name.trim(),
+        icon: formData.icon.trim() || undefined,
+        prompt: formData.prompt.trim(),
+        category: formData.category,
+        scope: formData.scope,
+      };
+
+      const res = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      const data = await res.json();
+
+      if (res.ok && data.success) {
+        toast.success(isEdit ? "操作已更新" : "操作已创建");
+        setDialogOpen(false);
+        fetchActions();
+      } else {
+        toast.error(data.error?.message || "操作失败");
+      }
+    } catch (error) {
+      console.error("保存操作失败:", error);
+      toast.error("保存操作失败");
+    } finally {
+      setFormLoading(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deletingAction) return;
+
+    setDeleteLoading(true);
+    try {
+      const res = await fetch(`/api/editor-ai/actions/${deletingAction.id}`, {
+        method: "DELETE",
+      });
+
+      const data = await res.json();
+
+      if (res.ok && data.success) {
+        toast.success("操作已删除");
+        setDeleteDialogOpen(false);
+        setDeletingAction(null);
+        fetchActions();
+      } else {
+        toast.error(data.error?.message || "删除失败");
+      }
+    } catch (error) {
+      console.error("删除操作失败:", error);
+      toast.error("删除操作失败");
+    } finally {
+      setDeleteLoading(false);
+    }
+  };
+
+  const handleToggle = async (action: EditorAIActionItem) => {
+    setTogglingId(action.id);
+    try {
+      const res = await fetch(`/api/editor-ai/actions/${action.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: !action.enabled }),
+      });
+
+      const data = await res.json();
+
+      if (res.ok && data.success) {
+        toast.success(action.enabled ? "已禁用" : "已启用");
+        fetchActions();
+      } else {
+        toast.error(data.error?.message || "切换状态失败");
+      }
+    } catch (error) {
+      console.error("切换状态失败:", error);
+      toast.error("切换状态失败");
+    } finally {
+      setTogglingId(null);
+    }
+  };
+
+  if (
+    status === "loading" ||
+    (status === "authenticated" && session?.user?.role !== "ADMIN")
+  ) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            编辑器 AI 操作管理
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            管理全局 AI 操作模板，所有用户共享
+          </p>
+        </div>
+        <Button onClick={openCreateDialog} className="w-full sm:w-auto">
+          <Plus className="h-4 w-4 mr-2" />
+          新建操作
+        </Button>
+      </div>
+
+      {/* Actions Table */}
+      <div className="border rounded-lg overflow-hidden">
+        {loading ? (
+          <div className="flex items-center justify-center h-48">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </div>
+        ) : actions.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-48 text-muted-foreground">
+            <Sparkles className="h-12 w-12 mb-3 opacity-50" />
+            <p>暂无 AI 操作</p>
+          </div>
+        ) : (
+          <>
+            {/* Desktop Table */}
+            <div className="hidden md:block overflow-x-auto">
+              <table className="w-full">
+                <thead className="bg-muted/50 border-b">
+                  <tr>
+                    <th className="text-left px-4 py-3 text-sm font-medium">
+                      操作
+                    </th>
+                    <th className="text-left px-4 py-3 text-sm font-medium">
+                      分类
+                    </th>
+                    <th className="text-left px-4 py-3 text-sm font-medium">
+                      范围
+                    </th>
+                    <th className="text-left px-4 py-3 text-sm font-medium">
+                      状态
+                    </th>
+                    <th className="text-left px-4 py-3 text-sm font-medium">
+                      类型
+                    </th>
+                    <th className="text-right px-4 py-3 text-sm font-medium">
+                      操作
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y">
+                  {actions.map((action) => (
+                    <tr
+                      key={action.id}
+                      className="hover:bg-muted/30 transition-colors"
+                    >
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-3">
+                          {action.icon && (
+                            <span className="text-lg">{action.icon}</span>
+                          )}
+                          <div>
+                            <p className="font-medium">{action.name}</p>
+                            <p className="text-sm text-muted-foreground line-clamp-1 max-w-[240px]">
+                              {action.prompt}
+                            </p>
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <Badge variant="secondary">
+                          {CATEGORY_LABELS[action.category as Category] ??
+                            action.category}
+                        </Badge>
+                      </td>
+                      <td className="px-4 py-3">
+                        <Badge variant="outline">
+                          {SCOPE_LABELS[action.scope] ?? action.scope}
+                        </Badge>
+                      </td>
+                      <td className="px-4 py-3">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleToggle(action)}
+                          disabled={
+                            togglingId === action.id || action.isBuiltIn
+                          }
+                        >
+                          {togglingId === action.id ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : action.enabled ? (
+                            <Power className="h-4 w-4 text-green-600" />
+                          ) : (
+                            <PowerOff className="h-4 w-4 text-muted-foreground" />
+                          )}
+                        </Button>
+                      </td>
+                      <td className="px-4 py-3">
+                        {action.isBuiltIn && (
+                          <Badge variant="default">内置</Badge>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex justify-end gap-2">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => openEditDialog(action)}
+                            disabled={action.isBuiltIn}
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => {
+                              setDeletingAction(action);
+                              setDeleteDialogOpen(true);
+                            }}
+                            disabled={action.isBuiltIn}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {/* Mobile Cards */}
+            <div className="md:hidden divide-y">
+              {actions.map((action) => (
+                <div key={action.id} className="p-4 space-y-3">
+                  <div className="flex items-start justify-between">
+                    <div className="flex items-center gap-3">
+                      {action.icon && <span className="text-lg">{action.icon}</span>}
+                      <div>
+                        <p className="font-medium">{action.name}</p>
+                        <p className="text-sm text-muted-foreground line-clamp-1">
+                          {action.prompt}
+                        </p>
+                      </div>
+                    </div>
+                    {action.isBuiltIn && <Badge variant="default">内置</Badge>}
+                  </div>
+
+                  <div className="flex gap-2">
+                    <Badge variant="secondary">
+                      {CATEGORY_LABELS[action.category as Category] ??
+                        action.category}
+                    </Badge>
+                    <Badge variant="outline">
+                      {SCOPE_LABELS[action.scope] ?? action.scope}
+                    </Badge>
+                    <Badge variant={action.enabled ? "default" : "outline"}>
+                      {action.enabled ? "已启用" : "已禁用"}
+                    </Badge>
+                  </div>
+
+                  <div className="flex items-center justify-between pt-2 border-t">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleToggle(action)}
+                      disabled={togglingId === action.id || action.isBuiltIn}
+                    >
+                      {togglingId === action.id ? (
+                        <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                      ) : action.enabled ? (
+                        <PowerOff className="h-3 w-3 mr-1" />
+                      ) : (
+                        <Power className="h-3 w-3 mr-1" />
+                      )}
+                      {action.enabled ? "禁用" : "启用"}
+                    </Button>
+                    <div className="flex gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => openEditDialog(action)}
+                        disabled={action.isBuiltIn}
+                      >
+                        <Pencil className="h-3 w-3 mr-1" />
+                        编辑
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => {
+                          setDeletingAction(action);
+                          setDeleteDialogOpen(true);
+                        }}
+                        disabled={action.isBuiltIn}
+                      >
+                        <Trash2 className="h-3 w-3 mr-1" />
+                        删除
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Create/Edit Dialog */}
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="sm:max-w-[525px]">
+          <DialogHeader>
+            <DialogTitle>
+              {editingAction ? "编辑 AI 操作" : "新建 AI 操作"}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="action-name">名称</Label>
+                <Input
+                  id="action-name"
+                  value={formData.name}
+                  onChange={(e) =>
+                    setFormData({ ...formData, name: e.target.value })
+                  }
+                  placeholder="例如：润色文本"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="action-icon">图标（emoji）</Label>
+                <Input
+                  id="action-icon"
+                  value={formData.icon}
+                  onChange={(e) =>
+                    setFormData({ ...formData, icon: e.target.value })
+                  }
+                  placeholder="例如：✨"
+                  maxLength={10}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="action-prompt">提示词</Label>
+              <Textarea
+                id="action-prompt"
+                value={formData.prompt}
+                onChange={(e) =>
+                  setFormData({ ...formData, prompt: e.target.value })
+                }
+                placeholder="输入 AI 提示词模板，可使用 {{selection}}、{{context}} 等变量"
+                rows={5}
+                className="resize-none"
+              />
+              <p className="text-xs text-muted-foreground">
+                可用变量：&#123;&#123;selection&#125;&#125;（选中文本）、&#123;&#123;context&#125;&#125;（上下文）、&#123;&#123;instruction&#125;&#125;（用户指令）
+              </p>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="action-category">分类</Label>
+                <Select
+                  value={formData.category}
+                  onValueChange={(v) =>
+                    v && setFormData({ ...formData, category: v as Category })
+                  }
+                >
+                  <SelectTrigger id="action-category">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {Object.entries(CATEGORY_LABELS).map(([value, label]) => (
+                      <SelectItem key={value} value={value}>
+                        {label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="action-scope">范围</Label>
+                <Select
+                  value={formData.scope}
+                  onValueChange={(v) =>
+                    v && setFormData({ ...formData, scope: v as Scope })
+                  }
+                >
+                  <SelectTrigger id="action-scope">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {Object.entries(SCOPE_LABELS).map(([value, label]) => (
+                      <SelectItem key={value} value={value}>
+                        {label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <p className="text-sm text-muted-foreground">
+              全局操作对所有用户可见。创建后可通过启用/禁用开关控制是否在编辑器中展示。
+            </p>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDialogOpen(false)}>
+              取消
+            </Button>
+            <Button onClick={handleSubmit} disabled={formLoading}>
+              {formLoading && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              {editingAction ? "保存" : "创建"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>确认删除</AlertDialogTitle>
+            <AlertDialogDescription>
+              确定要删除 AI 操作 &quot;{deletingAction?.name}&quot; 吗？此操作无法撤销。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>取消</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={deleteLoading}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {deleteLoading && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              删除
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/app/(reports)/reports/drafts/[id]/page.tsx
+++ b/src/app/(reports)/reports/drafts/[id]/page.tsx
@@ -297,7 +297,7 @@ function EditorContent() {
     const blocks = draft.sections[activeSection] || [];
     const text = blocks
       .map((b: any) => {
-        if (!b.content) return "";
+        if (!b.content || !Array.isArray(b.content)) return "";
         return b.content
           .filter((s: any) => s.type === "text")
           .map((s: any) => s.text)

--- a/src/app/(reports)/reports/drafts/[id]/page.tsx
+++ b/src/app/(reports)/reports/drafts/[id]/page.tsx
@@ -9,6 +9,10 @@ import { OutlinePanel } from "@/modules/reports/components/editor/OutlinePanel";
 import { CollaborationProvider, useCollaboration } from "@/modules/reports/components/editor/CollaborationProvider";
 import { OnlineUsers } from "@/modules/reports/components/editor/OnlineUsers";
 import { ShareDialog } from "@/modules/reports/components/editor/ShareDialog";
+import { AIChatSidebar } from "@/modules/reports/components/editor/ai/AIChatSidebar";
+import { useEditorAIStore } from "@/modules/reports/components/editor/ai/useEditorAIStore";
+import { AIActionForm } from "@/modules/reports/components/editor/ai/AIActionForm";
+import type { EditorAIActionItem } from "@/types/editor-ai";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { Streamdown } from "streamdown";
@@ -53,6 +57,9 @@ function EditorContent() {
   const editorRef = useRef<any>(null);
   const [editedPrompt, setEditedPrompt] = useState("");
   const [isEditingPrompt, setIsEditingPrompt] = useState(false);
+  const [rightTab, setRightTab] = useState<"outline" | "ai">("outline");
+  const [aiFormOpen, setAIFormOpen] = useState(false);
+  const [editingAction, setEditingAction] = useState<EditorAIActionItem | null>(null);
 
   const scheduleAutoSave = useCallback(() => {
     if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
@@ -511,20 +518,33 @@ function EditorContent() {
           collabFragment={provider ? getFragment(activeSection) : null}
           collabProvider={provider}
           onEditorMount={(editor) => { editorRef.current = editor; }}
+          onOpenAISidebar={() => { setRightTab("ai"); setRightCollapsed(false); }}
+          onEditAIAction={(action) => { setEditingAction(action); setAIFormOpen(true); }}
+          onCreateAIAction={() => { setEditingAction(null); setAIFormOpen(true); }}
         />
       </div>
 
-      {/* 右侧：大纲面板 */}
+      {/* 右侧：大纲/AI面板 */}
       <div
-        className={`shrink-0 border-l border-border bg-card overflow-y-auto overflow-x-hidden transition-[width] duration-200 flex flex-col ${rightCollapsed ? "w-0 border-l-0" : "w-48"}`}
+        className={`shrink-0 border-l border-border bg-card overflow-y-auto overflow-x-hidden transition-[width] duration-200 flex flex-col ${rightCollapsed ? "w-0 border-l-0" : "w-72"}`}
       >
-        <div className="w-48 flex flex-col flex-1">
-          <div className="flex items-center justify-end px-3 pt-3 pb-2">
-            <button onClick={() => setRightCollapsed(true)} className="p-0.5 rounded hover:bg-muted text-muted-foreground" title="折叠">
+        <div className="w-72 flex flex-col flex-1">
+          <div className="flex items-center border-b border-border">
+            <button onClick={() => setRightTab("outline")} className={`flex-1 px-3 py-2 text-xs font-medium ${
+              rightTab === "outline" ? "text-primary border-b-2 border-primary" : "text-muted-foreground hover:text-foreground"
+            }`}>大纲</button>
+            <button onClick={() => { setRightTab("ai"); }} className={`flex-1 px-3 py-2 text-xs font-medium ${
+              rightTab === "ai" ? "text-primary border-b-2 border-primary" : "text-muted-foreground hover:text-foreground"
+            }`}>✨ AI 助手</button>
+            <button onClick={() => setRightCollapsed(true)} className="p-0.5 px-2 rounded hover:bg-muted text-muted-foreground" title="折叠">
               <PanelRightClose width="14" height="14" />
             </button>
           </div>
-          <OutlinePanel sections={draft.sections} sectionEnabled={draft.sectionEnabled} activeSection={activeSection} onNavigateHeading={handleNavigateHeading} collapsed={rightCollapsed} />
+          {rightTab === "outline" ? (
+            <OutlinePanel sections={draft.sections} sectionEnabled={draft.sectionEnabled} activeSection={activeSection} onNavigateHeading={handleNavigateHeading} collapsed={rightCollapsed} />
+          ) : (
+            <AIChatSidebar editorRef={editorRef} />
+          )}
         </div>
       </div>
 
@@ -545,6 +565,13 @@ function EditorContent() {
         collaboratorIds={collaboratorIds}
         collaborators={collaborators}
         onCollaboratorsChange={setCollaborators}
+      />
+
+      <AIActionForm
+        open={aiFormOpen}
+        onOpenChange={setAIFormOpen}
+        action={editingAction}
+        onSuccess={() => { setAIFormOpen(false); }}
       />
     </div>
   );

--- a/src/app/(reports)/reports/drafts/[id]/page.tsx
+++ b/src/app/(reports)/reports/drafts/[id]/page.tsx
@@ -47,6 +47,7 @@ function EditorContent() {
   const [scrollTargetBlockId, setScrollTargetBlockId] = useState<string | undefined>();
   const [leftCollapsed, setLeftCollapsed] = useState(false);
   const [rightCollapsed, setRightCollapsed] = useState(false);
+  const [rightWidth, setRightWidth] = useState(288);
   const [shareOpen, setShareOpen] = useState(false);
 
   const [isGenerating, setIsGenerating] = useState(false);
@@ -525,28 +526,58 @@ function EditorContent() {
       </div>
 
       {/* 右侧：大纲/AI面板 */}
-      <div
-        className={`shrink-0 border-l border-border bg-card overflow-y-auto overflow-x-hidden transition-[width] duration-200 flex flex-col ${rightCollapsed ? "w-0 border-l-0" : "w-72"}`}
-      >
-        <div className="w-72 flex flex-col flex-1">
-          <div className="flex items-center border-b border-border">
-            <button onClick={() => setRightTab("outline")} className={`flex-1 px-3 py-2 text-xs font-medium ${
-              rightTab === "outline" ? "text-primary border-b-2 border-primary" : "text-muted-foreground hover:text-foreground"
-            }`}>大纲</button>
-            <button onClick={() => { setRightTab("ai"); }} className={`flex-1 px-3 py-2 text-xs font-medium ${
-              rightTab === "ai" ? "text-primary border-b-2 border-primary" : "text-muted-foreground hover:text-foreground"
-            }`}>✨ AI 助手</button>
-            <button onClick={() => setRightCollapsed(true)} className="p-0.5 px-2 rounded hover:bg-muted text-muted-foreground" title="折叠">
-              <PanelRightClose width="14" height="14" />
-            </button>
+      {!rightCollapsed && (
+        <div
+          className="shrink-0 border-l border-border bg-card flex flex-col relative"
+          style={{ width: rightWidth }}
+        >
+          {/* Drag handle on left edge */}
+          <div
+            className="absolute top-0 bottom-0 -left-1 z-10 w-2 cursor-col-resize group"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              const startX = e.clientX;
+              const startW = rightWidth;
+              document.body.style.cursor = "col-resize";
+              document.body.style.userSelect = "none";
+              const onMove = (ev: MouseEvent) => {
+                const delta = startX - ev.clientX;
+                setRightWidth(Math.min(640, Math.max(220, startW + delta)));
+              };
+              const cleanup = () => {
+                document.body.style.cursor = "";
+                document.body.style.userSelect = "";
+                document.removeEventListener("mousemove", onMove);
+                document.removeEventListener("mouseup", cleanup);
+                window.removeEventListener("blur", cleanup);
+              };
+              document.addEventListener("mousemove", onMove);
+              document.addEventListener("mouseup", cleanup);
+              window.addEventListener("blur", cleanup);
+            }}
+          >
+            <div className="h-full w-0.5 mx-auto bg-transparent group-hover:bg-primary/40 transition-colors" />
           </div>
-          {rightTab === "outline" ? (
-            <OutlinePanel sections={draft.sections} sectionEnabled={draft.sectionEnabled} activeSection={activeSection} onNavigateHeading={handleNavigateHeading} collapsed={rightCollapsed} />
-          ) : (
-            <AIChatSidebar editorRef={editorRef} />
-          )}
+          <div className="flex flex-col flex-1 overflow-y-auto overflow-x-hidden">
+            <div className="flex items-center border-b border-border">
+              <button onClick={() => setRightTab("outline")} className={`flex-1 px-3 py-2 text-xs font-medium ${
+                rightTab === "outline" ? "text-primary border-b-2 border-primary" : "text-muted-foreground hover:text-foreground"
+              }`}>大纲</button>
+              <button onClick={() => { setRightTab("ai"); }} className={`flex-1 px-3 py-2 text-xs font-medium ${
+                rightTab === "ai" ? "text-primary border-b-2 border-primary" : "text-muted-foreground hover:text-foreground"
+              }`}>✨ AI 助手</button>
+              <button onClick={() => setRightCollapsed(true)} className="p-0.5 px-2 rounded hover:bg-muted text-muted-foreground" title="折叠">
+                <PanelRightClose width="14" height="14" />
+              </button>
+            </div>
+            {rightTab === "outline" ? (
+              <OutlinePanel sections={draft.sections} sectionEnabled={draft.sectionEnabled} activeSection={activeSection} onNavigateHeading={handleNavigateHeading} collapsed={rightCollapsed} />
+            ) : (
+              <AIChatSidebar editorRef={editorRef} />
+            )}
+          </div>
         </div>
-      </div>
+      )}
 
       {/* 底部操作栏 */}
       <div className="fixed bottom-0 right-0 flex items-center gap-2 border-t border-border bg-card px-6 py-3"

--- a/src/app/(reports)/reports/drafts/[id]/page.tsx
+++ b/src/app/(reports)/reports/drafts/[id]/page.tsx
@@ -292,6 +292,22 @@ function EditorContent() {
     setIsGenerating(false);
   }, [activeSection]);
 
+  // Sync section text to AI store for context
+  useEffect(() => {
+    const blocks = draft.sections[activeSection] || [];
+    const text = blocks
+      .map((b: any) => {
+        if (!b.content) return "";
+        return b.content
+          .filter((s: any) => s.type === "text")
+          .map((s: any) => s.text)
+          .join("");
+      })
+      .filter(Boolean)
+      .join("\n");
+    useEditorAIStore.getState().setSectionContent(text.slice(0, 4000));
+  }, [activeSection, draft.sections]);
+
   useEffect(() => {
     setEditedPrompt(activePrompt?.prompt || "");
     setIsEditingPrompt(false);

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -3,24 +3,42 @@ import { authOptions } from "@/lib/auth-options";
 
 const nextAuthHandler = NextAuth(authOptions);
 
-export async function GET(
-  req: Request,
-  context: { params: Promise<{ nextauth: string[] }> }
-) {
+function resolveNextAuthUrl(req: Request): string {
   const url = new URL(req.url);
-  const dynamicBaseUrl = `${url.protocol}//${url.host}`;
+  // When dev server binds to 0.0.0.0, the host in request URL is "0.0.0.0:port"
+  // which browsers cannot access. Replace with localhost.
+  let host = url.host;
+  if (host.startsWith("0.0.0.0")) {
+    host = host.replace("0.0.0.0", "localhost");
+  }
+  // Prefer the Origin header when available — it reflects the browser's address.
+  const origin = req.headers.get("origin");
+  if (origin) return origin;
+  return `${url.protocol}//${host}`;
+}
 
+function withDynamicUrl(req: Request) {
+  const resolved = resolveNextAuthUrl(req);
   const original = process.env.NEXTAUTH_URL;
-  process.env.NEXTAUTH_URL = dynamicBaseUrl;
-
-  try {
-    return await nextAuthHandler(req, context);
-  } finally {
+  process.env.NEXTAUTH_URL = resolved;
+  return () => {
     if (original !== undefined) {
       process.env.NEXTAUTH_URL = original;
     } else {
       delete process.env.NEXTAUTH_URL;
     }
+  };
+}
+
+export async function GET(
+  req: Request,
+  context: { params: Promise<{ nextauth: string[] }> }
+) {
+  const restore = withDynamicUrl(req);
+  try {
+    return await nextAuthHandler(req, context);
+  } finally {
+    restore();
   }
 }
 
@@ -28,19 +46,10 @@ export async function POST(
   req: Request,
   context: { params: Promise<{ nextauth: string[] }> }
 ) {
-  const url = new URL(req.url);
-  const dynamicBaseUrl = `${url.protocol}//${url.host}`;
-
-  const original = process.env.NEXTAUTH_URL;
-  process.env.NEXTAUTH_URL = dynamicBaseUrl;
-
+  const restore = withDynamicUrl(req);
   try {
     return await nextAuthHandler(req, context);
   } finally {
-    if (original !== undefined) {
-      process.env.NEXTAUTH_URL = original;
-    } else {
-      delete process.env.NEXTAUTH_URL;
-    }
+    restore();
   }
 }

--- a/src/app/api/editor-ai/actions/[id]/route.ts
+++ b/src/app/api/editor-ai/actions/[id]/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { ZodError } from "zod";
+import {
+  updateAction,
+  deleteAction,
+} from "@/lib/services/editor-ai-action.service";
+import { updateActionSchema } from "@/validators/editor-ai";
+
+const ERROR_STATUS_MAP: Record<string, number> = {
+  NOT_FOUND: 404,
+  FORBIDDEN: 403,
+  BUILT_IN_PROTECTED: 400,
+};
+
+// PATCH /api/editor-ai/actions/[id] - Update an action
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "未登录" } },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const parsed = updateActionSchema.parse(body);
+    const isAdmin = session.user.role === "ADMIN";
+    const result = await updateAction(id, parsed, session.user.id, isAdmin);
+
+    if (!result.success) {
+      const status = ERROR_STATUS_MAP[result.error.code] ?? 400;
+      return NextResponse.json({ error: result.error }, { status });
+    }
+
+    return NextResponse.json({ success: true, data: result.data });
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "参数校验失败" } },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: error instanceof Error ? error.message : "更新动作失败",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}
+
+// DELETE /api/editor-ai/actions/[id] - Delete an action
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "未登录" } },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const { id } = await params;
+    const isAdmin = session.user.role === "ADMIN";
+    const result = await deleteAction(id, session.user.id, isAdmin);
+
+    if (!result.success) {
+      const status = ERROR_STATUS_MAP[result.error.code] ?? 400;
+      return NextResponse.json({ error: result.error }, { status });
+    }
+
+    return NextResponse.json({ success: true, data: result.data });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: error instanceof Error ? error.message : "删除动作失败",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/editor-ai/actions/route.ts
+++ b/src/app/api/editor-ai/actions/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { ZodError } from "zod";
+import {
+  listAvailableActions,
+  createUserAction,
+} from "@/lib/services/editor-ai-action.service";
+import { createActionSchema } from "@/validators/editor-ai";
+
+// GET /api/editor-ai/actions - List available actions for current user
+export async function GET() {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "未登录" } },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const result = await listAvailableActions(session.user.id);
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+
+    return NextResponse.json({ success: true, data: result.data });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: error instanceof Error ? error.message : "加载动作列表失败",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}
+
+// POST /api/editor-ai/actions - Create a user action
+export async function POST(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "未登录" } },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const parsed = createActionSchema.parse(body);
+    const result = await createUserAction(session.user.id, parsed);
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+
+    return NextResponse.json({ success: true, data: result.data }, { status: 201 });
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "参数校验失败" } },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: error instanceof Error ? error.message : "创建动作失败",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/editor-ai/actions/route.ts
+++ b/src/app/api/editor-ai/actions/route.ts
@@ -3,12 +3,14 @@ import { auth } from "@/lib/auth";
 import { ZodError } from "zod";
 import {
   listAvailableActions,
+  listAllActions,
   createUserAction,
+  createGlobalAction,
 } from "@/lib/services/editor-ai-action.service";
 import { createActionSchema } from "@/validators/editor-ai";
 
-// GET /api/editor-ai/actions - List available actions for current user
-export async function GET() {
+// GET /api/editor-ai/actions - List actions (admin: all global actions; user: available actions)
+export async function GET(request: NextRequest) {
   const session = await auth();
   if (!session?.user) {
     return NextResponse.json(
@@ -18,6 +20,17 @@ export async function GET() {
   }
 
   try {
+    const { searchParams } = new URL(request.url);
+    const isAdmin = session.user.role === "ADMIN";
+
+    if (isAdmin && searchParams.get("admin") === "true") {
+      const result = await listAllActions();
+      if (!result.success) {
+        return NextResponse.json({ error: result.error }, { status: 400 });
+      }
+      return NextResponse.json({ success: true, data: result.data });
+    }
+
     const result = await listAvailableActions(session.user.id);
 
     if (!result.success) {
@@ -38,7 +51,7 @@ export async function GET() {
   }
 }
 
-// POST /api/editor-ai/actions - Create a user action
+// POST /api/editor-ai/actions - Create action (admin: global; user: personal)
 export async function POST(request: NextRequest) {
   const session = await auth();
   if (!session?.user) {
@@ -51,6 +64,19 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const parsed = createActionSchema.parse(body);
+    const isAdmin = session.user.role === "ADMIN";
+
+    const { searchParams } = new URL(request.url);
+    const isGlobal = isAdmin && searchParams.get("admin") === "true";
+
+    if (isGlobal) {
+      const result = await createGlobalAction(parsed);
+      if (!result.success) {
+        return NextResponse.json({ error: result.error }, { status: 400 });
+      }
+      return NextResponse.json({ success: true, data: result.data }, { status: 201 });
+    }
+
     const result = await createUserAction(session.user.id, parsed);
 
     if (!result.success) {

--- a/src/app/api/editor-ai/chat/route.ts
+++ b/src/app/api/editor-ai/chat/route.ts
@@ -16,7 +16,7 @@ export async function POST(req: Request) {
     const body = await req.json();
     const parsed = chatSchema.parse(body);
 
-    const { model } = await resolveModel(parsed.model, session.user.id);
+    const { model, providerName, extraParams } = await resolveModel(parsed.model, session.user.id);
 
     let systemPrompt = "你是一个专业的报告写作助手。用户正在撰写报告，你可以帮助润色、改写、扩展、分析文本。\n\n";
 
@@ -37,6 +37,9 @@ export async function POST(req: Request) {
         role: m.role as "user" | "assistant",
         content: m.content,
       })),
+      providerOptions: extraParams
+        ? { [providerName]: extraParams } as Record<string, unknown> as import("@ai-sdk/provider").SharedV3ProviderOptions
+        : undefined,
     });
 
     return result.toTextStreamResponse();

--- a/src/app/api/editor-ai/chat/route.ts
+++ b/src/app/api/editor-ai/chat/route.ts
@@ -1,0 +1,50 @@
+import { streamText } from "ai";
+import { auth } from "@/lib/auth";
+import { resolveModel } from "@/lib/agent2/model-resolver";
+import { chatSchema } from "@/validators/editor-ai";
+
+export async function POST(req: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const body = await req.json();
+    const parsed = chatSchema.parse(body);
+
+    const { model } = await resolveModel(parsed.model, session.user.id);
+
+    let systemPrompt = "你是一个专业的报告写作助手。用户正在撰写报告，你可以帮助润色、改写、扩展、分析文本。\n\n";
+
+    if (parsed.context?.sectionContent) {
+      systemPrompt += `当前章节内容（供参考）：\n${parsed.context.sectionContent.slice(0, 4000)}\n\n`;
+    }
+
+    if (parsed.context?.pinnedSelections?.length) {
+      systemPrompt += `用户引用的文本片段：\n${parsed.context.pinnedSelections.map((s, i) => `[引用 ${i + 1}]: ${s}`).join("\n\n")}\n\n`;
+    }
+
+    systemPrompt += "请用中文回复。如果用户要求修改文本，直接返回修改后的内容。";
+
+    const result = streamText({
+      model,
+      system: systemPrompt,
+      messages: parsed.messages.map((m) => ({
+        role: m.role as "user" | "assistant",
+        content: m.content,
+      })),
+    });
+
+    return result.toTextStreamResponse();
+  } catch (error) {
+    console.error("[Editor AI Chat Error]", error);
+    return new Response(
+      JSON.stringify({ error: error instanceof Error ? error.message : "Unknown error" }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+}

--- a/src/app/api/editor-ai/execute/route.ts
+++ b/src/app/api/editor-ai/execute/route.ts
@@ -1,7 +1,7 @@
 import { streamText } from "ai";
 import { auth } from "@/lib/auth";
 import { resolveModel } from "@/lib/agent2/model-resolver";
-import { getAction, renderPrompt } from "@/lib/services/editor-ai-action.service";
+import { getActionForUser, renderPrompt } from "@/lib/services/editor-ai-action.service";
 import { executeActionSchema } from "@/validators/editor-ai";
 
 export async function POST(req: Request) {
@@ -21,7 +21,7 @@ export async function POST(req: Request) {
     let userMessage: string;
 
     if (parsed.actionId) {
-      const actionResult = await getAction(parsed.actionId);
+      const actionResult = await getActionForUser(parsed.actionId, session.user.id);
       if (!actionResult.success) {
         return new Response(JSON.stringify({ error: actionResult.error }), {
           status: 404,

--- a/src/app/api/editor-ai/execute/route.ts
+++ b/src/app/api/editor-ai/execute/route.ts
@@ -46,12 +46,15 @@ export async function POST(req: Request) {
     }
 
     const modelId = parsed.model || process.env.AI_MODEL || "gpt-4o";
-    const { model } = await resolveModel(modelId, session.user.id);
+    const { model, providerName, extraParams } = await resolveModel(modelId, session.user.id);
 
     const result = streamText({
       model,
       system: systemPrompt,
       messages: [{ role: "user", content: userMessage }],
+      providerOptions: extraParams
+        ? { [providerName]: extraParams } as Record<string, unknown> as import("@ai-sdk/provider").SharedV3ProviderOptions
+        : undefined,
     });
 
     return result.toTextStreamResponse();

--- a/src/app/api/editor-ai/execute/route.ts
+++ b/src/app/api/editor-ai/execute/route.ts
@@ -1,0 +1,65 @@
+import { streamText } from "ai";
+import { auth } from "@/lib/auth";
+import { resolveModel } from "@/lib/agent2/model-resolver";
+import { getAction, renderPrompt } from "@/lib/services/editor-ai-action.service";
+import { executeActionSchema } from "@/validators/editor-ai";
+
+export async function POST(req: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const body = await req.json();
+    const parsed = executeActionSchema.parse(body);
+
+    let systemPrompt: string;
+    let userMessage: string;
+
+    if (parsed.actionId) {
+      const actionResult = await getAction(parsed.actionId);
+      if (!actionResult.success) {
+        return new Response(JSON.stringify({ error: actionResult.error }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      systemPrompt = "你是一个专业的文本编辑助手。请根据用户指令处理提供的文本，直接返回处理后的结果，不要添加多余的解释。";
+      userMessage = renderPrompt(actionResult.data.prompt, {
+        selection: parsed.selection,
+        context: parsed.context,
+        instruction: parsed.instruction,
+      });
+    } else {
+      systemPrompt = "你是一个专业的文本编辑助手。请根据用户指令处理提供的文本，直接返回处理后的结果。";
+      userMessage = parsed.instruction || parsed.prompt || "";
+      if (parsed.selection) {
+        userMessage += "\n\n待处理文本：\n" + parsed.selection;
+      }
+      if (parsed.context) {
+        userMessage += "\n\n上下文：\n" + parsed.context;
+      }
+    }
+
+    const modelId = parsed.model || process.env.AI_MODEL || "gpt-4o";
+    const { model } = await resolveModel(modelId, session.user.id);
+
+    const result = streamText({
+      model,
+      system: systemPrompt,
+      messages: [{ role: "user", content: userMessage }],
+    });
+
+    return result.toTextStreamResponse();
+  } catch (error) {
+    console.error("[Editor AI Execute Error]", error);
+    return new Response(
+      JSON.stringify({ error: error instanceof Error ? error.message : "Unknown error" }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+}

--- a/src/components/layout/navigation/schema.ts
+++ b/src/components/layout/navigation/schema.ts
@@ -1,8 +1,8 @@
 import type { ComponentType } from "react";
-import { Bot, Database, FilePenLine, FileText, FolderHeart, GitBranch, House, LayoutGrid, Settings2, ShieldCheck, Users, WandSparkles } from "lucide-react";
+import { Bot, Database, FilePenLine, FileText, FolderHeart, GitBranch, House, Info, LayoutGrid, Settings2, ShieldCheck, Users, WandSparkles } from "lucide-react";
 import type { Role } from "@/generated/prisma/enums";
 
-export type NavSection = "main" | "reports" | "admin";
+export type NavSection = "main" | "reports" | "admin" | "footer";
 
 export type NavItem = {
   readonly id: string;
@@ -53,6 +53,7 @@ export const NAV_ITEMS: readonly NavItem[] = [
     order: 10,
     roles: ["ADMIN"],
   },
+  { id: "about", icon: Info, href: "/about", label: "关于", section: "footer", order: 99 },
 ] as const satisfies readonly NavItem[];
 
 /**

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -64,6 +64,7 @@ export function Sidebar() {
   const mainItems = navItems.filter((item) => item.section === "main");
   const reportItems = navItems.filter((item) => item.section === "reports");
   const adminItems = navItems.filter((item) => item.section === "admin");
+  const footerItems = navItems.filter((item) => item.section === "footer");
 
   return (
     <aside
@@ -124,8 +125,17 @@ export function Sidebar() {
         ) : null}
       </nav>
 
-      <div className="shrink-0 px-3 py-2 text-xs text-[#62666d]">
-        {!collapsed ? "IDRL填表系统 " : ""}v{process.env.NEXT_PUBLIC_APP_VERSION}
+      <div className="shrink-0 px-3 py-2">
+        <div className="text-xs text-[#62666d]">
+          {!collapsed ? "IDRL填表系统 " : ""}v{process.env.NEXT_PUBLIC_APP_VERSION}
+        </div>
+        {footerItems.length > 0 && (
+          <div className="mt-1 space-y-1">
+            {footerItems.map((item) => (
+              <SidebarNavLink key={item.id} item={item} pathname={pathname} collapsed={collapsed} />
+            ))}
+          </div>
+        )}
       </div>
 
       <div className="shrink-0 border-t border-[rgb(255_255_255_/_0.05)]">

--- a/src/lib/services/editor-ai-action.service.ts
+++ b/src/lib/services/editor-ai-action.service.ts
@@ -67,11 +67,18 @@ export async function listAllActions(): Promise<
   };
 }
 
-export async function getAction(
-  id: string
+export async function getActionForUser(
+  id: string,
+  userId: string
 ): Promise<ServiceResult<EditorAIActionItem>> {
   const action = await db.editorAIAction.findFirst({
-    where: { id },
+    where: {
+      id,
+      OR: [
+        { userId: null, enabled: true },
+        { userId },
+      ],
+    },
   });
 
   if (!action) {

--- a/src/lib/services/editor-ai-action.service.ts
+++ b/src/lib/services/editor-ai-action.service.ts
@@ -1,0 +1,253 @@
+import { db } from "@/lib/db";
+import type { EditorAIActionItem, EditorAIActionCreateInput, EditorAIActionUpdateInput } from "@/types/editor-ai";
+import type { ServiceResult } from "@/types/data-table";
+
+// ── Helpers ──
+
+function mapActionItem(row: {
+  id: string;
+  name: string;
+  icon: string | null;
+  prompt: string;
+  category: string;
+  scope: string;
+  sortOrder: number;
+  isBuiltIn: boolean;
+  enabled: boolean;
+  userId: string | null;
+  createdAt: Date;
+}): EditorAIActionItem {
+  return {
+    id: row.id,
+    name: row.name,
+    icon: row.icon,
+    prompt: row.prompt,
+    category: row.category,
+    scope: row.scope as EditorAIActionItem["scope"],
+    sortOrder: row.sortOrder,
+    isBuiltIn: row.isBuiltIn,
+    enabled: row.enabled,
+    userId: row.userId,
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+// ── Query functions ──
+
+export async function listAvailableActions(
+  userId: string
+): Promise<ServiceResult<EditorAIActionItem[]>> {
+  const actions = await db.editorAIAction.findMany({
+    where: {
+      OR: [
+        { userId: null, enabled: true },
+        { userId },
+      ],
+    },
+    orderBy: [{ category: "asc" }, { sortOrder: "asc" }],
+  });
+
+  return {
+    success: true,
+    data: actions.map(mapActionItem),
+  };
+}
+
+export async function listAllActions(): Promise<
+  ServiceResult<EditorAIActionItem[]>
+> {
+  const actions = await db.editorAIAction.findMany({
+    where: { userId: null },
+    orderBy: [{ category: "asc" }, { sortOrder: "asc" }],
+  });
+
+  return {
+    success: true,
+    data: actions.map(mapActionItem),
+  };
+}
+
+export async function getAction(
+  id: string
+): Promise<ServiceResult<EditorAIActionItem>> {
+  const action = await db.editorAIAction.findFirst({
+    where: { id },
+  });
+
+  if (!action) {
+    return {
+      success: false,
+      error: { code: "NOT_FOUND", message: "AI 动作不存在" },
+    };
+  }
+
+  return {
+    success: true,
+    data: mapActionItem(action),
+  };
+}
+
+// ── Create functions ──
+
+export async function createUserAction(
+  userId: string,
+  data: EditorAIActionCreateInput
+): Promise<ServiceResult<EditorAIActionItem>> {
+  const action = await db.editorAIAction.create({
+    data: {
+      name: data.name,
+      icon: data.icon ?? null,
+      prompt: data.prompt,
+      category: data.category ?? "general",
+      scope: data.scope ?? "selection",
+      isBuiltIn: false,
+      enabled: true,
+      userId,
+    },
+  });
+
+  return {
+    success: true,
+    data: mapActionItem(action),
+  };
+}
+
+export async function createGlobalAction(
+  data: EditorAIActionCreateInput
+): Promise<ServiceResult<EditorAIActionItem>> {
+  const action = await db.editorAIAction.create({
+    data: {
+      name: data.name,
+      icon: data.icon ?? null,
+      prompt: data.prompt,
+      category: data.category ?? "general",
+      scope: data.scope ?? "selection",
+      isBuiltIn: false,
+      enabled: true,
+      userId: null,
+    },
+  });
+
+  return {
+    success: true,
+    data: mapActionItem(action),
+  };
+}
+
+// ── Update function ──
+
+export async function updateAction(
+  id: string,
+  data: EditorAIActionUpdateInput,
+  userId: string,
+  isAdmin: boolean
+): Promise<ServiceResult<EditorAIActionItem>> {
+  const existing = await db.editorAIAction.findFirst({
+    where: { id },
+  });
+
+  if (!existing) {
+    return {
+      success: false,
+      error: { code: "NOT_FOUND", message: "AI 动作不存在" },
+    };
+  }
+
+  // Ownership check: non-admin can only edit their own actions
+  if (!isAdmin && existing.userId !== userId) {
+    return {
+      success: false,
+      error: { code: "FORBIDDEN", message: "无权修改此动作" },
+    };
+  }
+
+  // Built-in protection: cannot modify built-in actions
+  if (existing.isBuiltIn) {
+    return {
+      success: false,
+      error: { code: "BUILT_IN_PROTECTED", message: "内置动作不可修改" },
+    };
+  }
+
+  const updateData: Record<string, unknown> = {};
+  if (data.name !== undefined) updateData.name = data.name;
+  if (data.icon !== undefined) updateData.icon = data.icon ?? null;
+  if (data.prompt !== undefined) updateData.prompt = data.prompt;
+  if (data.category !== undefined) updateData.category = data.category;
+  if (data.scope !== undefined) updateData.scope = data.scope;
+  if (data.enabled !== undefined) updateData.enabled = data.enabled;
+  if (data.sortOrder !== undefined) updateData.sortOrder = data.sortOrder;
+
+  const updated = await db.editorAIAction.update({
+    where: { id },
+    data: updateData,
+  });
+
+  return {
+    success: true,
+    data: mapActionItem(updated),
+  };
+}
+
+// ── Delete function ──
+
+export async function deleteAction(
+  id: string,
+  userId: string,
+  isAdmin: boolean
+): Promise<ServiceResult<{ id: string }>> {
+  const existing = await db.editorAIAction.findFirst({
+    where: { id },
+  });
+
+  if (!existing) {
+    return {
+      success: false,
+      error: { code: "NOT_FOUND", message: "AI 动作不存在" },
+    };
+  }
+
+  // Ownership check: non-admin can only delete their own actions
+  if (!isAdmin && existing.userId !== userId) {
+    return {
+      success: false,
+      error: { code: "FORBIDDEN", message: "无权删除此动作" },
+    };
+  }
+
+  // Built-in protection: cannot delete built-in actions
+  if (existing.isBuiltIn) {
+    return {
+      success: false,
+      error: { code: "BUILT_IN_PROTECTED", message: "内置动作不可删除" },
+    };
+  }
+
+  await db.editorAIAction.delete({
+    where: { id },
+  });
+
+  return {
+    success: true,
+    data: { id },
+  };
+}
+
+// ── Prompt rendering ──
+
+export function renderPrompt(
+  template: string,
+  vars: { selection?: string; context?: string; instruction?: string }
+): string {
+  let result = template;
+  if (vars.selection !== undefined) {
+    result = result.replace(/\{\{selection\}\}/g, vars.selection);
+  }
+  if (vars.context !== undefined) {
+    result = result.replace(/\{\{context\}\}/g, vars.context);
+  }
+  if (vars.instruction !== undefined) {
+    result = result.replace(/\{\{instruction\}\}/g, vars.instruction);
+  }
+  return result;
+}

--- a/src/modules/reports/components/editor/SectionEditor.tsx
+++ b/src/modules/reports/components/editor/SectionEditor.tsx
@@ -14,9 +14,10 @@ import { DefaultChatTransport } from "ai";
 import {
   AIExtension,
   AIMenuController,
-  AIToolbarButton,
   getAISlashMenuItems,
 } from "@blocknote/xl-ai";
+import { AIActionButton } from "./ai/AIActionButton";
+import type { EditorAIActionItem } from "@/types/editor-ai";
 import { en as coreDictionary } from "@blocknote/core/locales";
 import { en as aiDictionary } from "@blocknote/xl-ai/locales";
 import {
@@ -35,6 +36,9 @@ interface SectionEditorProps {
   collabFragment?: Y.XmlFragment | null;
   collabProvider?: WebsocketProvider | null;
   onEditorMount?: (editor: any) => void;
+  onOpenAISidebar?: () => void;
+  onEditAIAction?: (action: EditorAIActionItem) => void;
+  onCreateAIAction?: () => void;
 }
 
 function isBlockNoteBlocks(blocks: EngineBlock[]): boolean {
@@ -104,20 +108,7 @@ function prepareBlocks(blocks: any[]): BlockLike[] {
 
 const aiTransport = new DefaultChatTransport({ api: "/api/reports/chat" });
 
-// AIToolbarButton crashes when editor.getSelection() returns empty blocks.
-// This wrapper only renders it when a valid selection exists.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function AIToolbarButtonSafe({ editor }: { editor: any }) {
-  try {
-    const sel = editor.getSelection();
-    if (!sel || sel.blocks.length === 0) return null;
-  } catch {
-    return null;
-  }
-  return <AIToolbarButton />;
-}
-
-export function SectionEditor({ blocks, onChange, scrollToBlockId, onScrolled, collabFragment, collabProvider, onEditorMount }: SectionEditorProps) {
+export function SectionEditor({ blocks, onChange, scrollToBlockId, onScrolled, collabFragment, collabProvider, onEditorMount, onOpenAISidebar, onEditAIAction, onCreateAIAction }: SectionEditorProps) {
   const { resolvedTheme } = useTheme();
   const { data: session } = useSession();
   const onChangeRef = useRef(onChange);
@@ -410,7 +401,12 @@ export function SectionEditor({ blocks, onChange, scrollToBlockId, onScrolled, c
           formattingToolbar={() => (
             <FormattingToolbar>
               {getFormattingToolbarItems()}
-              <AIToolbarButtonSafe key="ai" editor={editor} />
+              <AIActionButton
+                editor={editor}
+                onOpenSidebar={onOpenAISidebar ?? (() => {})}
+                onEditAction={onEditAIAction ?? (() => {})}
+                onCreateAction={onCreateAIAction ?? (() => {})}
+              />
             </FormattingToolbar>
           )}
         />

--- a/src/modules/reports/components/editor/SectionEditor.tsx
+++ b/src/modules/reports/components/editor/SectionEditor.tsx
@@ -17,6 +17,7 @@ import {
   getAISlashMenuItems,
 } from "@blocknote/xl-ai";
 import { AIActionButton } from "./ai/AIActionButton";
+import { AIActionDialog } from "./ai/AIActionDialog";
 import type { EditorAIActionItem } from "@/types/editor-ai";
 import { en as coreDictionary } from "@blocknote/core/locales";
 import { en as aiDictionary } from "@blocknote/xl-ai/locales";
@@ -403,9 +404,6 @@ export function SectionEditor({ blocks, onChange, scrollToBlockId, onScrolled, c
               {getFormattingToolbarItems()}
               <AIActionButton
                 editor={editor}
-                onOpenSidebar={onOpenAISidebar ?? (() => {})}
-                onEditAction={onEditAIAction ?? (() => {})}
-                onCreateAction={onCreateAIAction ?? (() => {})}
               />
             </FormattingToolbar>
           )}
@@ -416,6 +414,12 @@ export function SectionEditor({ blocks, onChange, scrollToBlockId, onScrolled, c
           getItems={getSlashMenuItems}
         />
       </BlockNoteView>
+      <AIActionDialog
+        editor={editor}
+        onOpenSidebar={onOpenAISidebar ?? (() => {})}
+        onEditAction={onEditAIAction ?? (() => {})}
+        onCreateAction={onCreateAIAction ?? (() => {})}
+      />
     </div>
   );
 }

--- a/src/modules/reports/components/editor/SectionEditor.tsx
+++ b/src/modules/reports/components/editor/SectionEditor.tsx
@@ -169,6 +169,28 @@ export function SectionEditor({ blocks, onChange, scrollToBlockId, onScrolled, c
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor]);
 
+  // Track last focused block ID so sidebar insertions go to the right place
+  useEffect(() => {
+    const pmView = (editor as any)?._tiptapEditor?.view;
+    if (!pmView?.updateState) return;
+    const origUpdateState = pmView.updateState.bind(pmView);
+    pmView.updateState = (state: any) => {
+      origUpdateState(state);
+      const pos = state.selection?.$anchor;
+      if (pos) {
+        for (let d = pos.depth; d > 0; d--) {
+          const node = pos.node(d);
+          if (node.attrs?.id) {
+            (editor as any).__lastFocusedBlockId = node.attrs.id;
+            return;
+          }
+        }
+      }
+    };
+    return () => { pmView.updateState = origUpdateState; };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editor]);
+
 
   // Load content after mount via replaceBlocks so errors can be caught.
   // In collab mode: wait until the Yjs provider has synced so we know whether

--- a/src/modules/reports/components/editor/ai/AIActionButton.tsx
+++ b/src/modules/reports/components/editor/ai/AIActionButton.tsx
@@ -21,38 +21,49 @@ interface AIActionButtonProps {
 
 function getSelection(editor: any): string {
   try {
+    // Try BlockNote's getSelectedText first
+    const selectedText = editor.getSelectedText?.();
+    if (selectedText) return selectedText;
+
     const selectionState = editor.getSelection();
-    if (!selectionState) return "";
-
-    const blocks = editor.topLevelBlocks;
-    const selectedBlocks = blocks.filter(
-      (block: any) =>
-        block.id === selectionState.block ||
-        (selectionState.block &&
-          selectionState.end &&
-          block.id >= selectionState.block &&
-          block.id <= selectionState.end),
-    );
-
-    // Fallback: if no blocks matched by ID range, collect text from focused block
-    if (selectedBlocks.length === 0) {
+    if (!selectionState) {
+      // Fallback: get focused block text
       const focused = editor.focusBlock;
       if (focused) {
-        const content = focused.content?.find((c: any) => c.type === "text");
-        return content?.text ?? "";
+        return extractBlockText(focused);
       }
       return "";
     }
 
-    return selectedBlocks
-      .map((block: any) => {
-        const textContent = block.content?.filter((c: any) => c.type === "text");
-        return textContent?.map((c: any) => c.text).join("") ?? "";
-      })
-      .join("\n");
+    const blocks = editor.topLevelBlocks;
+    const fromBlock = selectionState.from?.block ?? selectionState.block;
+    const toBlock = selectionState.to?.block ?? selectionState.end ?? fromBlock;
+    if (!fromBlock) {
+      const focused = editor.focusBlock;
+      return focused ? extractBlockText(focused) : "";
+    }
+
+    const selectedBlocks = blocks.filter(
+      (block: any) => block.id === fromBlock || (toBlock && block.id === toBlock),
+    );
+
+    if (selectedBlocks.length === 0) {
+      const focused = editor.focusBlock;
+      return focused ? extractBlockText(focused) : "";
+    }
+
+    return selectedBlocks.map(extractBlockText).filter(Boolean).join("\n");
   } catch {
     return "";
   }
+}
+
+function extractBlockText(block: any): string {
+  if (!block?.content) return "";
+  return block.content
+    .filter((c: any) => c.type === "text")
+    .map((c: any) => c.text)
+    .join("");
 }
 
 function getContext(editor: any): string {
@@ -60,10 +71,7 @@ function getContext(editor: any): string {
     const blocks = editor.topLevelBlocks ?? [];
     const text = blocks
       .slice(0, 5)
-      .map((block: any) => {
-        const textContent = block.content?.filter((c: any) => c.type === "text");
-        return textContent?.map((c: any) => c.text).join("") ?? "";
-      })
+      .map(extractBlockText)
       .filter(Boolean)
       .join("\n");
     return text.slice(0, 1000);
@@ -80,9 +88,20 @@ export function AIActionButton({
 }: AIActionButtonProps) {
   const { globalActions, userActions, loading } = useAIActions();
   const [open, setOpen] = useState(false);
+  const [selection, setSelection] = useState("");
+  const [context, setContext] = useState("");
 
-  const selection = getSelection(editor);
-  const context = getContext(editor);
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen) {
+        // Capture selection BEFORE the popover opens (focus shifts)
+        setSelection(getSelection(editor));
+        setContext(getContext(editor));
+      }
+      setOpen(nextOpen);
+    },
+    [editor],
+  );
 
   const handleOpenSidebar = useCallback(() => {
     setOpen(false);
@@ -103,7 +122,7 @@ export function AIActionButton({
   }, [onCreateAction]);
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger
         render={
           <Button

--- a/src/modules/reports/components/editor/ai/AIActionButton.tsx
+++ b/src/modules/reports/components/editor/ai/AIActionButton.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Sparkles, MessageSquare } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import type { EditorAIActionItem } from "@/types/editor-ai";
+import { useAIActions } from "./useAIActions";
+import { AIActionPopover } from "./AIActionPopover";
+
+interface AIActionButtonProps {
+  editor: any;
+  onOpenSidebar: () => void;
+  onEditAction: (action: EditorAIActionItem) => void;
+  onCreateAction: () => void;
+}
+
+function getSelection(editor: any): string {
+  try {
+    const selectionState = editor.getSelection();
+    if (!selectionState) return "";
+
+    const blocks = editor.topLevelBlocks;
+    const selectedBlocks = blocks.filter(
+      (block: any) =>
+        block.id === selectionState.block ||
+        (selectionState.block &&
+          selectionState.end &&
+          block.id >= selectionState.block &&
+          block.id <= selectionState.end),
+    );
+
+    // Fallback: if no blocks matched by ID range, collect text from focused block
+    if (selectedBlocks.length === 0) {
+      const focused = editor.focusBlock;
+      if (focused) {
+        const content = focused.content?.find((c: any) => c.type === "text");
+        return content?.text ?? "";
+      }
+      return "";
+    }
+
+    return selectedBlocks
+      .map((block: any) => {
+        const textContent = block.content?.filter((c: any) => c.type === "text");
+        return textContent?.map((c: any) => c.text).join("") ?? "";
+      })
+      .join("\n");
+  } catch {
+    return "";
+  }
+}
+
+function getContext(editor: any): string {
+  try {
+    const blocks = editor.topLevelBlocks ?? [];
+    const text = blocks
+      .slice(0, 5)
+      .map((block: any) => {
+        const textContent = block.content?.filter((c: any) => c.type === "text");
+        return textContent?.map((c: any) => c.text).join("") ?? "";
+      })
+      .filter(Boolean)
+      .join("\n");
+    return text.slice(0, 1000);
+  } catch {
+    return "";
+  }
+}
+
+export function AIActionButton({
+  editor,
+  onOpenSidebar,
+  onEditAction,
+  onCreateAction,
+}: AIActionButtonProps) {
+  const { globalActions, userActions, loading } = useAIActions();
+  const [open, setOpen] = useState(false);
+
+  const selection = getSelection(editor);
+  const context = getContext(editor);
+
+  const handleOpenSidebar = useCallback(() => {
+    setOpen(false);
+    onOpenSidebar();
+  }, [onOpenSidebar]);
+
+  const handleEditAction = useCallback(
+    (action: EditorAIActionItem) => {
+      setOpen(false);
+      onEditAction(action);
+    },
+    [onEditAction],
+  );
+
+  const handleCreateAction = useCallback(() => {
+    setOpen(false);
+    onCreateAction();
+  }, [onCreateAction]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="sm"
+            className="gap-1.5"
+            title="AI 助手"
+          />
+        }
+      >
+        <Sparkles className="size-4" />
+        <span>▾</span>
+      </PopoverTrigger>
+      <PopoverContent side="bottom" sideOffset={8}>
+        <AIActionPopover
+          globalActions={globalActions}
+          userActions={userActions}
+          selection={selection}
+          context={context}
+          onOpenSidebar={handleOpenSidebar}
+          onEditAction={handleEditAction}
+          onCreateAction={handleCreateAction}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/modules/reports/components/editor/ai/AIActionButton.tsx
+++ b/src/modules/reports/components/editor/ai/AIActionButton.tsx
@@ -29,6 +29,10 @@ function captureSelection(editor: any): SelectionSnapshot {
     const focused = editor.focusBlock;
     const blocks = editor.topLevelBlocks ?? [];
 
+    let blockIds: string[] = [];
+    let text = selectedText || "";
+
+    // Try to resolve block IDs from BlockNote selection state
     if (selectionState) {
       const fromBlock = selectionState.from?.block ?? selectionState.block;
       const toBlock = selectionState.to?.block ?? selectionState.end ?? fromBlock;
@@ -48,22 +52,23 @@ function captureSelection(editor: any): SelectionSnapshot {
           }
         }
         if (matched.length > 0) {
-          return {
-            text: selectedText || matched.map(extractBlockText).filter(Boolean).join("\n"),
-            blockIds: matched.map((b: any) => b.id),
-          };
+          blockIds = matched.map((b: any) => b.id);
+          if (!text) {
+            text = matched.map(extractBlockText).filter(Boolean).join("\n");
+          }
         }
       }
     }
 
-    if (focused) {
-      return {
-        text: selectedText || extractBlockText(focused),
-        blockIds: [focused.id],
-      };
+    // Always use focused block as fallback for block IDs
+    if (blockIds.length === 0 && focused) {
+      blockIds = [focused.id];
+      if (!text) {
+        text = extractBlockText(focused);
+      }
     }
 
-    return { text: selectedText || "", blockIds: [] };
+    return { text, blockIds };
   } catch {
     return { text: "", blockIds: [] };
   }

--- a/src/modules/reports/components/editor/ai/AIActionButton.tsx
+++ b/src/modules/reports/components/editor/ai/AIActionButton.tsx
@@ -1,61 +1,12 @@
 "use client";
 
-import { useState, useCallback } from "react";
-import { Sparkles, MessageSquare } from "lucide-react";
+import { useCallback } from "react";
+import { Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import type { EditorAIActionItem } from "@/types/editor-ai";
-import { useAIActions } from "./useAIActions";
-import { AIActionPopover } from "./AIActionPopover";
+import { useEditorAIStore } from "./useEditorAIStore";
 
 interface AIActionButtonProps {
   editor: any;
-  onOpenSidebar: () => void;
-  onEditAction: (action: EditorAIActionItem) => void;
-  onCreateAction: () => void;
-}
-
-function getSelection(editor: any): string {
-  try {
-    // Try BlockNote's getSelectedText first
-    const selectedText = editor.getSelectedText?.();
-    if (selectedText) return selectedText;
-
-    const selectionState = editor.getSelection();
-    if (!selectionState) {
-      // Fallback: get focused block text
-      const focused = editor.focusBlock;
-      if (focused) {
-        return extractBlockText(focused);
-      }
-      return "";
-    }
-
-    const blocks = editor.topLevelBlocks;
-    const fromBlock = selectionState.from?.block ?? selectionState.block;
-    const toBlock = selectionState.to?.block ?? selectionState.end ?? fromBlock;
-    if (!fromBlock) {
-      const focused = editor.focusBlock;
-      return focused ? extractBlockText(focused) : "";
-    }
-
-    const selectedBlocks = blocks.filter(
-      (block: any) => block.id === fromBlock || (toBlock && block.id === toBlock),
-    );
-
-    if (selectedBlocks.length === 0) {
-      const focused = editor.focusBlock;
-      return focused ? extractBlockText(focused) : "";
-    }
-
-    return selectedBlocks.map(extractBlockText).filter(Boolean).join("\n");
-  } catch {
-    return "";
-  }
 }
 
 function extractBlockText(block: any): string {
@@ -64,6 +15,58 @@ function extractBlockText(block: any): string {
     .filter((c: any) => c.type === "text")
     .map((c: any) => c.text)
     .join("");
+}
+
+interface SelectionSnapshot {
+  text: string;
+  blockIds: string[];
+}
+
+function captureSelection(editor: any): SelectionSnapshot {
+  try {
+    const selectedText = editor.getSelectedText?.();
+    const selectionState = editor.getSelection();
+    const focused = editor.focusBlock;
+    const blocks = editor.topLevelBlocks ?? [];
+
+    if (selectionState) {
+      const fromBlock = selectionState.from?.block ?? selectionState.block;
+      const toBlock = selectionState.to?.block ?? selectionState.end ?? fromBlock;
+
+      if (fromBlock) {
+        let inRange = false;
+        const matched: any[] = [];
+        for (const block of blocks) {
+          if (block.id === fromBlock) {
+            inRange = true;
+            matched.push(block);
+          } else if (inRange) {
+            matched.push(block);
+          }
+          if (block.id === toBlock) {
+            break;
+          }
+        }
+        if (matched.length > 0) {
+          return {
+            text: selectedText || matched.map(extractBlockText).filter(Boolean).join("\n"),
+            blockIds: matched.map((b: any) => b.id),
+          };
+        }
+      }
+    }
+
+    if (focused) {
+      return {
+        text: selectedText || extractBlockText(focused),
+        blockIds: [focused.id],
+      };
+    }
+
+    return { text: selectedText || "", blockIds: [] };
+  } catch {
+    return { text: "", blockIds: [] };
+  }
 }
 
 function getContext(editor: any): string {
@@ -80,73 +83,25 @@ function getContext(editor: any): string {
   }
 }
 
-export function AIActionButton({
-  editor,
-  onOpenSidebar,
-  onEditAction,
-  onCreateAction,
-}: AIActionButtonProps) {
-  const { globalActions, userActions, loading } = useAIActions();
-  const [open, setOpen] = useState(false);
-  const [selection, setSelection] = useState("");
-  const [context, setContext] = useState("");
+export function AIActionButton({ editor }: AIActionButtonProps) {
+  const openActionDialog = useEditorAIStore((s) => s.openActionDialog);
 
-  const handleOpenChange = useCallback(
-    (nextOpen: boolean) => {
-      if (nextOpen) {
-        // Capture selection BEFORE the popover opens (focus shifts)
-        setSelection(getSelection(editor));
-        setContext(getContext(editor));
-      }
-      setOpen(nextOpen);
-    },
-    [editor],
-  );
-
-  const handleOpenSidebar = useCallback(() => {
-    setOpen(false);
-    onOpenSidebar();
-  }, [onOpenSidebar]);
-
-  const handleEditAction = useCallback(
-    (action: EditorAIActionItem) => {
-      setOpen(false);
-      onEditAction(action);
-    },
-    [onEditAction],
-  );
-
-  const handleCreateAction = useCallback(() => {
-    setOpen(false);
-    onCreateAction();
-  }, [onCreateAction]);
+  const handleClick = useCallback(() => {
+    const snap = captureSelection(editor);
+    const ctx = getContext(editor);
+    openActionDialog(snap.text, snap.blockIds, ctx);
+  }, [editor, openActionDialog]);
 
   return (
-    <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger
-        render={
-          <Button
-            variant="ghost"
-            size="sm"
-            className="gap-1.5"
-            title="AI 助手"
-          />
-        }
-      >
-        <Sparkles className="size-4" />
-        <span>▾</span>
-      </PopoverTrigger>
-      <PopoverContent side="bottom" sideOffset={8}>
-        <AIActionPopover
-          globalActions={globalActions}
-          userActions={userActions}
-          selection={selection}
-          context={context}
-          onOpenSidebar={handleOpenSidebar}
-          onEditAction={handleEditAction}
-          onCreateAction={handleCreateAction}
-        />
-      </PopoverContent>
-    </Popover>
+    <Button
+      variant="ghost"
+      size="sm"
+      className="gap-1.5"
+      title="AI 助手"
+      onClick={handleClick}
+    >
+      <Sparkles className="size-4" />
+      <span>▾</span>
+    </Button>
   );
 }

--- a/src/modules/reports/components/editor/ai/AIActionDialog.tsx
+++ b/src/modules/reports/components/editor/ai/AIActionDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useCallback } from "react";
 import {
   Dialog,
   DialogContent,
@@ -27,18 +27,19 @@ export function AIActionDialog({
     actionDialogSelection,
     actionDialogBlockIds,
     actionDialogContext,
+    actionDialogExecuting,
     closeActionDialog,
+    setActionDialogExecuting,
   } = useEditorAIStore();
 
   const { globalActions, userActions } = useAIActions();
-  const [executing, setExecuting] = useState(false);
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
-      if (!open && executing) return;
+      if (!open && actionDialogExecuting) return;
       if (!open) closeActionDialog();
     },
-    [executing, closeActionDialog],
+    [actionDialogExecuting, closeActionDialog],
   );
 
   const handleOpenSidebar = useCallback(() => {
@@ -59,15 +60,14 @@ export function AIActionDialog({
     onCreateAction();
   }, [closeActionDialog, onCreateAction]);
 
-  // Reset executing when dialog closes
   const handleClose = useCallback(
     (open: boolean) => {
       if (!open) {
-        setExecuting(false);
+        setActionDialogExecuting(false);
       }
       handleOpenChange(open);
     },
-    [handleOpenChange],
+    [handleOpenChange, setActionDialogExecuting],
   );
 
   return (
@@ -80,8 +80,8 @@ export function AIActionDialog({
           selectedBlockIds={actionDialogBlockIds}
           context={actionDialogContext}
           editor={editor}
-          executing={executing}
-          onExecutingChange={setExecuting}
+          executing={actionDialogExecuting}
+          onExecutingChange={setActionDialogExecuting}
           onOpenSidebar={handleOpenSidebar}
           onEditAction={handleEditAction}
           onCreateAction={handleCreateAction}

--- a/src/modules/reports/components/editor/ai/AIActionDialog.tsx
+++ b/src/modules/reports/components/editor/ai/AIActionDialog.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import {
+  Dialog,
+  DialogContent,
+} from "@/components/ui/dialog";
+import { useEditorAIStore } from "./useEditorAIStore";
+import { AIActionPopover } from "./AIActionPopover";
+import { useAIActions } from "./useAIActions";
+
+interface AIActionDialogProps {
+  editor: any;
+  onOpenSidebar: () => void;
+  onEditAction: (action: any) => void;
+  onCreateAction: () => void;
+}
+
+export function AIActionDialog({
+  editor,
+  onOpenSidebar,
+  onEditAction,
+  onCreateAction,
+}: AIActionDialogProps) {
+  const {
+    actionDialogOpen,
+    actionDialogSelection,
+    actionDialogBlockIds,
+    actionDialogContext,
+    closeActionDialog,
+  } = useEditorAIStore();
+
+  const { globalActions, userActions } = useAIActions();
+  const [executing, setExecuting] = useState(false);
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open && executing) return;
+      if (!open) closeActionDialog();
+    },
+    [executing, closeActionDialog],
+  );
+
+  const handleOpenSidebar = useCallback(() => {
+    closeActionDialog();
+    onOpenSidebar();
+  }, [closeActionDialog, onOpenSidebar]);
+
+  const handleEditAction = useCallback(
+    (action: any) => {
+      closeActionDialog();
+      onEditAction(action);
+    },
+    [closeActionDialog, onEditAction],
+  );
+
+  const handleCreateAction = useCallback(() => {
+    closeActionDialog();
+    onCreateAction();
+  }, [closeActionDialog, onCreateAction]);
+
+  // Reset executing when dialog closes
+  const handleClose = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        setExecuting(false);
+      }
+      handleOpenChange(open);
+    },
+    [handleOpenChange],
+  );
+
+  return (
+    <Dialog open={actionDialogOpen} onOpenChange={handleClose}>
+      <DialogContent className="max-w-sm p-0 gap-0">
+        <AIActionPopover
+          globalActions={globalActions}
+          userActions={userActions}
+          selection={actionDialogSelection}
+          selectedBlockIds={actionDialogBlockIds}
+          context={actionDialogContext}
+          editor={editor}
+          executing={executing}
+          onExecutingChange={setExecuting}
+          onOpenSidebar={handleOpenSidebar}
+          onEditAction={handleEditAction}
+          onCreateAction={handleCreateAction}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/modules/reports/components/editor/ai/AIActionExecutor.ts
+++ b/src/modules/reports/components/editor/ai/AIActionExecutor.ts
@@ -1,0 +1,78 @@
+// src/modules/reports/components/editor/ai/AIActionExecutor.ts
+
+export interface ExecuteAIActionOptions {
+  actionId?: string;
+  prompt?: string;
+  selection?: string;
+  context?: string;
+  instruction?: string;
+  model?: string;
+  onChunk: (text: string) => void;
+  onDone: (text: string) => void;
+  onError: (message: string) => void;
+  signal?: AbortSignal;
+}
+
+export async function executeAIAction(options: ExecuteAIActionOptions) {
+  const {
+    actionId,
+    prompt,
+    selection,
+    context,
+    instruction,
+    model,
+    onChunk,
+    onDone,
+    onError,
+    signal,
+  } = options;
+
+  try {
+    const res = await fetch("/api/editor-ai/execute", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        actionId,
+        prompt,
+        selection,
+        context,
+        instruction,
+        model,
+      }),
+      signal,
+    });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      onError(body || `请求失败 (${res.status})`);
+      return;
+    }
+
+    // The endpoint uses toTextStreamResponse() which returns plain text chunks.
+    const reader = res.body?.getReader();
+    if (!reader) {
+      onError("无法读取响应流");
+      return;
+    }
+
+    const decoder = new TextDecoder();
+    let accumulated = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      const chunk = decoder.decode(value, { stream: true });
+      accumulated += chunk;
+      onChunk(accumulated);
+    }
+
+    onDone(accumulated);
+  } catch (err: unknown) {
+    if (err instanceof DOMException && err.name === "AbortError") {
+      // Cancellation — do not call onError
+      return;
+    }
+    onError(err instanceof Error ? err.message : "未知错误");
+  }
+}

--- a/src/modules/reports/components/editor/ai/AIActionForm.tsx
+++ b/src/modules/reports/components/editor/ai/AIActionForm.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import type { EditorAIActionItem } from "@/types/editor-ai";
+
+interface AIActionFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  action?: EditorAIActionItem | null;
+  onSuccess: () => void;
+}
+
+const QUICK_EMOJIS = [
+  "✨",
+  "📝",
+  "📖",
+  "🌐",
+  "🎯",
+  "💼",
+  "😊",
+  "💡",
+  "🔬",
+  "🎓",
+];
+
+const CATEGORY_OPTIONS = [
+  { value: "general", label: "通用" },
+  { value: "writing", label: "写作" },
+  { value: "translation", label: "翻译" },
+  { value: "analysis", label: "分析" },
+] as const;
+
+const SCOPE_OPTIONS = [
+  { value: "selection", label: "选中文本" },
+  { value: "paragraph", label: "当前段落" },
+  { value: "document", label: "整篇文档" },
+] as const;
+
+type FormState = {
+  name: string;
+  icon: string;
+  category: string;
+  scope: "selection" | "paragraph" | "document";
+  prompt: string;
+};
+
+const INITIAL_FORM: FormState = {
+  name: "",
+  icon: "✨",
+  category: "general",
+  scope: "selection",
+  prompt: "",
+};
+
+export function AIActionForm({
+  open,
+  onOpenChange,
+  action,
+  onSuccess,
+}: AIActionFormProps) {
+  const [form, setForm] = useState<FormState>(INITIAL_FORM);
+  const [submitting, setSubmitting] = useState(false);
+  const isEdit = !!action;
+
+  // Reset form when dialog opens or action changes
+  useEffect(() => {
+    if (!open) return;
+    if (action) {
+      setForm({
+        name: action.name,
+        icon: action.icon ?? "✨",
+        category: action.category ?? "general",
+        scope: action.scope,
+        prompt: action.prompt,
+      });
+    } else {
+      setForm(INITIAL_FORM);
+    }
+  }, [open, action]);
+
+  const updateField = useCallback(
+    <K extends keyof FormState>(key: K, value: FormState[K]) => {
+      setForm((prev) => ({ ...prev, [key]: value }));
+    },
+    [],
+  );
+
+  const handleSubmit = useCallback(async () => {
+    if (!form.name.trim()) {
+      toast.error("请输入名称");
+      return;
+    }
+    if (!form.prompt.trim()) {
+      toast.error("请输入 Prompt 模板");
+      return;
+    }
+
+    setSubmitting(true);
+
+    try {
+      const body = {
+        name: form.name.trim(),
+        icon: form.icon || undefined,
+        prompt: form.prompt.trim(),
+        category: form.category,
+        scope: form.scope,
+      };
+
+      let res: Response;
+
+      if (isEdit && action) {
+        res = await fetch(`/api/editor-ai/actions/${action.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+      } else {
+        res = await fetch("/api/editor-ai/actions", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+      }
+
+      if (!res.ok) {
+        const json = await res.json().catch(() => null);
+        const message = json?.error?.message ?? "操作失败";
+        toast.error(message);
+        return;
+      }
+
+      toast.success("已保存");
+      onSuccess();
+      onOpenChange(false);
+    } catch {
+      toast.error("网络错误，请重试");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [form, isEdit, action, onSuccess, onOpenChange]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? "编辑模板" : "新建模板"}</DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? "修改 AI 助手的 Prompt 模板配置"
+              : "创建一个 AI 助手 Prompt 模板，可快速复用"}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4 py-2">
+          {/* Name */}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="ai-action-name">
+              名称 <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="ai-action-name"
+              value={form.name}
+              onChange={(e) => updateField("name", e.target.value)}
+              maxLength={50}
+              placeholder="例如：润色文本"
+            />
+          </div>
+
+          {/* Icon */}
+          <div className="flex flex-col gap-1.5">
+            <Label>图标</Label>
+            <div className="flex flex-wrap items-center gap-1.5">
+              {QUICK_EMOJIS.map((emoji) => (
+                <button
+                  key={emoji}
+                  type="button"
+                  className={`inline-flex size-8 items-center justify-center rounded-md border text-base transition-colors ${
+                    form.icon === emoji
+                      ? "border-primary bg-primary/10"
+                      : "border-transparent hover:bg-muted"
+                  }`}
+                  onClick={() => updateField("icon", emoji)}
+                >
+                  {emoji}
+                </button>
+              ))}
+              <Input
+                value={form.icon}
+                onChange={(e) => updateField("icon", e.target.value)}
+                maxLength={10}
+                placeholder="自定义"
+                className="h-8 w-16 text-center text-base"
+              />
+            </div>
+          </div>
+
+          {/* Category + Scope in a row */}
+          <div className="grid grid-cols-2 gap-4">
+            {/* Category */}
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="ai-action-category">分组</Label>
+              <select
+                id="ai-action-category"
+                value={form.category}
+                onChange={(e) => updateField("category", e.target.value)}
+                className="flex h-8 w-full rounded-md border border-input bg-transparent px-2.5 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+              >
+                {CATEGORY_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Scope */}
+            <div className="flex flex-col gap-1.5">
+              <Label>作用域</Label>
+              <div className="flex items-center gap-3 pt-1">
+                {SCOPE_OPTIONS.map((opt) => (
+                  <label
+                    key={opt.value}
+                    className="flex cursor-pointer items-center gap-1.5 text-sm"
+                  >
+                    <input
+                      type="radio"
+                      name="scope"
+                      value={opt.value}
+                      checked={form.scope === opt.value}
+                      onChange={(e) =>
+                        updateField(
+                          "scope",
+                          e.target.value as FormState["scope"],
+                        )
+                      }
+                      className="accent-primary"
+                    />
+                    <span className="text-muted-foreground">{opt.label}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Prompt */}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="ai-action-prompt">
+              Prompt 模板 <span className="text-destructive">*</span>
+            </Label>
+            <Textarea
+              id="ai-action-prompt"
+              value={form.prompt}
+              onChange={(e) => updateField("prompt", e.target.value)}
+              maxLength={2000}
+              placeholder="输入 Prompt 模板..."
+              rows={6}
+              className="resize-y"
+            />
+            <p className="text-xs text-muted-foreground">
+              可用变量：
+              <code className="mx-0.5 rounded bg-muted px-1 text-xs">
+                {"{{selection}}"}
+              </code>
+              <code className="mx-0.5 rounded bg-muted px-1 text-xs">
+                {"{{context}}"}
+              </code>
+              <code className="mx-0.5 rounded bg-muted px-1 text-xs">
+                {"{{instruction}}"}
+              </code>
+              — 分别代表选中文本、上下文段落、附加指令
+            </p>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={submitting}
+          >
+            取消
+          </Button>
+          <Button onClick={handleSubmit} disabled={submitting}>
+            {submitting ? "保存中..." : "保存"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/modules/reports/components/editor/ai/AIActionPopover.tsx
+++ b/src/modules/reports/components/editor/ai/AIActionPopover.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useState, useRef, useCallback } from "react";
-import { Send, Settings, ChevronDown } from "lucide-react";
+import { Send, Settings, ChevronDown, Copy, ArrowRightLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { PopoverDescription, PopoverHeader, PopoverTitle } from "@/components/ui/popover";
 import type { EditorAIActionItem } from "@/types/editor-ai";
 import { executeAIAction } from "./AIActionExecutor";
 
@@ -11,7 +10,11 @@ interface AIActionPopoverProps {
   globalActions: EditorAIActionItem[];
   userActions: EditorAIActionItem[];
   selection: string;
+  selectedBlockIds: string[];
   context: string;
+  editor: any;
+  executing: boolean;
+  onExecutingChange: (v: boolean) => void;
   onOpenSidebar: () => void;
   onEditAction: (action: EditorAIActionItem) => void;
   onCreateAction: () => void;
@@ -21,12 +24,15 @@ export function AIActionPopover({
   globalActions,
   userActions,
   selection,
+  selectedBlockIds,
   context,
+  editor,
+  executing,
+  onExecutingChange,
   onOpenSidebar,
   onEditAction,
   onCreateAction,
 }: AIActionPopoverProps) {
-  const [executing, setExecuting] = useState(false);
   const [result, setResult] = useState("");
   const [input, setInput] = useState("");
   const abortRef = useRef<AbortController | null>(null);
@@ -36,7 +42,7 @@ export function AIActionPopover({
       if (executing) return;
 
       setResult("");
-      setExecuting(true);
+      onExecutingChange(true);
 
       const controller = new AbortController();
       abortRef.current = controller;
@@ -48,12 +54,12 @@ export function AIActionPopover({
         onChunk: (text) => setResult(text),
         onDone: (text) => {
           setResult(text);
-          setExecuting(false);
+          onExecutingChange(false);
           abortRef.current = null;
         },
         onError: (message) => {
           setResult(`错误: ${message}`);
-          setExecuting(false);
+          onExecutingChange(false);
           abortRef.current = null;
         },
         signal: controller.signal,
@@ -66,7 +72,7 @@ export function AIActionPopover({
     if (!input.trim() || executing) return;
 
     setResult("");
-    setExecuting(true);
+    onExecutingChange(true);
 
     const controller = new AbortController();
     abortRef.current = controller;
@@ -78,12 +84,12 @@ export function AIActionPopover({
       onChunk: (text) => setResult(text),
       onDone: (text) => {
         setResult(text);
-        setExecuting(false);
+        onExecutingChange(false);
         abortRef.current = null;
       },
       onError: (message) => {
         setResult(`错误: ${message}`);
-        setExecuting(false);
+        onExecutingChange(false);
         abortRef.current = null;
       },
       signal: controller.signal,
@@ -95,17 +101,60 @@ export function AIActionPopover({
   const handleCancel = useCallback(() => {
     abortRef.current?.abort();
     abortRef.current = null;
-    setExecuting(false);
+    onExecutingChange(false);
   }, []);
+
+  const handleReplace = useCallback(() => {
+    if (!result || !editor) return;
+    try {
+      const newBlocks = editor.tryParseMarkdownToBlocks?.(result);
+      if (!newBlocks?.length) return;
+
+      if (selectedBlockIds.length > 0) {
+        const blocksToReplace = editor.topLevelBlocks.filter((b: any) =>
+          selectedBlockIds.includes(b.id),
+        );
+        if (blocksToReplace.length > 0) {
+          editor.replaceBlocks(blocksToReplace, newBlocks);
+          return;
+        }
+      }
+
+      // Fallback: insert after focused block
+      const focused = editor.focusBlock;
+      if (focused) {
+        editor.insertBlocks(newBlocks, focused, "after");
+      }
+    } catch {}
+  }, [result, editor, selectedBlockIds]);
+
+  const handleInsert = useCallback(() => {
+    if (!result || !editor) return;
+    try {
+      const newBlocks = editor.tryParseMarkdownToBlocks?.(result);
+      if (!newBlocks?.length) return;
+      const focused = editor.focusBlock;
+      if (focused) {
+        editor.insertBlocks(newBlocks, focused, "after");
+      }
+    } catch {}
+  }, [result, editor]);
+
+  const handleCopy = useCallback(async () => {
+    if (!result) return;
+    try {
+      await navigator.clipboard.writeText(result);
+    } catch {}
+  }, [result]);
 
   return (
     <div className="flex w-80 flex-col gap-3">
-      <PopoverHeader>
-        <PopoverTitle>✨ AI 助手</PopoverTitle>
-        <PopoverDescription>
+      <div className="flex flex-col gap-0.5">
+        <span className="font-medium">✨ AI 助手</span>
+        <span className="text-xs text-muted-foreground">
           {executing ? "正在生成..." : "选择操作或输入指令"}
-        </PopoverDescription>
-      </PopoverHeader>
+        </span>
+      </div>
 
       {/* Preset actions */}
       {globalActions.length > 0 && (
@@ -163,9 +212,47 @@ export function AIActionPopover({
 
       {/* Result preview */}
       {result && (
-        <div className="max-h-40 overflow-y-auto rounded-md border bg-muted/50 p-2 text-xs">
-          <pre className="whitespace-pre-wrap font-sentence">{result}</pre>
-          {executing && <span className="ml-0.5 inline-block animate-pulse">▌</span>}
+        <div className="flex flex-col gap-1.5">
+          <div className="max-h-40 overflow-y-auto rounded-md border bg-muted/50 p-2 text-xs">
+            <pre className="whitespace-pre-wrap font-sentence">{result}</pre>
+            {executing && <span className="ml-0.5 inline-block animate-pulse">▌</span>}
+          </div>
+          {/* Action buttons */}
+          {!executing && (
+            <div className="flex items-center gap-1">
+              {selection && (
+                <Button
+                  variant="default"
+                  size="xs"
+                  className="h-6 gap-1 text-xs"
+                  onClick={handleReplace}
+                  title="替换选中的原文"
+                >
+                  <ArrowRightLeft className="size-3" />
+                  替换原文
+                </Button>
+              )}
+              <Button
+                variant="outline"
+                size="xs"
+                className="h-6 gap-1 text-xs"
+                onClick={handleInsert}
+                title="插入到光标后"
+              >
+                插入
+              </Button>
+              <Button
+                variant="ghost"
+                size="xs"
+                className="h-6 gap-1 text-xs"
+                onClick={handleCopy}
+                title="复制到剪贴板"
+              >
+                <Copy className="size-3" />
+                复制
+              </Button>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/modules/reports/components/editor/ai/AIActionPopover.tsx
+++ b/src/modules/reports/components/editor/ai/AIActionPopover.tsx
@@ -5,6 +5,15 @@ import { Send, Settings, ChevronDown, Copy, ArrowRightLeft } from "lucide-react"
 import { Button } from "@/components/ui/button";
 import type { EditorAIActionItem } from "@/types/editor-ai";
 import { executeAIAction } from "./AIActionExecutor";
+import { useEditorAIStore } from "./useEditorAIStore";
+
+function extractBlockText(block: any): string {
+  if (!block?.content) return "";
+  return block.content
+    .filter((c: any) => c.type === "text")
+    .map((c: any) => c.text)
+    .join("");
+}
 
 interface AIActionPopoverProps {
   globalActions: EditorAIActionItem[];
@@ -33,9 +42,11 @@ export function AIActionPopover({
   onEditAction,
   onCreateAction,
 }: AIActionPopoverProps) {
-  const [result, setResult] = useState("");
-  const [input, setInput] = useState("");
+  const result = useEditorAIStore((s) => s.actionDialogResult);
+  const setResult = useEditorAIStore((s) => s.setActionDialogResult);
+  const resetResult = useEditorAIStore((s) => s.resetActionDialogResult);
   const abortRef = useRef<AbortController | null>(null);
+  const [input, setInput] = useState("");
 
   const handleExecute = useCallback(
     (action: EditorAIActionItem) => {
@@ -110,8 +121,10 @@ export function AIActionPopover({
       const newBlocks = editor.tryParseMarkdownToBlocks?.(result);
       if (!newBlocks?.length) return;
 
+      // Strategy 1: Replace by block IDs directly using the stored snapshot
       if (selectedBlockIds.length > 0) {
-        const blocksToReplace = editor.topLevelBlocks.filter((b: any) =>
+        const docBlocks = editor.document ?? editor.topLevelBlocks ?? [];
+        const blocksToReplace = docBlocks.filter((b: any) =>
           selectedBlockIds.includes(b.id),
         );
         if (blocksToReplace.length > 0) {
@@ -120,13 +133,28 @@ export function AIActionPopover({
         }
       }
 
-      // Fallback: insert after focused block
+      // Strategy 2: Find block containing the selection text
+      if (selection) {
+        const docBlocks = editor.document ?? editor.topLevelBlocks ?? [];
+        const match = docBlocks.find((b: any) => {
+          const text = extractBlockText(b);
+          return text && selection && text.includes(selection.trim());
+        });
+        if (match) {
+          editor.replaceBlocks([match], newBlocks);
+          return;
+        }
+      }
+
+      // Strategy 3: Use focused block
       const focused = editor.focusBlock;
       if (focused) {
-        editor.insertBlocks(newBlocks, focused, "after");
+        editor.replaceBlocks([focused], newBlocks);
       }
-    } catch {}
-  }, [result, editor, selectedBlockIds]);
+    } catch (err) {
+      console.error("[AIActionPopover] replace error:", err);
+    }
+  }, [result, editor, selectedBlockIds, selection]);
 
   const handleInsert = useCallback(() => {
     if (!result || !editor) return;
@@ -225,7 +253,7 @@ export function AIActionPopover({
                   variant="default"
                   size="xs"
                   className="h-6 gap-1 text-xs"
-                  onClick={handleReplace}
+                  onClick={(e) => { e.stopPropagation(); handleReplace(); }}
                   title="替换选中的原文"
                 >
                   <ArrowRightLeft className="size-3" />
@@ -236,7 +264,7 @@ export function AIActionPopover({
                 variant="outline"
                 size="xs"
                 className="h-6 gap-1 text-xs"
-                onClick={handleInsert}
+                onClick={(e) => { e.stopPropagation(); handleInsert(); }}
                 title="插入到光标后"
               >
                 插入
@@ -245,7 +273,7 @@ export function AIActionPopover({
                 variant="ghost"
                 size="xs"
                 className="h-6 gap-1 text-xs"
-                onClick={handleCopy}
+                onClick={(e) => { e.stopPropagation(); handleCopy(); }}
                 title="复制到剪贴板"
               >
                 <Copy className="size-3" />

--- a/src/modules/reports/components/editor/ai/AIActionPopover.tsx
+++ b/src/modules/reports/components/editor/ai/AIActionPopover.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
+import { Send, Settings, ChevronDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { PopoverDescription, PopoverHeader, PopoverTitle } from "@/components/ui/popover";
+import type { EditorAIActionItem } from "@/types/editor-ai";
+import { executeAIAction } from "./AIActionExecutor";
+
+interface AIActionPopoverProps {
+  globalActions: EditorAIActionItem[];
+  userActions: EditorAIActionItem[];
+  selection: string;
+  context: string;
+  onOpenSidebar: () => void;
+  onEditAction: (action: EditorAIActionItem) => void;
+  onCreateAction: () => void;
+}
+
+export function AIActionPopover({
+  globalActions,
+  userActions,
+  selection,
+  context,
+  onOpenSidebar,
+  onEditAction,
+  onCreateAction,
+}: AIActionPopoverProps) {
+  const [executing, setExecuting] = useState(false);
+  const [result, setResult] = useState("");
+  const [input, setInput] = useState("");
+  const abortRef = useRef<AbortController | null>(null);
+
+  const handleExecute = useCallback(
+    (action: EditorAIActionItem) => {
+      if (executing) return;
+
+      setResult("");
+      setExecuting(true);
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      executeAIAction({
+        actionId: action.id,
+        selection: selection || undefined,
+        context: context || undefined,
+        onChunk: (text) => setResult(text),
+        onDone: (text) => {
+          setResult(text);
+          setExecuting(false);
+          abortRef.current = null;
+        },
+        onError: (message) => {
+          setResult(`错误: ${message}`);
+          setExecuting(false);
+          abortRef.current = null;
+        },
+        signal: controller.signal,
+      });
+    },
+    [executing, selection, context],
+  );
+
+  const handleFreeInput = useCallback(() => {
+    if (!input.trim() || executing) return;
+
+    setResult("");
+    setExecuting(true);
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    executeAIAction({
+      prompt: input.trim(),
+      selection: selection || undefined,
+      context: context || undefined,
+      onChunk: (text) => setResult(text),
+      onDone: (text) => {
+        setResult(text);
+        setExecuting(false);
+        abortRef.current = null;
+      },
+      onError: (message) => {
+        setResult(`错误: ${message}`);
+        setExecuting(false);
+        abortRef.current = null;
+      },
+      signal: controller.signal,
+    });
+
+    setInput("");
+  }, [input, executing, selection, context]);
+
+  const handleCancel = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setExecuting(false);
+  }, []);
+
+  return (
+    <div className="flex w-80 flex-col gap-3">
+      <PopoverHeader>
+        <PopoverTitle>✨ AI 助手</PopoverTitle>
+        <PopoverDescription>
+          {executing ? "正在生成..." : "选择操作或输入指令"}
+        </PopoverDescription>
+      </PopoverHeader>
+
+      {/* Preset actions */}
+      {globalActions.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          <span className="text-xs font-medium text-muted-foreground">常用操作</span>
+          <div className="grid grid-cols-2 gap-1">
+            {globalActions.map((action) => (
+              <Button
+                key={action.id}
+                variant="outline"
+                size="xs"
+                className="justify-start text-left"
+                disabled={executing}
+                onClick={() => handleExecute(action)}
+              >
+                <span className="mr-1">{action.icon || "🤖"}</span>
+                <span className="truncate">{action.name}</span>
+              </Button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* User templates */}
+      {userActions.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          <span className="text-xs font-medium text-muted-foreground">我的模板</span>
+          <div className="flex flex-col gap-0.5">
+            {userActions.map((action) => (
+              <div key={action.id} className="flex items-center gap-1">
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  className="flex-1 justify-start text-left"
+                  disabled={executing}
+                  onClick={() => handleExecute(action)}
+                >
+                  <span className="mr-1">{action.icon || "📄"}</span>
+                  <span className="truncate">{action.name}</span>
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  className="h-6 w-6 shrink-0 p-0"
+                  onClick={() => onEditAction(action)}
+                  title="编辑模板"
+                >
+                  <Settings className="size-3" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Result preview */}
+      {result && (
+        <div className="max-h-40 overflow-y-auto rounded-md border bg-muted/50 p-2 text-xs">
+          <pre className="whitespace-pre-wrap font-sentence">{result}</pre>
+          {executing && <span className="ml-0.5 inline-block animate-pulse">▌</span>}
+        </div>
+      )}
+
+      {/* Free input */}
+      <div className="flex items-center gap-1">
+        <input
+          type="text"
+          className="flex h-7 flex-1 rounded-md border bg-transparent px-2 text-xs outline-none focus:border-ring"
+          placeholder="输入自定义指令..."
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              if (executing) {
+                handleCancel();
+              } else {
+                handleFreeInput();
+              }
+            }
+          }}
+          disabled={executing}
+        />
+        <Button
+          variant={executing ? "destructive" : "default"}
+          size="xs"
+          className="h-7 w-7 shrink-0 p-0"
+          onClick={executing ? handleCancel : handleFreeInput}
+          disabled={!executing && !input.trim()}
+          title={executing ? "停止" : "发送"}
+        >
+          {executing ? <ChevronDown className="size-3" /> : <Send className="size-3" />}
+        </Button>
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <button
+          type="button"
+          className="hover:text-foreground"
+          onClick={onCreateAction}
+        >
+          + 新建模板
+        </button>
+        <button
+          type="button"
+          className="hover:text-foreground"
+          onClick={onOpenSidebar}
+        >
+          侧边栏对话
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/reports/components/editor/ai/AIChatSidebar.tsx
+++ b/src/modules/reports/components/editor/ai/AIChatSidebar.tsx
@@ -95,7 +95,7 @@ export function AIChatSidebar({ editorRef }: AIChatSidebarProps) {
   // ---------- Send message ----------
   const handleSend = useCallback(async () => {
     const trimmed = input.trim();
-    if (!trimmed || streaming) return;
+    if (!trimmed || streaming || !selectedModel) return;
 
     // Add user message to store
     const userPinnedSelections = pinnedSelections.length > 0 ? [...pinnedSelections] : undefined;

--- a/src/modules/reports/components/editor/ai/AIChatSidebar.tsx
+++ b/src/modules/reports/components/editor/ai/AIChatSidebar.tsx
@@ -22,14 +22,11 @@ import { useAIActions } from "./useAIActions";
 import { SelectionAttachment } from "./SelectionAttachment";
 import type { PinnedSelection } from "@/types/editor-ai";
 
-// ---------- Model list ----------
-const MODEL_OPTIONS = [
-  { value: "gpt-4o", label: "GPT-4o" },
-  { value: "gpt-4o-mini", label: "GPT-4o Mini" },
-  { value: "deepseek-chat", label: "DeepSeek Chat" },
-  { value: "deepseek-reasoner", label: "DeepSeek Reasoner" },
-  { value: "kimi-k2", label: "Kimi K2" },
-];
+// ---------- Model type ----------
+interface ModelOption {
+  id: string;
+  name: string;
+}
 
 // ---------- Props ----------
 interface AIChatSidebarProps {
@@ -55,9 +52,27 @@ export function AIChatSidebar({ editorRef }: AIChatSidebarProps) {
 
   const [input, setInput] = useState("");
   const [streaming, setStreaming] = useState(false);
+  const [modelOptions, setModelOptions] = useState<ModelOption[]>([]);
   const abortRef = useRef<AbortController | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Load available models from Agent2
+  useEffect(() => {
+    let active = true;
+    fetch("/api/agent2/models")
+      .then((res) => res.json())
+      .then((data) => {
+        if (!active || !data?.success) return;
+        setModelOptions(data.data);
+        // Set default model if none selected
+        if (!useEditorAIStore.getState().selectedModel && data.data.length > 0) {
+          setSelectedModel(data.data[0].id);
+        }
+      })
+      .catch(() => {});
+    return () => { active = false; };
+  }, [setSelectedModel]);
 
   // Auto-scroll to bottom when messages change
   useEffect(() => {
@@ -108,6 +123,9 @@ export function AIChatSidebar({ editorRef }: AIChatSidebarProps) {
     const controller = new AbortController();
     abortRef.current = controller;
 
+    // Timeout after 60s of no response
+    const timeoutId = setTimeout(() => controller.abort(), 60_000);
+
     // Add placeholder assistant message
     addMessage({ role: "assistant", content: "" });
 
@@ -155,6 +173,7 @@ export function AIChatSidebar({ editorRef }: AIChatSidebarProps) {
 
       setStreaming(false);
       abortRef.current = null;
+      clearTimeout(timeoutId);
     } catch (err: unknown) {
       if (err instanceof DOMException && err.name === "AbortError") {
         updateLastAssistantMessage((prev) => {
@@ -163,6 +182,7 @@ export function AIChatSidebar({ editorRef }: AIChatSidebarProps) {
         });
         setStreaming(false);
         abortRef.current = null;
+        clearTimeout(timeoutId);
         return;
       }
       updateLastAssistantMessage(
@@ -170,6 +190,7 @@ export function AIChatSidebar({ editorRef }: AIChatSidebarProps) {
       );
       setStreaming(false);
       abortRef.current = null;
+      clearTimeout(timeoutId);
     }
   }, [
     input,
@@ -296,9 +317,9 @@ export function AIChatSidebar({ editorRef }: AIChatSidebarProps) {
           onChange={(e) => setSelectedModel(e.target.value)}
           className="h-6 rounded border bg-transparent px-1.5 text-xs outline-none focus:border-ring"
         >
-          {MODEL_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
+          {modelOptions.map((opt) => (
+            <option key={opt.id} value={opt.id}>
+              {opt.name}
             </option>
           ))}
         </select>

--- a/src/modules/reports/components/editor/ai/AIChatSidebar.tsx
+++ b/src/modules/reports/components/editor/ai/AIChatSidebar.tsx
@@ -284,10 +284,8 @@ export function AIChatSidebar({ editorRef }: AIChatSidebarProps) {
   );
 
   // ---------- Render ----------
-  if (!sidebarOpen) return null;
-
   return (
-    <div className="flex h-full w-80 shrink-0 flex-col border-l bg-background">
+    <div className="flex h-full flex-col bg-background overflow-hidden">
       {/* Header */}
       <div className="flex items-center gap-2 border-b px-3 py-2">
         <Sparkles className="size-4 text-primary" />

--- a/src/modules/reports/components/editor/ai/AIChatSidebar.tsx
+++ b/src/modules/reports/components/editor/ai/AIChatSidebar.tsx
@@ -246,12 +246,26 @@ export function AIChatSidebar({ editorRef }: AIChatSidebarProps) {
   }, []);
 
   // ---------- Quick action ----------
+  // Replace template variables in prompt: {{selection}}, {{context}}, {{instruction}}
+  const resolvePromptTemplate = useCallback(
+    (template: string) => {
+      let resolved = template;
+      const selectionText = pinnedSelections.map((s) => s.text).join("\n---\n");
+      resolved = resolved.replace(/\{\{selection\}\}/g, selectionText || "(未选中文本)");
+      resolved = resolved.replace(/\{\{context\}\}/g, sectionContent || "(无章节内容)");
+      // {{instruction}} is left as-is for user to fill in
+      return resolved;
+    },
+    [pinnedSelections, sectionContent],
+  );
+
   const handleQuickAction = useCallback(
     (prompt: string) => {
-      setInput(prompt);
+      const resolved = resolvePromptTemplate(prompt);
+      setInput(resolved);
       textareaRef.current?.focus();
     },
-    [],
+    [resolvePromptTemplate],
   );
 
   // ---------- Keyboard ----------
@@ -406,7 +420,7 @@ export function AIChatSidebar({ editorRef }: AIChatSidebarProps) {
       {globalActions.length > 0 && (
         <div className="border-t px-3 py-2">
           <div className="flex gap-1.5 overflow-x-auto scrollbar-none">
-            {globalActions.slice(0, 6).map((action) => (
+            {globalActions.map((action) => (
               <button
                 key={action.id}
                 type="button"

--- a/src/modules/reports/components/editor/ai/AIChatSidebar.tsx
+++ b/src/modules/reports/components/editor/ai/AIChatSidebar.tsx
@@ -14,6 +14,7 @@ import {
   ArrowDownToLine,
   ChevronDown,
   Sparkles,
+  Paperclip,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -42,6 +43,7 @@ export function AIChatSidebar({ editorRef }: AIChatSidebarProps) {
     addMessage,
     clearMessages,
     pinnedSelections,
+    addPinnedSelection,
     removePinnedSelection,
     selectedModel,
     setSelectedModel,
@@ -243,16 +245,62 @@ export function AIChatSidebar({ editorRef }: AIChatSidebarProps) {
     (content: string) => {
       try {
         const editor = editorRef.current;
-        if (!editor?.tryParseMarkdownToBlocks || !editor?.insertBlocks) {
+        if (!editor?.tryParseMarkdownToBlocks || !editor?.insertBlocks) return;
+        const blocks = editor.tryParseMarkdownToBlocks(content);
+        if (!blocks || blocks.length === 0) return;
+
+        const docBlocks: any[] = editor.document ?? editor.topLevelBlocks ?? [];
+
+        const findAndInsert = (blockId: string): boolean => {
+          const findBlock = (list: any[]): any => {
+            for (const b of list) {
+              if (b.id === blockId) return b;
+              if (b.children?.length) {
+                const child = findBlock(b.children);
+                if (child) return child;
+              }
+            }
+            return null;
+          };
+          const match = findBlock(docBlocks);
+          if (match) {
+            editor.insertBlocks(blocks, match, "after");
+            return true;
+          }
+          return false;
+        };
+
+        // 1. Try focused block (editor still has focus)
+        const focused = editor.focusBlock;
+        if (focused) {
+          editor.insertBlocks(blocks, focused, "after");
           return;
         }
-        const blocks = editor.tryParseMarkdownToBlocks(content);
-        if (blocks && blocks.length > 0) {
-          editor.insertBlocks(blocks);
-        }
-      } catch {
-        // Silently fail — the editor API might not be available
-      }
+
+        // 2. Use tracked last focused block ID from SectionEditor
+        const lastFocusedId = (editor as any).__lastFocusedBlockId;
+        if (lastFocusedId && findAndInsert(lastFocusedId)) return;
+
+        // 3. Read block ID from ProseMirror's DOM selection (persists after blur)
+        try {
+          const pm = (editor as any)?._tiptapEditor?.view?.dom as HTMLElement | undefined;
+          if (pm) {
+            const sel = (pm.getRootNode() as Document).getSelection();
+            if (sel && sel.rangeCount > 0) {
+              let node: Node | null = sel.anchorNode;
+              while (node && node !== pm) {
+                const dataId = (node as Element).getAttribute?.("data-id");
+                if (dataId && findAndInsert(dataId)) return;
+                node = node.parentElement;
+              }
+            }
+          }
+        } catch {}
+
+        // 4. Fallback: end of document
+        const lastBlock = docBlocks[docBlocks.length - 1];
+        if (lastBlock) editor.insertBlocks(blocks, lastBlock, "after");
+      } catch {}
     },
     [editorRef],
   );
@@ -341,7 +389,7 @@ export function AIChatSidebar({ editorRef }: AIChatSidebarProps) {
       )}
 
       {/* Messages area */}
-      <ScrollArea className="flex-1" ref={scrollRef}>
+      <ScrollArea className="min-h-0 flex-1" ref={scrollRef}>
         <div className="flex flex-col gap-3 p-3">
           {messages.length === 0 && (
             <div className="py-8 text-center text-xs text-muted-foreground">
@@ -468,6 +516,27 @@ export function AIChatSidebar({ editorRef }: AIChatSidebarProps) {
 
       {/* Input area */}
       <div className="border-t p-3">
+        {/* Quote selection button */}
+        <div className="mb-2 flex items-center gap-1.5">
+          <Button
+            variant="outline"
+            size="xs"
+            className="h-6 gap-1 text-xs"
+            onClick={() => {
+              const editor = editorRef.current;
+              if (!editor) return;
+              const text = editor.getSelectedText?.();
+              if (!text?.trim()) return;
+              const focused = editor.focusBlock;
+              const blockIds = focused ? [focused.id] : [];
+              addPinnedSelection({ text: text.trim(), blockIds });
+            }}
+            title="引用编辑器中选中的文字"
+          >
+            <Paperclip className="size-3" />
+            引用选中文本
+          </Button>
+        </div>
         <div className="flex items-end gap-2">
           <textarea
             ref={textareaRef}

--- a/src/modules/reports/components/editor/ai/AIChatSidebar.tsx
+++ b/src/modules/reports/components/editor/ai/AIChatSidebar.tsx
@@ -1,0 +1,466 @@
+"use client";
+
+import {
+  useState,
+  useRef,
+  useCallback,
+  useEffect,
+  type KeyboardEvent,
+} from "react";
+import {
+  X,
+  Send,
+  Copy,
+  ArrowDownToLine,
+  ChevronDown,
+  Sparkles,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { useEditorAIStore } from "./useEditorAIStore";
+import { useAIActions } from "./useAIActions";
+import { SelectionAttachment } from "./SelectionAttachment";
+import type { PinnedSelection } from "@/types/editor-ai";
+
+// ---------- Model list ----------
+const MODEL_OPTIONS = [
+  { value: "gpt-4o", label: "GPT-4o" },
+  { value: "gpt-4o-mini", label: "GPT-4o Mini" },
+  { value: "deepseek-chat", label: "DeepSeek Chat" },
+  { value: "deepseek-reasoner", label: "DeepSeek Reasoner" },
+  { value: "kimi-k2", label: "Kimi K2" },
+];
+
+// ---------- Props ----------
+interface AIChatSidebarProps {
+  editorRef: React.RefObject<any>;
+}
+
+// ---------- Component ----------
+export function AIChatSidebar({ editorRef }: AIChatSidebarProps) {
+  const {
+    sidebarOpen,
+    setSidebarOpen,
+    messages,
+    addMessage,
+    clearMessages,
+    pinnedSelections,
+    removePinnedSelection,
+    selectedModel,
+    setSelectedModel,
+    sectionContent,
+  } = useEditorAIStore();
+
+  const { globalActions } = useAIActions();
+
+  const [input, setInput] = useState("");
+  const [streaming, setStreaming] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Auto-scroll to bottom when messages change
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [messages]);
+
+  // Auto-resize textarea
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (el) {
+      el.style.height = "auto";
+      el.style.height = Math.min(el.scrollHeight, 160) + "px";
+    }
+  }, [input]);
+
+  // ---------- Send message ----------
+  const handleSend = useCallback(async () => {
+    const trimmed = input.trim();
+    if (!trimmed || streaming) return;
+
+    // Add user message to store
+    const userPinnedSelections = pinnedSelections.length > 0 ? [...pinnedSelections] : undefined;
+    addMessage({ role: "user", content: trimmed, pinnedSelections: userPinnedSelections });
+    setInput("");
+    setStreaming(true);
+
+    // Build API messages (exclude system messages, add user pinned refs)
+    const apiMessages = [
+      ...messages
+        .filter((m) => m.role !== "system")
+        .map((m) => ({
+          role: m.role,
+          content: m.content,
+        })),
+      { role: "user" as const, content: trimmed },
+    ];
+
+    const context: { sectionContent?: string; pinnedSelections?: string[] } = {};
+    if (sectionContent) {
+      context.sectionContent = sectionContent;
+    }
+    if (pinnedSelections.length > 0) {
+      context.pinnedSelections = pinnedSelections.map((s) => s.text);
+    }
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    // Add placeholder assistant message
+    addMessage({ role: "assistant", content: "" });
+
+    try {
+      const res = await fetch("/api/editor-ai/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: apiMessages,
+          model: selectedModel,
+          context: Object.keys(context).length > 0 ? context : undefined,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        // Update last assistant message with error
+        updateLastAssistantMessage(`错误: ${body || `请求失败 (${res.status})`}`);
+        setStreaming(false);
+        abortRef.current = null;
+        return;
+      }
+
+      // Stream reading
+      const reader = res.body?.getReader();
+      if (!reader) {
+        updateLastAssistantMessage("错误: 无法读取响应流");
+        setStreaming(false);
+        abortRef.current = null;
+        return;
+      }
+
+      const decoder = new TextDecoder();
+      let accumulated = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        const chunk = decoder.decode(value, { stream: true });
+        accumulated += chunk;
+        updateLastAssistantMessage(accumulated);
+      }
+
+      setStreaming(false);
+      abortRef.current = null;
+    } catch (err: unknown) {
+      if (err instanceof DOMException && err.name === "AbortError") {
+        updateLastAssistantMessage((prev) => {
+          const current = getCurrentAssistantContent();
+          return current + "\n\n*已停止生成*";
+        });
+        setStreaming(false);
+        abortRef.current = null;
+        return;
+      }
+      updateLastAssistantMessage(
+        `错误: ${err instanceof Error ? err.message : "未知错误"}`,
+      );
+      setStreaming(false);
+      abortRef.current = null;
+    }
+  }, [
+    input,
+    streaming,
+    pinnedSelections,
+    messages,
+    selectedModel,
+    sectionContent,
+    addMessage,
+  ]);
+
+  // ---------- Helpers to update last assistant message ----------
+  const updateLastAssistantMessage = useCallback(
+    (updater: string | ((prev: string) => string)) => {
+      const currentMessages = useEditorAIStore.getState().messages;
+      const lastIdx = currentMessages.length - 1;
+      if (lastIdx < 0 || currentMessages[lastIdx].role !== "assistant") return;
+
+      const lastMsg = currentMessages[lastIdx];
+      const newContent =
+        typeof updater === "function"
+          ? (updater as (prev: string) => string)(lastMsg.content)
+          : updater;
+
+      useEditorAIStore.setState({
+        messages: currentMessages.map((m, i) =>
+          i === lastIdx ? { ...m, content: newContent } : m,
+        ),
+      });
+    },
+    [],
+  );
+
+  const getCurrentAssistantContent = useCallback(() => {
+    const currentMessages = useEditorAIStore.getState().messages;
+    const lastIdx = currentMessages.length - 1;
+    if (lastIdx < 0 || currentMessages[lastIdx].role !== "assistant") return "";
+    return currentMessages[lastIdx].content;
+  }, []);
+
+  // ---------- Stop streaming ----------
+  const handleStop = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setStreaming(false);
+  }, []);
+
+  // ---------- Insert to editor ----------
+  const handleInsertToEditor = useCallback(
+    (content: string) => {
+      try {
+        const editor = editorRef.current;
+        if (!editor?.tryParseMarkdownToBlocks || !editor?.insertBlocks) {
+          return;
+        }
+        const blocks = editor.tryParseMarkdownToBlocks(content);
+        if (blocks && blocks.length > 0) {
+          editor.insertBlocks(blocks);
+        }
+      } catch {
+        // Silently fail — the editor API might not be available
+      }
+    },
+    [editorRef],
+  );
+
+  // ---------- Copy ----------
+  const handleCopy = useCallback(async (content: string) => {
+    try {
+      await navigator.clipboard.writeText(content);
+    } catch {
+      // Fallback: no-op
+    }
+  }, []);
+
+  // ---------- Quick action ----------
+  const handleQuickAction = useCallback(
+    (prompt: string) => {
+      setInput(prompt);
+      textareaRef.current?.focus();
+    },
+    [],
+  );
+
+  // ---------- Keyboard ----------
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        if (streaming) {
+          handleStop();
+        } else {
+          handleSend();
+        }
+      }
+    },
+    [streaming, handleSend, handleStop],
+  );
+
+  // ---------- Render ----------
+  if (!sidebarOpen) return null;
+
+  return (
+    <div className="flex h-full w-80 shrink-0 flex-col border-l bg-background">
+      {/* Header */}
+      <div className="flex items-center gap-2 border-b px-3 py-2">
+        <Sparkles className="size-4 text-primary" />
+        <span className="text-sm font-medium">AI 助手</span>
+        <div className="flex-1" />
+        <select
+          value={selectedModel}
+          onChange={(e) => setSelectedModel(e.target.value)}
+          className="h-6 rounded border bg-transparent px-1.5 text-xs outline-none focus:border-ring"
+        >
+          {MODEL_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          onClick={() => setSidebarOpen(false)}
+          title="关闭"
+        >
+          <X className="size-3.5" />
+        </Button>
+      </div>
+
+      {/* Context indicator */}
+      {sectionContent && (
+        <div className="border-b px-3 py-1.5 text-xs text-muted-foreground">
+          📄 已关联当前章节
+        </div>
+      )}
+
+      {/* Messages area */}
+      <ScrollArea className="flex-1" ref={scrollRef}>
+        <div className="flex flex-col gap-3 p-3">
+          {messages.length === 0 && (
+            <div className="py-8 text-center text-xs text-muted-foreground">
+              <Sparkles className="mx-auto mb-2 size-8 text-muted-foreground/50" />
+              <p>你好！我是 AI 助手</p>
+              <p className="mt-1">可以帮你润色、改写、扩展文本</p>
+            </div>
+          )}
+
+          {messages.map((msg, idx) => {
+            const isLast =
+              idx === messages.length - 1 && msg.role === "assistant";
+            const isStreamingThis = isLast && streaming;
+
+            // System message
+            if (msg.role === "system") {
+              return (
+                <div
+                  key={msg.id}
+                  className="rounded bg-muted px-3 py-2 text-xs text-muted-foreground"
+                >
+                  {msg.content}
+                </div>
+              );
+            }
+
+            // User message
+            if (msg.role === "user") {
+              return (
+                <div key={msg.id} className="flex flex-col items-end gap-1">
+                  {msg.pinnedSelections && msg.pinnedSelections.length > 0 && (
+                    <div className="flex flex-col gap-1 text-right">
+                      {msg.pinnedSelections.map((sel) => (
+                        <div
+                          key={sel.id}
+                          className="inline-flex items-center gap-1 text-xs text-blue-500"
+                        >
+                          <span>📎 引用了 ({sel.text.length} 字)</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                  <div className="max-w-[85%] rounded-lg bg-primary px-3 py-2 text-sm text-primary-foreground">
+                    {msg.content}
+                  </div>
+                </div>
+              );
+            }
+
+            // Assistant message
+            return (
+              <div
+                key={msg.id}
+                className="flex flex-col gap-1.5 rounded-lg border px-3 py-2"
+              >
+                <div className="whitespace-pre-wrap text-sm leading-relaxed">
+                  {msg.content || (isStreamingThis ? "" : "...")}
+                  {isStreamingThis && (
+                    <span className="ml-0.5 inline-block animate-pulse">▌</span>
+                  )}
+                </div>
+
+                {/* Action buttons (only for completed messages with content) */}
+                {msg.content && !isStreamingThis && (
+                  <div className="flex items-center gap-1 border-t pt-1.5">
+                    <Button
+                      variant="ghost"
+                      size="xs"
+                      className="h-5 gap-1 text-xs"
+                      onClick={() => handleInsertToEditor(msg.content)}
+                      title="插入到编辑器"
+                    >
+                      <ArrowDownToLine className="size-3" />
+                      插入到编辑器
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="xs"
+                      className="h-5 gap-1 text-xs"
+                      onClick={() => handleCopy(msg.content)}
+                      title="复制"
+                    >
+                      <Copy className="size-3" />
+                      复制
+                    </Button>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </ScrollArea>
+
+      {/* Quick action bar */}
+      {globalActions.length > 0 && (
+        <div className="border-t px-3 py-2">
+          <div className="flex gap-1.5 overflow-x-auto scrollbar-none">
+            {globalActions.slice(0, 6).map((action) => (
+              <button
+                key={action.id}
+                type="button"
+                onClick={() => handleQuickAction(action.prompt)}
+                className="shrink-0 rounded-full border px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                {action.icon || "🤖"} {action.name}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Pinned selections */}
+      {pinnedSelections.length > 0 && (
+        <div className="flex flex-col gap-1.5 border-t px-3 py-2">
+          {pinnedSelections.map((sel) => (
+            <SelectionAttachment
+              key={sel.id}
+              selection={sel}
+              onRemove={removePinnedSelection}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Input area */}
+      <div className="border-t p-3">
+        <div className="flex items-end gap-2">
+          <textarea
+            ref={textareaRef}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="输入消息... (Shift+Enter 换行)"
+            rows={1}
+            className="flex max-h-40 min-h-[2rem] flex-1 resize-none rounded-md border bg-transparent px-2.5 py-1.5 text-sm outline-none focus:border-ring"
+            disabled={streaming}
+          />
+          <Button
+            variant={streaming ? "destructive" : "default"}
+            size="icon-xs"
+            onClick={streaming ? handleStop : handleSend}
+            disabled={!streaming && !input.trim()}
+            title={streaming ? "停止" : "发送"}
+          >
+            {streaming ? (
+              <ChevronDown className="size-3" />
+            ) : (
+              <Send className="size-3" />
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/reports/components/editor/ai/SelectionAttachment.tsx
+++ b/src/modules/reports/components/editor/ai/SelectionAttachment.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { X } from "lucide-react";
+import type { PinnedSelection } from "@/types/editor-ai";
+
+interface SelectionAttachmentProps {
+  selection: PinnedSelection;
+  onRemove: (id: string) => void;
+}
+
+export function SelectionAttachment({ selection, onRemove }: SelectionAttachmentProps) {
+  const preview =
+    selection.text.length > 60
+      ? selection.text.slice(0, 60) + "..."
+      : selection.text;
+
+  return (
+    <div className="flex items-start gap-1.5 rounded-md border border-blue-200 bg-blue-50/50 p-2 text-xs dark:border-blue-800 dark:bg-blue-950/30">
+      <span className="shrink-0 text-blue-500" title="选中文本">
+        📎 选中文本
+        <span className="ml-1 text-muted-foreground">
+          ({selection.text.length} 字)
+        </span>
+      </span>
+      <span className="flex-1 truncate text-foreground">{preview}</span>
+      <button
+        type="button"
+        onClick={() => onRemove(selection.id)}
+        className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+        title="移除"
+      >
+        <X className="size-3" />
+      </button>
+    </div>
+  );
+}

--- a/src/modules/reports/components/editor/ai/useAIActions.ts
+++ b/src/modules/reports/components/editor/ai/useAIActions.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import type { EditorAIActionItem } from "@/types/editor-ai";
+
+export function useAIActions() {
+  const [actions, setActions] = useState<EditorAIActionItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchActions = useCallback(async () => {
+    try {
+      const res = await fetch("/api/editor-ai/actions");
+      if (res.ok) {
+        const json = await res.json();
+        setActions(json.data ?? []);
+      }
+    } catch {
+      // Silently fail — actions are non-critical
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchActions();
+  }, [fetchActions]);
+
+  const globalActions = actions.filter((a) => !a.userId);
+  const userActions = actions.filter((a) => a.userId);
+
+  return { actions, globalActions, userActions, loading, refresh: fetchActions };
+}

--- a/src/modules/reports/components/editor/ai/useEditorAIStore.ts
+++ b/src/modules/reports/components/editor/ai/useEditorAIStore.ts
@@ -1,0 +1,68 @@
+import { create } from "zustand";
+import type { PinnedSelection } from "@/types/editor-ai";
+
+interface ChatMessage {
+  id: string;
+  role: "user" | "assistant" | "system";
+  content: string;
+  pinnedSelections?: PinnedSelection[];
+  timestamp: number;
+}
+
+interface EditorAIState {
+  sidebarOpen: boolean;
+  setSidebarOpen: (open: boolean) => void;
+
+  messages: ChatMessage[];
+  addMessage: (msg: Omit<ChatMessage, "id" | "timestamp">) => void;
+  clearMessages: () => void;
+
+  pinnedSelections: PinnedSelection[];
+  addPinnedSelection: (sel: Omit<PinnedSelection, "id" | "timestamp">) => void;
+  removePinnedSelection: (id: string) => void;
+  clearPinnedSelections: () => void;
+
+  selectedModel: string;
+  setSelectedModel: (model: string) => void;
+
+  sectionContent: string;
+  setSectionContent: (content: string) => void;
+}
+
+export const useEditorAIStore = create<EditorAIState>((set) => ({
+  sidebarOpen: false,
+  setSidebarOpen: (open) => set({ sidebarOpen: open }),
+
+  messages: [],
+  addMessage: (msg) =>
+    set((state) => ({
+      messages: [
+        ...state.messages,
+        { ...msg, id: crypto.randomUUID(), timestamp: Date.now() },
+      ],
+    })),
+  clearMessages: () => set({ messages: [] }),
+
+  pinnedSelections: [],
+  addPinnedSelection: (sel) =>
+    set((state) => {
+      if (state.pinnedSelections.length >= 5) return state;
+      return {
+        pinnedSelections: [
+          ...state.pinnedSelections,
+          { ...sel, id: crypto.randomUUID(), timestamp: Date.now() },
+        ],
+      };
+    }),
+  removePinnedSelection: (id) =>
+    set((state) => ({
+      pinnedSelections: state.pinnedSelections.filter((s) => s.id !== id),
+    })),
+  clearPinnedSelections: () => set({ pinnedSelections: [] }),
+
+  selectedModel: "gpt-4o",
+  setSelectedModel: (model) => set({ selectedModel: model }),
+
+  sectionContent: "",
+  setSectionContent: (content) => set({ sectionContent: content }),
+}));

--- a/src/modules/reports/components/editor/ai/useEditorAIStore.ts
+++ b/src/modules/reports/components/editor/ai/useEditorAIStore.ts
@@ -3,8 +3,8 @@ import type { PinnedSelection } from "@/types/editor-ai";
 
 let _idCounter = 0;
 function generateId(): string {
-  if (typeof crypto !== "undefined" && crypto.randomUUID) {
-    return generateId();
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
   }
   return `id-${Date.now()}-${++_idCounter}`;
 }
@@ -27,6 +27,12 @@ interface EditorAIState {
   actionDialogContext: string;
   openActionDialog: (selection: string, blockIds: string[], context: string) => void;
   closeActionDialog: () => void;
+
+  actionDialogResult: string;
+  actionDialogExecuting: boolean;
+  setActionDialogResult: (result: string) => void;
+  setActionDialogExecuting: (executing: boolean) => void;
+  resetActionDialogResult: () => void;
 
   messages: ChatMessage[];
   addMessage: (msg: Omit<ChatMessage, "id" | "timestamp">) => void;
@@ -56,6 +62,12 @@ export const useEditorAIStore = create<EditorAIState>((set) => ({
     set({ actionDialogOpen: true, actionDialogSelection: selection, actionDialogBlockIds: blockIds, actionDialogContext: context }),
   closeActionDialog: () =>
     set({ actionDialogOpen: false, actionDialogSelection: "", actionDialogBlockIds: [], actionDialogContext: "" }),
+
+  actionDialogResult: "",
+  actionDialogExecuting: false,
+  setActionDialogResult: (result) => set({ actionDialogResult: result }),
+  setActionDialogExecuting: (executing) => set({ actionDialogExecuting: executing }),
+  resetActionDialogResult: () => set({ actionDialogResult: "", actionDialogExecuting: false }),
 
   messages: [],
   addMessage: (msg) =>

--- a/src/modules/reports/components/editor/ai/useEditorAIStore.ts
+++ b/src/modules/reports/components/editor/ai/useEditorAIStore.ts
@@ -60,7 +60,7 @@ export const useEditorAIStore = create<EditorAIState>((set) => ({
     })),
   clearPinnedSelections: () => set({ pinnedSelections: [] }),
 
-  selectedModel: "gpt-4o",
+  selectedModel: "",
   setSelectedModel: (model) => set({ selectedModel: model }),
 
   sectionContent: "",

--- a/src/modules/reports/components/editor/ai/useEditorAIStore.ts
+++ b/src/modules/reports/components/editor/ai/useEditorAIStore.ts
@@ -21,6 +21,13 @@ interface EditorAIState {
   sidebarOpen: boolean;
   setSidebarOpen: (open: boolean) => void;
 
+  actionDialogOpen: boolean;
+  actionDialogSelection: string;
+  actionDialogBlockIds: string[];
+  actionDialogContext: string;
+  openActionDialog: (selection: string, blockIds: string[], context: string) => void;
+  closeActionDialog: () => void;
+
   messages: ChatMessage[];
   addMessage: (msg: Omit<ChatMessage, "id" | "timestamp">) => void;
   clearMessages: () => void;
@@ -40,6 +47,15 @@ interface EditorAIState {
 export const useEditorAIStore = create<EditorAIState>((set) => ({
   sidebarOpen: false,
   setSidebarOpen: (open) => set({ sidebarOpen: open }),
+
+  actionDialogOpen: false,
+  actionDialogSelection: "",
+  actionDialogBlockIds: [],
+  actionDialogContext: "",
+  openActionDialog: (selection, blockIds, context) =>
+    set({ actionDialogOpen: true, actionDialogSelection: selection, actionDialogBlockIds: blockIds, actionDialogContext: context }),
+  closeActionDialog: () =>
+    set({ actionDialogOpen: false, actionDialogSelection: "", actionDialogBlockIds: [], actionDialogContext: "" }),
 
   messages: [],
   addMessage: (msg) =>

--- a/src/modules/reports/components/editor/ai/useEditorAIStore.ts
+++ b/src/modules/reports/components/editor/ai/useEditorAIStore.ts
@@ -1,6 +1,14 @@
 import { create } from "zustand";
 import type { PinnedSelection } from "@/types/editor-ai";
 
+let _idCounter = 0;
+function generateId(): string {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return generateId();
+  }
+  return `id-${Date.now()}-${++_idCounter}`;
+}
+
 interface ChatMessage {
   id: string;
   role: "user" | "assistant" | "system";
@@ -38,7 +46,7 @@ export const useEditorAIStore = create<EditorAIState>((set) => ({
     set((state) => ({
       messages: [
         ...state.messages,
-        { ...msg, id: crypto.randomUUID(), timestamp: Date.now() },
+        { ...msg, id: generateId(), timestamp: Date.now() },
       ],
     })),
   clearMessages: () => set({ messages: [] }),
@@ -50,7 +58,7 @@ export const useEditorAIStore = create<EditorAIState>((set) => ({
       return {
         pinnedSelections: [
           ...state.pinnedSelections,
-          { ...sel, id: crypto.randomUUID(), timestamp: Date.now() },
+          { ...sel, id: generateId(), timestamp: Date.now() },
         ],
       };
     }),

--- a/src/types/editor-ai.ts
+++ b/src/types/editor-ai.ts
@@ -1,0 +1,58 @@
+// src/types/editor-ai.ts
+
+export interface EditorAIActionItem {
+  id: string;
+  name: string;
+  icon: string | null;
+  prompt: string;
+  category: string;
+  scope: "selection" | "paragraph" | "document";
+  sortOrder: number;
+  isBuiltIn: boolean;
+  enabled: boolean;
+  userId: string | null;
+  createdAt: string;
+}
+
+export interface EditorAIActionCreateInput {
+  name: string;
+  icon?: string;
+  prompt: string;
+  category?: string;
+  scope?: "selection" | "paragraph" | "document";
+}
+
+export interface EditorAIActionUpdateInput {
+  name?: string;
+  icon?: string;
+  prompt?: string;
+  category?: string;
+  scope?: "selection" | "paragraph" | "document";
+  enabled?: boolean;
+  sortOrder?: number;
+}
+
+export interface EditorAIExecuteRequest {
+  actionId?: string;
+  prompt?: string;
+  selection?: string;
+  context?: string;
+  instruction?: string;
+  model?: string;
+}
+
+export interface EditorAIChatRequest {
+  messages: Array<{ role: string; content: string }>;
+  model: string;
+  context?: {
+    sectionContent?: string;
+    pinnedSelections?: string[];
+  };
+}
+
+export interface PinnedSelection {
+  id: string;
+  text: string;
+  blockIds: string[];
+  timestamp: number;
+}

--- a/src/validators/editor-ai.ts
+++ b/src/validators/editor-ai.ts
@@ -1,0 +1,50 @@
+// src/validators/editor-ai.ts
+import { z } from "zod";
+
+export const createActionSchema = z.object({
+  name: z.string().min(1).max(50),
+  icon: z.string().max(10).optional(),
+  prompt: z.string().min(1).max(2000),
+  category: z.enum(["general", "writing", "translation", "analysis"]).optional(),
+  scope: z.enum(["selection", "paragraph", "document"]).optional(),
+});
+
+export const updateActionSchema = z.object({
+  name: z.string().min(1).max(50).optional(),
+  icon: z.string().max(10).optional(),
+  prompt: z.string().min(1).max(2000).optional(),
+  category: z.enum(["general", "writing", "translation", "analysis"]).optional(),
+  scope: z.enum(["selection", "paragraph", "document"]).optional(),
+  enabled: z.boolean().optional(),
+  sortOrder: z.number().int().min(0).optional(),
+});
+
+export const executeActionSchema = z.object({
+  actionId: z.string().optional(),
+  prompt: z.string().max(2000).optional(),
+  selection: z.string().optional(),
+  context: z.string().optional(),
+  instruction: z.string().max(1000).optional(),
+  model: z.string().optional(),
+}).refine((data) => data.actionId || data.prompt, {
+  message: "必须提供 actionId 或 prompt",
+});
+
+export const chatSchema = z.object({
+  messages: z.array(
+    z.object({
+      role: z.enum(["user", "assistant"]),
+      content: z.string().min(1),
+    })
+  ).min(1),
+  model: z.string().min(1),
+  context: z.object({
+    sectionContent: z.string().optional(),
+    pinnedSelections: z.array(z.string()).optional(),
+  }).optional(),
+});
+
+export type CreateActionInput = z.infer<typeof createActionSchema>;
+export type UpdateActionInput = z.infer<typeof updateActionSchema>;
+export type ExecuteActionInput = z.infer<typeof executeActionSchema>;
+export type ChatInput = z.infer<typeof chatSchema>;


### PR DESCRIPTION
## Summary
- 完整的报告编辑器 AI 助手功能：侧边栏对话、AI 操作弹窗、模板管理
- 右侧 AI 助手侧边栏支持拖拽调整宽度（220-640px）
- 支持引用编辑器选中文本到 AI 对话上下文
- "插入到编辑器"精确定位到最后聚焦的光标位置（4 层策略查找）
- 修复对话较多时无法向下滚动的问题
- AI 操作模板 CRUD API + 管理后台页面
- AI 操作弹窗支持预设操作和自定义指令，可替换/插入/复制结果

## Changes
- **新增组件**: AIChatSidebar, AIActionButton, AIActionDialog, AIActionPopover, AIActionExecutor, AIActionForm, SelectionAttachment, useEditorAIStore, useAIActions
- **新增 API**: /api/editor-ai/actions (CRUD), /api/editor-ai/execute, /api/editor-ai/chat
- **新增页面**: /admin/editor-ai (模板管理), /about
- **Prisma**: 新增 EditorAIAction 模型 + 种子数据
- **修复**: 开发模式登录 0.0.0.0 重定向问题

## Test plan
- [ ] 打开报告草稿编辑页，切换到 AI 助手 tab，发送消息并验证流式回复
- [ ] 拖拽 AI 侧边栏左边缘验证宽度调整
- [ ] 选中编辑器文字，点击"引用选中文本"按钮，验证引用出现在输入区
- [ ] 点击"插入到编辑器"，验证内容插入到光标聚焦位置而非文档末尾
- [ ] 多轮对话后验证消息区域可正常滚动
- [ ] 选中文本后点击格式工具栏 AI 按钮，验证弹窗出现并执行操作
- [ ] 管理后台创建/编辑/删除 AI 操作模板

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)