### PR TITLE
[Enhancement] 加载体验与错误边界优化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ report-engine/src/*.egg-info/
 /sidebar-test.png
 /src/generated/prisma
 .superpowers/
-docs/superpowers/
 # testing
 test-results/
 /tool-error.png

--- a/docs/superpowers/specs/2026-05-05-loading-error-ux-design.md
+++ b/docs/superpowers/specs/2026-05-05-loading-error-ux-design.md
@@ -1,0 +1,208 @@
+# 加载体验与错误边界优化设计
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 统一所有 dashboard 页面的加载状态和错误处理体验，消除白屏等待，提供一致的操作反馈。
+
+**Architecture:** 4 种骨架屏模板覆盖 35+ 路由，全局 + 路由级错误边界，统一 Toast 通知规范。
+
+**Tech Stack:** Next.js 16 Suspense, React Error Boundary, Tailwind CSS skeleton animations, Sonner toast.
+
+**GitHub Issue:** #152
+
+---
+
+## 1. 骨架屏模板
+
+创建 4 种可复用的骨架屏组件，放在 `src/components/shared/skeletons/` 目录。
+
+### 1.1 组件结构
+
+```
+src/components/shared/skeletons/
+├── list-page-skeleton.tsx      # 列表页（表格 + 筛选）
+├── detail-page-skeleton.tsx    # 详情页（面包屑 + 卡片）
+├── form-page-skeleton.tsx      # 表单页（标题 + 字段组）
+├── special-skeleton.tsx        # 特殊页面（数据表、报告编辑器、AI 助手）
+└── index.ts                    # barrel export
+```
+
+### 1.2 通用 Skeleton 基础组件
+
+在 `src/components/ui/skeleton.tsx` 中创建基础骨架块（如果不存在），使用 Tailwind animate-pulse：
+
+```tsx
+// 灰色脉冲背景块
+<div className="animate-pulse rounded-md bg-muted/40" />
+```
+
+### 1.3 ListPageSkeleton
+
+适用于：`/templates`, `/records`, `/drafts`, `/collections`, `/automations`, `/admin/users`, `/admin/audit-logs`, `/reports/drafts`, `/reports/templates`, `/data`, `/generate`
+
+布局：
+- PageHeader 区域（标题行 + 描述行）
+- 筛选栏（2-3 个圆角矩形标签占位）
+- 表格/卡片区域（5 行高度 48px 的横条，间距 8px）
+
+### 1.4 DetailPageSkeleton
+
+适用于：`/templates/[id]`, `/records/[id]`, `/collections/[id]`, `/automations/[id]`, `/data/[tableId]/fields`, `/budget`
+
+布局：
+- Breadcrumbs 区域（2 个短条）
+- 大卡片区域（高度约 200px）
+- 内容区域（3-4 个横条，宽窄交替）
+
+### 1.5 FormPageSkeleton
+
+适用于：`/templates/[id]/fill`, `/templates/[id]/edit`, `/templates/new`, `/collections/new`, `/automations/new`, `/data/[tableId]/new`, `/data/[tableId]/[recordId]/edit`, `/data/[tableId]/import`, `/templates/[id]/batch`
+
+布局：
+- PageHeader 区域
+- 4 组表单字段（每组：标签行 80px 宽 + 输入框 100% 宽 40px 高）
+
+### 1.6 SpecialSkeleton
+
+三个特殊变体：
+
+**DataTableSkeleton**（`/data/[tableId]`）：
+- 工具栏（按钮组占位）
+- 表格头（8 列）
+- 5 行数据行
+
+**ReportEditorSkeleton**（`/reports/drafts/[id]`）：
+- 左侧章节面板（窄条）
+- 中间编辑区域（大面积）
+- 右侧 AI 面板折叠态
+
+**AiAgentSkeleton**（`/ai-agent2`）：
+- 左侧对话列表（窄条 x 10）
+- 右侧对话区域（气泡占位 + 输入框）
+
+---
+
+## 2. loading.tsx 部署
+
+### 2.1 部署策略
+
+使用 Next.js 的 Suspense + `loading.tsx` 机制。在每个路由目录放置 `loading.tsx`，引用对应的骨架屏组件。
+
+### 2.2 路由级 loading.tsx 映射
+
+| 路由 | 骨架屏类型 |
+|------|-----------|
+| `(dashboard)/loading.tsx` | ListPageSkeleton（首页工作台） |
+| `(dashboard)/about/loading.tsx` | DetailPageSkeleton |
+| `(dashboard)/generate/loading.tsx` | ListPageSkeleton |
+| `(dashboard)/templates/loading.tsx` | ListPageSkeleton |
+| `(dashboard)/templates/new/loading.tsx` | FormPageSkeleton |
+| `(dashboard)/templates/[id]/loading.tsx` | DetailPageSkeleton |
+| `(dashboard)/templates/[id]/edit/loading.tsx` | FormPageSkeleton |
+| `(dashboard)/templates/[id]/fill/loading.tsx` | FormPageSkeleton |
+| `(dashboard)/templates/[id]/batch/loading.tsx` | FormPageSkeleton |
+| `(dashboard)/records/loading.tsx` | ListPageSkeleton |
+| `(dashboard)/records/[id]/loading.tsx` | DetailPageSkeleton |
+| `(dashboard)/drafts/loading.tsx` | ListPageSkeleton |
+| `(dashboard)/data/loading.tsx` | ListPageSkeleton |
+| `(dashboard)/data/[tableId]/loading.tsx` | SpecialSkeleton(DataTable) |
+| `(dashboard)/data/[tableId]/fields/loading.tsx` | FormPageSkeleton |
+| `(dashboard)/data/[tableId]/new/loading.tsx` | FormPageSkeleton |
+| `(dashboard)/data/[tableId]/import/loading.tsx` | FormPageSkeleton |
+| `(dashboard)/data/[tableId]/[recordId]/edit/loading.tsx` | FormPageSkeleton |
+| `(dashboard)/reports/drafts/loading.tsx` | ListPageSkeleton |
+| `(dashboard)/reports/drafts/[id]/loading.tsx` | SpecialSkeleton(ReportEditor) |
+| `(dashboard)/reports/templates/loading.tsx` | ListPageSkeleton |
+| `(dashboard)/budget/loading.tsx` | DetailPageSkeleton |
+| `(dashboard)/collections/loading.tsx` | ListPageSkeleton |
+| `(dashboard)/collections/new/loading.tsx` | FormPageSkeleton |
+| `(dashboard)/collections/[id]/loading.tsx` | DetailPageSkeleton |
+| `(dashboard)/automations/loading.tsx` | ListPageSkeleton |
+| `(dashboard)/automations/new/loading.tsx` | FormPageSkeleton |
+| `(dashboard)/automations/[id]/loading.tsx` | DetailPageSkeleton |
+| `(dashboard)/ai-agent2/loading.tsx` | SpecialSkeleton(AiAgent) |
+| `(dashboard)/admin/users/loading.tsx` | ListPageSkeleton |
+| `(dashboard)/admin/settings/loading.tsx` | DetailPageSkeleton |
+| `(dashboard)/admin/editor-ai/loading.tsx` | DetailPageSkeleton |
+| `(dashboard)/admin/audit-logs/loading.tsx` | ListPageSkeleton |
+
+总计 32 个 `loading.tsx` 文件。每个文件仅 3-5 行，引用对应骨架屏组件。
+
+---
+
+## 3. 错误边界
+
+### 3.1 根级错误页面
+
+**`src/app/error.tsx`** — 全局错误边界（必须是客户端组件）
+
+- 显示错误图标 + "页面加载出错" 标题
+- 错误消息摘要（不暴露堆栈）
+- 两个按钮："重试"（调用 reset()）、"返回首页"
+- 样式与 EmptyState 组件一致，居中布局
+
+**`src/app/not-found.tsx`** — 全局 404 页面
+
+- 显示 404 图标 + "页面未找到" 标题
+- 搜索框（调用全局搜索对话框）
+- "返回首页" 按钮
+
+### 3.2 路由级错误边界
+
+仅在关键操作页面添加 `error.tsx`，提供更具体的恢复建议：
+
+| 路由 | 错误提示 | 恢复动作 |
+|------|---------|---------|
+| `(dashboard)/error.tsx` | 通用 dashboard 错误 | 重试 + 返回首页 |
+| `(dashboard)/templates/[id]/fill/error.tsx` | "表单加载失败" | 重试 + 返回模板列表 |
+| `(dashboard)/data/[tableId]/error.tsx` | "数据表加载失败" | 重试 + 返回数据表列表 |
+| `(dashboard)/reports/drafts/[id]/error.tsx` | "报告加载失败" | 重试 + 返回报告列表 |
+
+---
+
+## 4. Toast 通知统一规范
+
+### 4.1 Toast 配置
+
+在 `src/components/providers/toast-provider.tsx`（或现有的 Toaster 配置）中统一设置：
+
+```
+位置：底部右侧（bottom-right）
+成功：duration 3000ms，绿色图标
+错误：duration 5000ms，红色图标，带"查看详情"展开
+加载中：duration Infinity（手动 dismiss），蓝色图标
+```
+
+### 4.2 Toast 使用规范
+
+| 操作类型 | Toast 样式 | 示例 |
+|---------|-----------|------|
+| 创建成功 | success, 3s | "模板创建成功" |
+| 更新成功 | success, 3s | "设置已保存" |
+| 删除成功 | success, 3s | "模板已删除" |
+| 操作失败 | error, 5s | "生成失败：网络错误" |
+| 权限不足 | error, 5s | "无权限执行此操作" |
+| 后台任务 | loading → success/error | "正在生成文档..." → "文档生成成功" |
+
+### 4.3 实施方式
+
+创建 `src/lib/toast-helpers.ts` 工具函数，封装常用 toast 调用：
+
+```ts
+toastSuccess(message: string)      // 成功，3s
+toastError(message: string)        // 错误，5s
+toastLoading(message: string)      // 加载中，返回 id
+toastDismiss(id: string | number)  // 关闭指定 toast
+```
+
+逐步将现有散落的 `toast.success()` / `toast.error()` 调用替换为统一函数（可在后续迭代中完成，不必本次全部替换）。
+
+---
+
+## 5. 不做的事
+
+- 不做移动端专属优化（单独子项目）
+- 不做性能优化（虚拟滚动、懒加载 → 子项目 2）
+- 不做功能增强（搜索、快捷键 → 子项目 3）
+- 不改动现有页面逻辑和 UI 布局
+- 不引入新的 UI 库

--- a/src/app/(dashboard)/about/loading.tsx
+++ b/src/app/(dashboard)/about/loading.tsx
@@ -1,0 +1,5 @@
+import { DetailPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <DetailPageSkeleton />;
+}

--- a/src/app/(dashboard)/admin/audit-logs/loading.tsx
+++ b/src/app/(dashboard)/admin/audit-logs/loading.tsx
@@ -1,0 +1,5 @@
+import { ListPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <ListPageSkeleton />;
+}

--- a/src/app/(dashboard)/admin/editor-ai/loading.tsx
+++ b/src/app/(dashboard)/admin/editor-ai/loading.tsx
@@ -1,0 +1,5 @@
+import { DetailPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <DetailPageSkeleton />;
+}

--- a/src/app/(dashboard)/admin/settings/loading.tsx
+++ b/src/app/(dashboard)/admin/settings/loading.tsx
@@ -1,0 +1,5 @@
+import { DetailPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <DetailPageSkeleton />;
+}

--- a/src/app/(dashboard)/admin/users/loading.tsx
+++ b/src/app/(dashboard)/admin/users/loading.tsx
@@ -1,0 +1,5 @@
+import { ListPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <ListPageSkeleton />;
+}

--- a/src/app/(dashboard)/ai-agent2/loading.tsx
+++ b/src/app/(dashboard)/ai-agent2/loading.tsx
@@ -1,0 +1,5 @@
+import { AiAgentSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <AiAgentSkeleton />;
+}

--- a/src/app/(dashboard)/automations/[id]/loading.tsx
+++ b/src/app/(dashboard)/automations/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { DetailPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <DetailPageSkeleton />;
+}

--- a/src/app/(dashboard)/automations/loading.tsx
+++ b/src/app/(dashboard)/automations/loading.tsx
@@ -1,0 +1,5 @@
+import { ListPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <ListPageSkeleton />;
+}

--- a/src/app/(dashboard)/automations/new/loading.tsx
+++ b/src/app/(dashboard)/automations/new/loading.tsx
@@ -1,0 +1,5 @@
+import { FormPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <FormPageSkeleton />;
+}

--- a/src/app/(dashboard)/budget/loading.tsx
+++ b/src/app/(dashboard)/budget/loading.tsx
@@ -1,0 +1,5 @@
+import { DetailPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <DetailPageSkeleton />;
+}

--- a/src/app/(dashboard)/collections/[id]/loading.tsx
+++ b/src/app/(dashboard)/collections/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { DetailPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <DetailPageSkeleton />;
+}

--- a/src/app/(dashboard)/collections/loading.tsx
+++ b/src/app/(dashboard)/collections/loading.tsx
@@ -1,0 +1,5 @@
+import { ListPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <ListPageSkeleton />;
+}

--- a/src/app/(dashboard)/collections/new/loading.tsx
+++ b/src/app/(dashboard)/collections/new/loading.tsx
@@ -1,0 +1,5 @@
+import { FormPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <FormPageSkeleton />;
+}

--- a/src/app/(dashboard)/data/[tableId]/[recordId]/edit/loading.tsx
+++ b/src/app/(dashboard)/data/[tableId]/[recordId]/edit/loading.tsx
@@ -1,0 +1,5 @@
+import { FormPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <FormPageSkeleton />;
+}

--- a/src/app/(dashboard)/data/[tableId]/error.tsx
+++ b/src/app/(dashboard)/data/[tableId]/error.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { AlertTriangle, Database, RotateCw } from "lucide-react";
+import Link from "next/link";
+
+export default function DataTableError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center text-center">
+      <div className="flex h-14 w-14 items-center justify-center rounded-xl border border-border bg-card">
+        <AlertTriangle className="h-7 w-7 text-destructive" />
+      </div>
+      <h2 className="mt-5 text-xl font-[510] tracking-tight text-foreground">
+        数据表加载失败
+      </h2>
+      <p className="mt-2 max-w-md text-sm text-muted-foreground">
+        {error.message || "无法加载数据表，请稍后重试。"}
+      </p>
+      <div className="mt-6 flex items-center gap-3">
+        <button
+          onClick={reset}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-[510] text-white transition-colors hover:bg-accent"
+        >
+          <RotateCw className="h-4 w-4" />
+          重试
+        </button>
+        <Link
+          href="/data"
+          className="inline-flex items-center gap-2 rounded-md border border-border px-4 py-2 text-sm font-[510] text-muted-foreground transition-colors hover:border-border-hover hover:text-foreground"
+        >
+          <Database className="h-4 w-4" />
+          返回数据表列表
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/data/[tableId]/fields/loading.tsx
+++ b/src/app/(dashboard)/data/[tableId]/fields/loading.tsx
@@ -1,0 +1,5 @@
+import { FormPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <FormPageSkeleton />;
+}

--- a/src/app/(dashboard)/data/[tableId]/import/loading.tsx
+++ b/src/app/(dashboard)/data/[tableId]/import/loading.tsx
@@ -1,0 +1,5 @@
+import { FormPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <FormPageSkeleton />;
+}

--- a/src/app/(dashboard)/data/[tableId]/loading.tsx
+++ b/src/app/(dashboard)/data/[tableId]/loading.tsx
@@ -1,0 +1,5 @@
+import { DataTableSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <DataTableSkeleton />;
+}

--- a/src/app/(dashboard)/data/[tableId]/new/loading.tsx
+++ b/src/app/(dashboard)/data/[tableId]/new/loading.tsx
@@ -1,0 +1,5 @@
+import { FormPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <FormPageSkeleton />;
+}

--- a/src/app/(dashboard)/data/loading.tsx
+++ b/src/app/(dashboard)/data/loading.tsx
@@ -1,0 +1,5 @@
+import { ListPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <ListPageSkeleton />;
+}

--- a/src/app/(dashboard)/drafts/loading.tsx
+++ b/src/app/(dashboard)/drafts/loading.tsx
@@ -1,0 +1,5 @@
+import { ListPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <ListPageSkeleton />;
+}

--- a/src/app/(dashboard)/error.tsx
+++ b/src/app/(dashboard)/error.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { AlertTriangle, Home, RotateCw } from "lucide-react";
+import Link from "next/link";
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center text-center">
+      <div className="flex h-14 w-14 items-center justify-center rounded-xl border border-border bg-card">
+        <AlertTriangle className="h-7 w-7 text-destructive" />
+      </div>
+      <h2 className="mt-5 text-xl font-[510] tracking-tight text-foreground">
+        页面加载出错
+      </h2>
+      <p className="mt-2 max-w-md text-sm text-muted-foreground">
+        {error.message || "数据加载失败，请稍后重试。"}
+      </p>
+      <div className="mt-6 flex items-center gap-3">
+        <button
+          onClick={reset}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-[510] text-white transition-colors hover:bg-accent"
+        >
+          <RotateCw className="h-4 w-4" />
+          重试
+        </button>
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 rounded-md border border-border px-4 py-2 text-sm font-[510] text-muted-foreground transition-colors hover:border-border-hover hover:text-foreground"
+        >
+          <Home className="h-4 w-4" />
+          返回首页
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/generate/loading.tsx
+++ b/src/app/(dashboard)/generate/loading.tsx
@@ -1,0 +1,5 @@
+import { ListPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <ListPageSkeleton />;
+}

--- a/src/app/(dashboard)/loading.tsx
+++ b/src/app/(dashboard)/loading.tsx
@@ -1,0 +1,5 @@
+import { ListPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <ListPageSkeleton />;
+}

--- a/src/app/(dashboard)/records/[id]/loading.tsx
+++ b/src/app/(dashboard)/records/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { DetailPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <DetailPageSkeleton />;
+}

--- a/src/app/(dashboard)/records/loading.tsx
+++ b/src/app/(dashboard)/records/loading.tsx
@@ -1,0 +1,5 @@
+import { ListPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <ListPageSkeleton />;
+}

--- a/src/app/(dashboard)/reports/drafts/[id]/error.tsx
+++ b/src/app/(dashboard)/reports/drafts/[id]/error.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { AlertTriangle, PenLine, RotateCw } from "lucide-react";
+import Link from "next/link";
+
+export default function ReportEditorError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center text-center">
+      <div className="flex h-14 w-14 items-center justify-center rounded-xl border border-border bg-card">
+        <AlertTriangle className="h-7 w-7 text-destructive" />
+      </div>
+      <h2 className="mt-5 text-xl font-[510] tracking-tight text-foreground">
+        报告加载失败
+      </h2>
+      <p className="mt-2 max-w-md text-sm text-muted-foreground">
+        {error.message || "无法加载报告，请稍后重试。"}
+      </p>
+      <div className="mt-6 flex items-center gap-3">
+        <button
+          onClick={reset}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-[510] text-white transition-colors hover:bg-accent"
+        >
+          <RotateCw className="h-4 w-4" />
+          重试
+        </button>
+        <Link
+          href="/reports/drafts"
+          className="inline-flex items-center gap-2 rounded-md border border-border px-4 py-2 text-sm font-[510] text-muted-foreground transition-colors hover:border-border-hover hover:text-foreground"
+        >
+          <PenLine className="h-4 w-4" />
+          返回报告列表
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/reports/drafts/[id]/loading.tsx
+++ b/src/app/(dashboard)/reports/drafts/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { ReportEditorSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <ReportEditorSkeleton />;
+}

--- a/src/app/(dashboard)/reports/drafts/loading.tsx
+++ b/src/app/(dashboard)/reports/drafts/loading.tsx
@@ -1,0 +1,5 @@
+import { ListPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <ListPageSkeleton />;
+}

--- a/src/app/(dashboard)/reports/templates/loading.tsx
+++ b/src/app/(dashboard)/reports/templates/loading.tsx
@@ -1,0 +1,5 @@
+import { ListPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <ListPageSkeleton />;
+}

--- a/src/app/(dashboard)/templates/[id]/batch/loading.tsx
+++ b/src/app/(dashboard)/templates/[id]/batch/loading.tsx
@@ -1,0 +1,5 @@
+import { FormPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <FormPageSkeleton />;
+}

--- a/src/app/(dashboard)/templates/[id]/edit/loading.tsx
+++ b/src/app/(dashboard)/templates/[id]/edit/loading.tsx
@@ -1,0 +1,5 @@
+import { FormPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <FormPageSkeleton />;
+}

--- a/src/app/(dashboard)/templates/[id]/fill/error.tsx
+++ b/src/app/(dashboard)/templates/[id]/fill/error.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { AlertTriangle, FileText, RotateCw } from "lucide-react";
+import Link from "next/link";
+
+export default function FillFormError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center text-center">
+      <div className="flex h-14 w-14 items-center justify-center rounded-xl border border-border bg-card">
+        <AlertTriangle className="h-7 w-7 text-destructive" />
+      </div>
+      <h2 className="mt-5 text-xl font-[510] tracking-tight text-foreground">
+        表单加载失败
+      </h2>
+      <p className="mt-2 max-w-md text-sm text-muted-foreground">
+        {error.message || "无法加载表单，请稍后重试。"}
+      </p>
+      <div className="mt-6 flex items-center gap-3">
+        <button
+          onClick={reset}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-[510] text-white transition-colors hover:bg-accent"
+        >
+          <RotateCw className="h-4 w-4" />
+          重试
+        </button>
+        <Link
+          href="/templates"
+          className="inline-flex items-center gap-2 rounded-md border border-border px-4 py-2 text-sm font-[510] text-muted-foreground transition-colors hover:border-border-hover hover:text-foreground"
+        >
+          <FileText className="h-4 w-4" />
+          返回模板列表
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/templates/[id]/fill/loading.tsx
+++ b/src/app/(dashboard)/templates/[id]/fill/loading.tsx
@@ -1,0 +1,5 @@
+import { FormPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <FormPageSkeleton />;
+}

--- a/src/app/(dashboard)/templates/[id]/loading.tsx
+++ b/src/app/(dashboard)/templates/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { DetailPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <DetailPageSkeleton />;
+}

--- a/src/app/(dashboard)/templates/loading.tsx
+++ b/src/app/(dashboard)/templates/loading.tsx
@@ -1,0 +1,5 @@
+import { ListPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <ListPageSkeleton />;
+}

--- a/src/app/(dashboard)/templates/new/loading.tsx
+++ b/src/app/(dashboard)/templates/new/loading.tsx
@@ -1,0 +1,5 @@
+import { FormPageSkeleton } from "@/components/shared";
+
+export default function Loading() {
+  return <FormPageSkeleton />;
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { AlertTriangle, Home, RotateCw } from "lucide-react";
+import Link from "next/link";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center text-center">
+      <div className="flex h-14 w-14 items-center justify-center rounded-xl border border-border bg-card">
+        <AlertTriangle className="h-7 w-7 text-destructive" />
+      </div>
+      <h2 className="mt-5 text-xl font-[510] tracking-tight text-foreground">
+        页面加载出错
+      </h2>
+      <p className="mt-2 max-w-md text-sm text-muted-foreground">
+        {error.message || "发生了意外错误，请稍后重试。"}
+      </p>
+      <div className="mt-6 flex items-center gap-3">
+        <button
+          onClick={reset}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-[510] text-white transition-colors hover:bg-accent"
+        >
+          <RotateCw className="h-4 w-4" />
+          重试
+        </button>
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 rounded-md border border-border px-4 py-2 text-sm font-[510] text-muted-foreground transition-colors hover:border-border-hover hover:text-foreground"
+        >
+          <Home className="h-4 w-4" />
+          返回首页
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,25 @@
+import { FileQuestion, Home } from "lucide-react";
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center text-center">
+      <div className="flex h-14 w-14 items-center justify-center rounded-xl border border-border bg-card">
+        <FileQuestion className="h-7 w-7 text-muted-foreground" />
+      </div>
+      <h2 className="mt-5 text-xl font-[510] tracking-tight text-foreground">
+        页面未找到
+      </h2>
+      <p className="mt-2 max-w-md text-sm text-muted-foreground">
+        你访问的页面不存在或已被移除。
+      </p>
+      <Link
+        href="/"
+        className="mt-6 inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-[510] text-white transition-colors hover:bg-accent"
+      >
+        <Home className="h-4 w-4" />
+        返回首页
+      </Link>
+    </div>
+  );
+}

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -3,3 +3,4 @@ export { EmptyState } from "./empty-state";
 export { FilterBar } from "./filter-bar";
 export { ContentCard } from "./content-card";
 export { Breadcrumbs } from "./breadcrumbs";
+export { ListPageSkeleton, DetailPageSkeleton, FormPageSkeleton, DataTableSkeleton, ReportEditorSkeleton, AiAgentSkeleton } from "./skeletons";

--- a/src/components/shared/skeletons/detail-page-skeleton.tsx
+++ b/src/components/shared/skeletons/detail-page-skeleton.tsx
@@ -1,0 +1,26 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function DetailPageSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-2">
+        <Skeleton className="h-4 w-16" />
+        <Skeleton className="h-3 w-3" />
+        <Skeleton className="h-4 w-24" />
+      </div>
+      <div className="rounded-lg border border-border/50 p-6 space-y-4">
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-3/4" />
+        <Skeleton className="h-4 w-1/2" />
+      </div>
+      <div className="space-y-3">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-5/6" />
+        <Skeleton className="h-4 w-2/3" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-4/5" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/shared/skeletons/form-page-skeleton.tsx
+++ b/src/components/shared/skeletons/form-page-skeleton.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function FormPageSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Skeleton className="h-7 w-40" />
+        <Skeleton className="h-4 w-64" />
+      </div>
+      <div className="space-y-5">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="space-y-2">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-10 w-full rounded-md" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/shared/skeletons/index.ts
+++ b/src/components/shared/skeletons/index.ts
@@ -1,0 +1,4 @@
+export { ListPageSkeleton } from "./list-page-skeleton";
+export { DetailPageSkeleton } from "./detail-page-skeleton";
+export { FormPageSkeleton } from "./form-page-skeleton";
+export { DataTableSkeleton, ReportEditorSkeleton, AiAgentSkeleton } from "./special-skeleton";

--- a/src/components/shared/skeletons/list-page-skeleton.tsx
+++ b/src/components/shared/skeletons/list-page-skeleton.tsx
@@ -1,0 +1,31 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function ListPageSkeleton() {
+  return (
+    <div className="space-y-6">
+      {/* PageHeader */}
+      <div className="space-y-2">
+        <Skeleton className="h-7 w-40" />
+        <Skeleton className="h-4 w-64" />
+      </div>
+      {/* Filter bar */}
+      <div className="flex gap-2">
+        <Skeleton className="h-8 w-14 rounded-full" />
+        <Skeleton className="h-8 w-14 rounded-full" />
+        <Skeleton className="h-8 w-16 rounded-full" />
+      </div>
+      {/* Table rows */}
+      <div className="space-y-2">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-4 rounded-lg border border-border/50 px-4 py-3">
+            <Skeleton className="h-4 w-4 rounded" />
+            <Skeleton className="h-4 flex-1" />
+            <Skeleton className="h-4 flex-1" />
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-4 w-16" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/shared/skeletons/special-skeleton.tsx
+++ b/src/components/shared/skeletons/special-skeleton.tsx
@@ -1,0 +1,91 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function DataTableSkeleton() {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-8 w-24" />
+          <Skeleton className="h-8 w-20" />
+          <Skeleton className="h-8 w-20" />
+        </div>
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-8 w-32" />
+          <Skeleton className="h-8 w-24" />
+        </div>
+      </div>
+      <div className="flex gap-0 border-b border-border pb-2">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <Skeleton key={i} className="h-4 flex-1 mx-1" />
+        ))}
+      </div>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="flex gap-0 py-2 border-b border-border/30">
+          {Array.from({ length: 8 }).map((_, j) => (
+            <Skeleton key={j} className="h-4 flex-1 mx-1" />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function ReportEditorSkeleton() {
+  return (
+    <div className="flex gap-0 h-[calc(100vh-3.5rem)]">
+      <div className="w-64 border-r border-border/50 p-4 space-y-2">
+        <Skeleton className="h-5 w-20" />
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-8 w-full" />
+        ))}
+        <div className="mt-6 space-y-1">
+          <Skeleton className="h-4 w-24" />
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-8 w-full" />
+          ))}
+        </div>
+      </div>
+      <div className="flex-1 p-6 space-y-4">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-5/6" />
+        <Skeleton className="h-4 w-4/5" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-3/4" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-2/3" />
+      </div>
+    </div>
+  );
+}
+
+export function AiAgentSkeleton() {
+  return (
+    <div className="flex h-[calc(100vh-3.5rem)]">
+      <div className="w-72 border-r border-border/50 p-3 space-y-1">
+        <Skeleton className="h-8 w-full mb-3" />
+        {Array.from({ length: 10 }).map((_, i) => (
+          <Skeleton key={i} className="h-10 w-full rounded-md" />
+        ))}
+      </div>
+      <div className="flex-1 flex flex-col">
+        <div className="flex-1 p-6 space-y-4">
+          <div className="flex gap-3">
+            <Skeleton className="h-8 w-8 rounded-full" />
+            <Skeleton className="h-16 w-3/5 rounded-lg" />
+          </div>
+          <div className="flex gap-3 justify-end">
+            <Skeleton className="h-12 w-2/5 rounded-lg" />
+          </div>
+          <div className="flex gap-3">
+            <Skeleton className="h-8 w-8 rounded-full" />
+            <Skeleton className="h-20 w-3/5 rounded-lg" />
+          </div>
+        </div>
+        <div className="border-t border-border/50 p-4">
+          <Skeleton className="h-20 w-full rounded-lg" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -9,6 +9,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
 
   return (
     <Sonner
+      position="bottom-right"
       theme={resolvedTheme as ToasterProps["theme"]}
       className="toaster group"
       icons={{

--- a/src/lib/toast-helpers.ts
+++ b/src/lib/toast-helpers.ts
@@ -1,0 +1,36 @@
+import { toast } from "sonner";
+
+const SUCCESS_DURATION = 3000;
+const ERROR_DURATION = 5000;
+
+export function toastSuccess(message: string) {
+  toast.success(message, { duration: SUCCESS_DURATION });
+}
+
+export function toastError(message: string) {
+  toast.error(message, { duration: ERROR_DURATION });
+}
+
+export function toastLoading(message: string): string | number {
+  return toast.loading(message, { duration: Infinity });
+}
+
+export function toastDismiss(id: string | number) {
+  toast.dismiss(id);
+}
+
+export function toastPromise<T>(
+  promise: Promise<T>,
+  opts: {
+    loading: string;
+    success: string;
+    error: string;
+  },
+) {
+  toast.promise(promise, {
+    loading: opts.loading,
+    success: opts.success,
+    error: opts.error,
+    duration: SUCCESS_DURATION,
+  });
+}


### PR DESCRIPTION
## Summary
- 添加 4 种可复用骨架屏组件（列表页、详情页、表单页、特殊页面）
- 部署 33 个 `loading.tsx` 覆盖所有 dashboard 路由
- 添加全局错误边界 `error.tsx` 和 404 页面 `not-found.tsx`
- 添加 4 个路由级错误边界（填表、数据表、报告编辑器等关键页面）
- 添加统一 Toast 辅助函数，配置 Sonner 位置为右下角

## Test plan
- [ ] 切换页面时短暂看到骨架屏动画（本地可能太快，可模拟慢网络）
- [ ] 访问不存在的页面显示 404 页面
- [ ] 触发 toast 通知出现在右下角
- [ ] TypeScript 编译无错误

Closes #152

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)