### PR TITLE
[Enhancement] 功能体验打磨：搜索、快捷键、批量操作、导出

### DIFF
--- a/docs/superpowers/plans/2026-05-05-ux-polish.md
+++ b/docs/superpowers/plans/2026-05-05-ux-polish.md
@@ -1,0 +1,1969 @@
+# 功能体验打磨 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 实现命令面板（整合全局搜索）、全局快捷键、列表页批量操作和导出优化。
+
+**Architecture:** 以 cmdk 组件为基础构建命令面板，整合搜索和命令执行；扩展现有 search.service 支持多数据源；抽取通用批量操作组件；扩展 export.service 支持模板/记录导出。
+
+**Tech Stack:** Next.js 16, cmdk, Prisma 7, ExcelJS (xlsx), shadcn/ui v4
+
+---
+
+## Task 1: 扩展搜索服务 — 多数据源搜索后端
+
+**Files:**
+- Modify: `src/lib/services/search.service.ts`
+- Modify: `src/app/api/search/route.ts`
+
+- [ ] **Step 1: 在 search.service.ts 中添加模板搜索函数**
+
+在文件末尾（`globalSearch` 函数后）添加：
+
+```typescript
+export interface TemplateSearchItem {
+  id: string;
+  name: string;
+  description: string | null;
+  status: string;
+  categoryName: string | null;
+}
+
+export async function searchTemplates(
+  query: string,
+  limit: number = 5
+): Promise<ServiceResult<TemplateSearchItem[]>> {
+  try {
+    const templates = await db.template.findMany({
+      where: {
+        OR: [
+          { name: { contains: query, mode: "insensitive" } },
+          { description: { contains: query, mode: "insensitive" } },
+          { tags: { some: { tag: { name: { contains: query, mode: "insensitive" } } } } },
+        ],
+      },
+      take: limit,
+      orderBy: { updatedAt: "desc" },
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        status: true,
+        category: { select: { name: true } },
+      },
+    });
+    return {
+      success: true,
+      data: templates.map((t) => ({
+        id: t.id,
+        name: t.name,
+        description: t.description,
+        status: t.status,
+        categoryName: t.category?.name ?? null,
+      })),
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: { code: "SEARCH_TEMPLATES_ERROR", message: error instanceof Error ? error.message : "搜索模板失败" },
+    };
+  }
+}
+```
+
+- [ ] **Step 2: 添加文档记录搜索函数**
+
+```typescript
+export interface RecordSearchItem {
+  id: string;
+  fileName: string | null;
+  templateName: string;
+  status: string;
+  createdAt: string;
+}
+
+export async function searchRecords(
+  query: string,
+  limit: number = 5
+): Promise<ServiceResult<RecordSearchItem[]>> {
+  try {
+    const records = await db.record.findMany({
+      where: {
+        OR: [
+          { fileName: { contains: query, mode: "insensitive" } },
+          { template: { name: { contains: query, mode: "insensitive" } } },
+        ],
+      },
+      take: limit,
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        fileName: true,
+        status: true,
+        createdAt: true,
+        template: { select: { name: true } },
+      },
+    });
+    return {
+      success: true,
+      data: records.map((r) => ({
+        id: r.id,
+        fileName: r.fileName,
+        templateName: r.template.name,
+        status: r.status,
+        createdAt: r.createdAt.toISOString(),
+      })),
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: { code: "SEARCH_RECORDS_ERROR", message: error instanceof Error ? error.message : "搜索记录失败" },
+    };
+  }
+}
+```
+
+- [ ] **Step 3: 添加文档收集任务搜索函数**
+
+```typescript
+export interface CollectionTaskSearchItem {
+  id: string;
+  title: string;
+  description: string | null;
+  status: string;
+}
+
+export async function searchCollectionTasks(
+  query: string,
+  limit: number = 5
+): Promise<ServiceResult<CollectionTaskSearchItem[]>> {
+  try {
+    const tasks = await db.documentCollectionTask.findMany({
+      where: {
+        OR: [
+          { title: { contains: query, mode: "insensitive" } },
+          { instruction: { contains: query, mode: "insensitive" } },
+        ],
+      },
+      take: limit,
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        title: true,
+        instruction: true,
+        status: true,
+      },
+    });
+    return {
+      success: true,
+      data: tasks.map((t) => ({
+        id: t.id,
+        title: t.title,
+        description: t.instruction,
+        status: t.status,
+      })),
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: { code: "SEARCH_COLLECTIONS_ERROR", message: error instanceof Error ? error.message : "搜索收集任务失败" },
+    };
+  }
+}
+```
+
+- [ ] **Step 4: 添加报告模板搜索函数**
+
+```typescript
+export interface ReportTemplateSearchItem {
+  id: string;
+  name: string;
+  originalFilename: string;
+}
+
+export async function searchReportTemplates(
+  query: string,
+  limit: number = 5
+): Promise<ServiceResult<ReportTemplateSearchItem[]>> {
+  try {
+    const templates = await db.reportTemplate.findMany({
+      where: {
+        OR: [
+          { name: { contains: query, mode: "insensitive" } },
+          { originalFilename: { contains: query, mode: "insensitive" } },
+        ],
+      },
+      take: limit,
+      orderBy: { updatedAt: "desc" },
+      select: {
+        id: true,
+        name: true,
+        originalFilename: true,
+      },
+    });
+    return {
+      success: true,
+      data: templates.map((t) => ({
+        id: t.id,
+        name: t.name,
+        originalFilename: t.originalFilename,
+      })),
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: { code: "SEARCH_REPORTS_ERROR", message: error instanceof Error ? error.message : "搜索报告模板失败" },
+    };
+  }
+}
+```
+
+- [ ] **Step 5: 添加统一搜索聚合函数**
+
+```typescript
+export interface UnifiedSearchResult {
+  templates: TemplateSearchItem[];
+  records: RecordSearchItem[];
+  dataRecords: SearchTableResult[];
+  collectionTasks: CollectionTaskSearchItem[];
+  reportTemplates: ReportTemplateSearchItem[];
+}
+
+export async function unifiedSearch(
+  query: string,
+  limit: number = 5
+): Promise<ServiceResult<UnifiedSearchResult>> {
+  const [templatesRes, recordsRes, dataRecordsRes, collectionsRes, reportsRes] = await Promise.all([
+    searchTemplates(query, limit),
+    searchRecords(query, limit),
+    globalSearch(query, limit),
+    searchCollectionTasks(query, limit),
+    searchReportTemplates(query, limit),
+  ]);
+
+  return {
+    success: true,
+    data: {
+      templates: templatesRes.success ? templatesRes.data : [],
+      records: recordsRes.success ? recordsRes.data : [],
+      dataRecords: dataRecordsRes.success ? dataRecordsRes.data : [],
+      collectionTasks: collectionsRes.success ? collectionsRes.data : [],
+      reportTemplates: reportsRes.success ? reportsRes.data : [],
+    },
+  };
+}
+```
+
+- [ ] **Step 6: 更新搜索 API 路由**
+
+修改 `src/app/api/search/route.ts`，将 `globalSearch` 替换为 `unifiedSearch`：
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { unifiedSearch } from "@/lib/services/search.service";
+
+export async function GET(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "未登录" } },
+      { status: 401 }
+    );
+  }
+
+  const q = request.nextUrl.searchParams.get("q")?.trim();
+  if (!q) {
+    return NextResponse.json({ success: true, data: { templates: [], records: [], dataRecords: [], collectionTasks: [], reportTemplates: [] } });
+  }
+
+  const limit = Math.min(
+    Math.max(parseInt(request.nextUrl.searchParams.get("limit") ?? "5", 10) || 5, 1),
+    20
+  );
+
+  const result = await unifiedSearch(q, limit);
+
+  if (!result.success) {
+    return NextResponse.json(
+      { error: { code: result.error.code, message: result.error.message } },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ success: true, data: result.data });
+}
+```
+
+- [ ] **Step 7: 类型检查**
+
+Run: `npx tsc --noEmit`
+Expected: 无错误
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/services/search.service.ts src/app/api/search/route.ts
+git commit -m "feat(search): expand search to multiple data sources
+
+Add template, record, collection task, and report template search.
+Create unified search API returning results from all sources."
+```
+
+---
+
+## Task 2: 命令面板组件
+
+**Files:**
+- Create: `src/components/layout/command-palette.tsx`
+- Create: `src/hooks/use-command-palette.ts`
+
+- [ ] **Step 1: 创建命令面板 Hook**
+
+创建 `src/hooks/use-command-palette.ts`：
+
+```typescript
+"use client";
+
+import { useRouter, usePathname } from "next/navigation";
+import { useCallback, useMemo } from "react";
+import {
+  LayoutGrid,
+  Database,
+  FileText,
+  Upload,
+  History,
+  FilePenLine,
+  Calculator,
+  Zap,
+  BookOpen,
+  Bot,
+} from "lucide-react";
+
+export interface CommandItem {
+  id: string;
+  label: string;
+  icon?: React.ReactNode;
+  shortcut?: string;
+  onSelect: () => void;
+  group: string;
+  keywords?: string[];
+}
+
+const NAV_COMMANDS = [
+  { id: "nav-templates", label: "模板库", href: "/templates", icon: LayoutGrid, shortcut: "⌘1", keywords: ["moban", "模板"] },
+  { id: "nav-generate", label: "我要填表", href: "/generate", icon: Upload, keywords: ["tianbiao", "填表", "生成"] },
+  { id: "nav-records", label: "生成记录", href: "/records", icon: FileText, shortcut: "⌘3", keywords: ["jilu", "记录"] },
+  { id: "nav-drafts", label: "我的草稿", href: "/drafts", icon: FilePenLine, keywords: ["caogao", "草稿"] },
+  { id: "nav-data", label: "数据表", href: "/data", icon: Database, shortcut: "⌘2", keywords: ["shuju", "数据"] },
+  { id: "nav-reports", label: "撰写报告", href: "/reports/drafts", icon: BookOpen, keywords: ["baogao", "报告"] },
+  { id: "nav-report-templates", label: "报告模板", href: "/reports/templates", icon: LayoutGrid, keywords: ["baogao", "报告", "模板"] },
+  { id: "nav-budget", label: "预算报告", href: "/budget", icon: Calculator, keywords: ["yusuan", "预算"] },
+  { id: "nav-automations", label: "自动化", href: "/automations", icon: Zap, keywords: ["zidonghua", "自动"] },
+  { id: "nav-collections", label: "文档收集", href: "/collections", icon: FileText, shortcut: "⌘4", keywords: ["shouji", "收集"] },
+  { id: "nav-ai", label: "智能助手", href: "/ai-agent2", icon: Bot, keywords: ["zhuneng", "助手", "AI"] },
+];
+
+export function useCommands() {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const commands = useMemo<CommandItem[]>(() => {
+    const navItems: CommandItem[] = NAV_COMMANDS.map((cmd) => ({
+      id: cmd.id,
+      label: cmd.label,
+      icon: <cmd.icon className="h-4 w-4" />,
+      shortcut: cmd.shortcut,
+      keywords: cmd.keywords,
+      group: "导航",
+      onSelect: () => router.push(cmd.href),
+    }));
+
+    return navItems;
+  }, [router]);
+
+  return commands;
+}
+```
+
+- [ ] **Step 2: 创建命令面板组件**
+
+创建 `src/components/layout/command-palette.tsx`：
+
+```typescript
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+} from "@/components/ui/command";
+import {
+  LayoutGrid,
+  FileText,
+  Table2,
+  Inbox,
+  BookOpen,
+  Clock,
+  X,
+} from "lucide-react";
+import { useCommands, type CommandItem } from "@/hooks/use-command-palette";
+import { toast } from "sonner";
+
+const STORAGE_KEY = "recent-searches";
+const MAX_RECENT = 10;
+
+interface TemplateSearchItem {
+  id: string;
+  name: string;
+  description: string | null;
+  status: string;
+  categoryName: string | null;
+}
+
+interface RecordSearchItem {
+  id: string;
+  fileName: string | null;
+  templateName: string;
+  status: string;
+  createdAt: string;
+}
+
+interface DataRecordSearchResult {
+  tableId: string;
+  tableName: string;
+  tableIcon: string | null;
+  records: Array<{ id: string; data: Record<string, unknown>; matchedFields: string[] }>;
+  hasMore: boolean;
+}
+
+interface CollectionTaskSearchItem {
+  id: string;
+  title: string;
+  description: string | null;
+  status: string;
+}
+
+interface ReportTemplateSearchItem {
+  id: string;
+  name: string;
+  originalFilename: string;
+}
+
+function getRecentSearches(): string[] {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]");
+  } catch {
+    return [];
+  }
+}
+
+function addRecentSearch(query: string) {
+  const recent = getRecentSearches().filter((s) => s !== query);
+  recent.unshift(query);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(recent.slice(0, MAX_RECENT)));
+}
+
+function removeRecentSearch(query: string) {
+  const recent = getRecentSearches().filter((s) => s !== query);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(recent));
+}
+
+export function CommandPalette({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const router = useRouter();
+  const commands = useCommands();
+  const [query, setQuery] = useState("");
+  const [isCommandMode, setIsCommandMode] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [templates, setTemplates] = useState<TemplateSearchItem[]>([]);
+  const [records, setRecords] = useState<RecordSearchItem[]>([]);
+  const [dataRecords, setDataRecords] = useState<DataRecordSearchResult[]>([]);
+  const [collectionTasks, setCollectionTasks] = useState<CollectionTaskSearchItem[]>([]);
+  const [reportTemplates, setReportTemplates] = useState<ReportTemplateSearchItem[]>([]);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const recentSearches = useMemo(() => getRecentSearches(), [open]);
+
+  const hasResults = templates.length > 0 || records.length > 0 || dataRecords.length > 0 || collectionTasks.length > 0 || reportTemplates.length > 0;
+
+  // Detect command mode
+  useEffect(() => {
+    setIsCommandMode(query.startsWith(">"));
+  }, [query]);
+
+  // Reset on open/close
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setTemplates([]);
+      setRecords([]);
+      setDataRecords([]);
+      setCollectionTasks([]);
+      setReportTemplates([]);
+    }
+  }, [open]);
+
+  // Debounced search
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    const searchQuery = isCommandMode ? query.slice(1).trim() : query.trim();
+    if (!searchQuery) {
+      setTemplates([]);
+      setRecords([]);
+      setDataRecords([]);
+      setCollectionTasks([]);
+      setReportTemplates([]);
+      return;
+    }
+
+    if (isCommandMode) return; // Don't search in command mode
+
+    debounceRef.current = setTimeout(async () => {
+      setIsLoading(true);
+      try {
+        const res = await fetch(`/api/search?q=${encodeURIComponent(searchQuery)}`);
+        if (res.ok) {
+          const json = await res.json();
+          const data = json.data;
+          setTemplates(data.templates ?? []);
+          setRecords(data.records ?? []);
+          setDataRecords(data.dataRecords ?? []);
+          setCollectionTasks(data.collectionTasks ?? []);
+          setReportTemplates(data.reportTemplates ?? []);
+        }
+      } catch {
+        toast.error("搜索失败");
+      } finally {
+        setIsLoading(false);
+      }
+    }, 300);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query, isCommandMode]);
+
+  const handleSelect = useCallback(
+    (callback: () => void) => {
+      const searchQuery = query.trim();
+      if (searchQuery && !isCommandMode) {
+        addRecentSearch(searchQuery);
+      }
+      onClose();
+      callback();
+    },
+    [query, isCommandMode, onClose]
+  );
+
+  const filteredCommands = useMemo(() => {
+    if (!isCommandMode) return commands;
+    const cmdQuery = query.slice(1).trim().toLowerCase();
+    if (!cmdQuery) return commands;
+    return commands.filter(
+      (cmd) =>
+        cmd.label.toLowerCase().includes(cmdQuery) ||
+        cmd.keywords?.some((k) => k.toLowerCase().includes(cmdQuery))
+    );
+  }, [commands, query, isCommandMode]);
+
+  const placeholder = isCommandMode ? "输入命令..." : "搜索模板、记录、数据表...";
+
+  return (
+    <CommandDialog
+      title="命令面板"
+      description="搜索或执行命令"
+      open={open}
+      onOpenChange={(v) => { if (!v) onClose(); }}
+    >
+      <CommandInput placeholder={placeholder} value={query} onValueChange={setQuery} />
+      <CommandList>
+        <CommandEmpty>{isLoading ? "搜索中..." : isCommandMode ? "无匹配命令" : "未找到匹配结果"}</CommandEmpty>
+
+        {/* Recent searches */}
+        {!query && recentSearches.length > 0 && (
+          <CommandGroup heading="最近搜索">
+            {recentSearches.map((s) => (
+              <CommandItem
+                key={`recent-${s}`}
+                value={`recent-${s}`}
+                onSelect={() => {
+                  setQuery(s);
+                }}
+              >
+                <Clock className="h-4 w-4 text-muted-foreground" />
+                <span className="flex-1">{s}</span>
+                <button
+                  className="text-muted-foreground hover:text-foreground"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    removeRecentSearch(s);
+                    setQuery(""); // trigger re-render
+                  }}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
+        {/* Command mode */}
+        {isCommandMode && filteredCommands.length > 0 && (
+          <CommandGroup heading="命令">
+            {filteredCommands.map((cmd) => (
+              <CommandItem
+                key={cmd.id}
+                value={cmd.id}
+                onSelect={() => handleSelect(cmd.onSelect)}
+              >
+                {cmd.icon}
+                <span>{cmd.label}</span>
+                {cmd.shortcut && <CommandShortcut>{cmd.shortcut}</CommandShortcut>}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
+        {/* Search results - only in search mode */}
+        {!isCommandMode && query && hasResults && (
+          <>
+            {templates.length > 0 && (
+              <CommandGroup heading="模板">
+                {templates.map((t) => (
+                  <CommandItem
+                    key={`tpl-${t.id}`}
+                    value={`tpl-${t.id}`}
+                    onSelect={() => handleSelect(() => router.push(`/templates/${t.id}`))}
+                  >
+                    <LayoutGrid className="h-4 w-4 text-muted-foreground" />
+                    <span className="flex-1">{t.name}</span>
+                    {t.categoryName && (
+                      <span className="text-xs text-muted-foreground">{t.categoryName}</span>
+                    )}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+
+            {records.length > 0 && (
+              <CommandGroup heading="生成记录">
+                {records.map((r) => (
+                  <CommandItem
+                    key={`rec-${r.id}`}
+                    value={`rec-${r.id}`}
+                    onSelect={() => handleSelect(() => router.push(`/records/${r.id}`))}
+                  >
+                    <FileText className="h-4 w-4 text-muted-foreground" />
+                    <span className="flex-1">{r.fileName || r.templateName}</span>
+                    <span className="text-xs text-muted-foreground">{r.templateName}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+
+            {dataRecords.length > 0 && (
+              <CommandGroup heading="数据表">
+                {dataRecords.map((table) =>
+                  table.records.map((record) => (
+                    <CommandItem
+                      key={`data-${table.tableId}-${record.id}`}
+                      value={`data-${table.tableId}-${record.id}`}
+                      onSelect={() =>
+                        handleSelect(() =>
+                          router.push(`/data/${table.tableId}?recordId=${record.id}`)
+                        )
+                      }
+                    >
+                      {table.tableIcon ? (
+                        <span className="text-sm">{table.tableIcon}</span>
+                      ) : (
+                        <Table2 className="h-4 w-4 text-muted-foreground" />
+                      )}
+                      <span className="flex-1">{getRecordLabel(record.data, record.matchedFields)}</span>
+                      <span className="text-xs text-muted-foreground">{table.tableName}</span>
+                    </CommandItem>
+                  ))
+                )}
+              </CommandGroup>
+            )}
+
+            {collectionTasks.length > 0 && (
+              <CommandGroup heading="文档收集">
+                {collectionTasks.map((t) => (
+                  <CommandItem
+                    key={`coll-${t.id}`}
+                    value={`coll-${t.id}`}
+                    onSelect={() => handleSelect(() => router.push(`/collections/${t.id}`))}
+                  >
+                    <Inbox className="h-4 w-4 text-muted-foreground" />
+                    <span className="flex-1">{t.title}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+
+            {reportTemplates.length > 0 && (
+              <CommandGroup heading="报告模板">
+                {reportTemplates.map((t) => (
+                  <CommandItem
+                    key={`rpt-${t.id}`}
+                    value={`rpt-${t.id}`}
+                    onSelect={() => handleSelect(() => router.push(`/reports/templates`))}
+                  >
+                    <BookOpen className="h-4 w-4 text-muted-foreground" />
+                    <span className="flex-1">{t.name}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+          </>
+        )}
+      </CommandList>
+    </CommandDialog>
+  );
+}
+
+function getRecordLabel(
+  data: Record<string, unknown>,
+  matchedFields: string[]
+): string {
+  for (const key of matchedFields) {
+    const val = data[key];
+    if (typeof val === "string" && val.trim()) return val;
+  }
+  for (const val of Object.values(data)) {
+    if (typeof val === "string" && val.trim()) return val;
+  }
+  return "未命名记录";
+}
+```
+
+- [ ] **Step 3: 更新 Header 引用命令面板**
+
+修改 `src/components/layout/header.tsx`，替换 `GlobalSearchDialog` 为 `CommandPalette`：
+
+将导入 `GlobalSearchDialog` 替换为：
+```typescript
+import { CommandPalette } from "@/components/layout/command-palette";
+```
+
+将 `<GlobalSearchDialog open={searchOpen} onClose={() => setSearchOpen(false)} />` 替换为：
+```typescript
+<CommandPalette open={searchOpen} onClose={() => setSearchOpen(false)} />
+```
+
+- [ ] **Step 4: 类型检查**
+
+Run: `npx tsc --noEmit`
+Expected: 无错误
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/layout/command-palette.tsx src/hooks/use-command-palette.ts src/components/layout/header.tsx
+git commit -m "feat(command-palette): replace global search with command palette
+
+Unified search + command mode using cmdk component.
+Supports multiple data sources, recent searches, and command execution."
+```
+
+---
+
+## Task 3: 全局快捷键
+
+**Files:**
+- Modify: `src/components/layout/header.tsx`
+
+- [ ] **Step 1: 添加全局导航快捷键**
+
+在 `header.tsx` 的 `handleKeyDown` 函数中，在现有 `⌘K` 处理之后添加：
+
+```typescript
+const handleKeyDown = useCallback((e: KeyboardEvent) => {
+  if (isTypingElement(e.target)) return;
+
+  const mod = e.metaKey || e.ctrlKey;
+  if (!mod) return;
+
+  const key = e.key;
+
+  if (key.toLowerCase() === "k") {
+    e.preventDefault();
+    setSearchOpen((v) => !v);
+    return;
+  }
+
+  // Navigation shortcuts
+  const navMap: Record<string, string> = {
+    "1": "/templates",
+    "2": "/data",
+    "3": "/records",
+    "4": "/collections",
+    "5": "/reports/drafts",
+  };
+
+  if (navMap[key]) {
+    e.preventDefault();
+    router.push(navMap[key]);
+    return;
+  }
+
+  // Help shortcut
+  if (key === "/") {
+    e.preventDefault();
+    setSearchOpen(true);
+  }
+}, [router]);
+```
+
+注意：需要在 Header 组件中添加 `useRouter` 导入和使用：
+
+```typescript
+import { usePathname, useRouter } from "next/navigation";
+// ...
+const router = useRouter();
+```
+
+- [ ] **Step 2: 类型检查**
+
+Run: `npx tsc --noEmit`
+Expected: 无错误
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/layout/header.tsx
+git commit -m "feat(keyboard): add global navigation shortcuts
+
+⌘1-5 for quick navigation, ⌘/ for command palette help."
+```
+
+---
+
+## Task 4: 通用批量操作组件
+
+**Files:**
+- Create: `src/components/shared/batch-action-bar.tsx`
+
+- [ ] **Step 1: 创建通用批量操作栏**
+
+创建 `src/components/shared/batch-action-bar.tsx`：
+
+```typescript
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { X } from "lucide-react";
+
+export interface BatchAction {
+  label: string;
+  icon?: React.ReactNode;
+  onClick: () => void;
+  variant?: "default" | "destructive";
+}
+
+interface SharedBatchActionBarProps {
+  selectedCount: number;
+  actions: BatchAction[];
+  onClearSelection: () => void;
+}
+
+export function SharedBatchActionBar({
+  selectedCount,
+  actions,
+  onClearSelection,
+}: SharedBatchActionBarProps) {
+  return (
+    <div className="flex items-center gap-2 px-3 py-1.5 bg-primary/10 border rounded-md text-sm">
+      <span className="font-medium">已选择 {selectedCount} 条</span>
+      <div className="h-4 w-px bg-border" />
+      {actions.map((action) => (
+        <Button
+          key={action.label}
+          variant="ghost"
+          size="sm"
+          className={`h-7 text-xs gap-1 ${action.variant === "destructive" ? "text-destructive hover:text-destructive" : ""}`}
+          onClick={action.onClick}
+        >
+          {action.icon}
+          {action.label}
+        </Button>
+      ))}
+      <div className="h-4 w-px bg-border" />
+      <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={onClearSelection}>
+        <X className="h-3 w-3" />
+      </Button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/shared/batch-action-bar.tsx
+git commit -m "feat: add shared batch action bar component
+
+Reusable batch operation bar with configurable actions."
+```
+
+---
+
+## Task 5: 模板批量操作后端 API
+
+**Files:**
+- Create: `src/app/api/templates/batch/route.ts`
+
+- [ ] **Step 1: 创建模板批量操作 API**
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import type { Role } from "@/generated/prisma/enums";
+import { TemplateStatus } from "@/generated/prisma/enums";
+
+export async function POST(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: { code: "UNAUTHORIZED", message: "未登录" } }, { status: 401 });
+  }
+
+  const isAdmin = (session.user.role as Role) === "ADMIN";
+  if (!isAdmin) {
+    return NextResponse.json({ error: { code: "FORBIDDEN", message: "仅管理员可执行批量操作" } }, { status: 403 });
+  }
+
+  const body = await request.json();
+  const { action, ids, payload } = body as {
+    action: "delete" | "updateStatus" | "updateCategory";
+    ids: string[];
+    payload?: { status?: string; categoryId?: string | null };
+  };
+
+  if (!ids || !Array.isArray(ids) || ids.length === 0) {
+    return NextResponse.json({ error: { code: "INVALID_INPUT", message: "请选择至少一条记录" } }, { status: 400 });
+  }
+
+  try {
+    switch (action) {
+      case "delete": {
+        await db.template.deleteMany({ where: { id: { in: ids } } });
+        return NextResponse.json({ success: true, data: { deleted: ids.length } });
+      }
+      case "updateStatus": {
+        if (!payload?.status || !Object.values(TemplateStatus).includes(payload.status as TemplateStatus)) {
+          return NextResponse.json({ error: { code: "INVALID_INPUT", message: "无效的状态值" } }, { status: 400 });
+        }
+        await db.template.updateMany({
+          where: { id: { in: ids } },
+          data: { status: payload.status as TemplateStatus },
+        });
+        return NextResponse.json({ success: true, data: { updated: ids.length } });
+      }
+      case "updateCategory": {
+        await db.template.updateMany({
+          where: { id: { in: ids } },
+          data: { categoryId: payload?.categoryId ?? null },
+        });
+        return NextResponse.json({ success: true, data: { updated: ids.length } });
+      }
+      default:
+        return NextResponse.json({ error: { code: "INVALID_ACTION", message: "不支持的操作" } }, { status: 400 });
+    }
+  } catch (error) {
+    return NextResponse.json(
+      { error: { code: "BATCH_ERROR", message: error instanceof Error ? error.message : "批量操作失败" } },
+      { status: 500 }
+    );
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/api/templates/batch/route.ts
+git commit -m "feat(templates): add batch operations API
+
+Support batch delete, update status, and update category."
+```
+
+---
+
+## Task 6: 记录批量操作后端 API
+
+**Files:**
+- Create: `src/app/api/records/batch/route.ts`
+
+- [ ] **Step 1: 创建记录批量操作 API**
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import type { Role } from "@/generated/prisma/enums";
+
+export async function POST(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: { code: "UNAUTHORIZED", message: "未登录" } }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { action, ids } = body as {
+    action: "delete" | "export";
+    ids: string[];
+  };
+
+  if (!ids || !Array.isArray(ids) || ids.length === 0) {
+    return NextResponse.json({ error: { code: "INVALID_INPUT", message: "请选择至少一条记录" } }, { status: 400 });
+  }
+
+  const isAdmin = (session.user.role as Role) === "ADMIN";
+
+  try {
+    switch (action) {
+      case "delete": {
+        const where = isAdmin ? { id: { in: ids } } : { id: { in: ids }, userId: session.user.id };
+        const result = await db.record.deleteMany({ where });
+        return NextResponse.json({ success: true, data: { deleted: result.count } });
+      }
+      case "export": {
+        const where = isAdmin ? { id: { in: ids } } : { id: { in: ids }, userId: session.user.id };
+        const records = await db.record.findMany({
+          where,
+          include: { template: { select: { name: true } }, user: { select: { name: true } } },
+          orderBy: { createdAt: "desc" },
+        });
+        return NextResponse.json({ success: true, data: records });
+      }
+      default:
+        return NextResponse.json({ error: { code: "INVALID_ACTION", message: "不支持的操作" } }, { status: 400 });
+    }
+  } catch (error) {
+    return NextResponse.json(
+      { error: { code: "BATCH_ERROR", message: error instanceof Error ? error.message : "批量操作失败" } },
+      { status: 500 }
+    );
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/api/records/batch/route.ts
+git commit -m "feat(records): add batch operations API
+
+Support batch delete and export for records."
+```
+
+---
+
+## Task 7: 模板列表页批量操作前端
+
+**Files:**
+- Create: `src/components/templates/template-list-client.tsx`
+- Modify: `src/app/(dashboard)/templates/page.tsx`
+
+- [ ] **Step 1: 创建模板列表客户端组件**
+
+创建 `src/components/templates/template-list-client.tsx`：
+
+```typescript
+"use client";
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { Trash2, Pencil, ArrowRight } from "lucide-react";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import { SharedBatchActionBar } from "@/components/shared/batch-action-bar";
+import { toast } from "sonner";
+import type { TemplateStatus } from "@/generated/prisma/enums";
+
+interface TemplateItem {
+  id: string;
+  name: string;
+  status: string;
+  categoryName: string | null;
+}
+
+interface Category {
+  id: string;
+  name: string;
+}
+
+interface TemplateListClientProps {
+  templates: TemplateItem[];
+  categories: Category[];
+  isAdmin: boolean;
+}
+
+export function TemplateListClient({
+  templates,
+  categories,
+  isAdmin,
+}: TemplateListClientProps) {
+  const router = useRouter();
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [statusDialogOpen, setStatusDialogOpen] = useState(false);
+  const [categoryDialogOpen, setCategoryDialogOpen] = useState(false);
+  const [targetStatus, setTargetStatus] = useState<string>("");
+  const [targetCategoryId, setTargetCategoryId] = useState<string>("");
+
+  const allSelected = templates.length > 0 && selectedIds.size === templates.length;
+  const someSelected = selectedIds.size > 0;
+
+  const toggleAll = useCallback(() => {
+    if (allSelected) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(templates.map((t) => t.id)));
+    }
+  }, [allSelected, templates]);
+
+  const toggleOne = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const handleBatchDelete = useCallback(async () => {
+    try {
+      const res = await fetch("/api/templates/batch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "delete", ids: [...selectedIds] }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        toast.success(`已删除 ${data.data.deleted} 个模板`);
+        setSelectedIds(new Set());
+        router.refresh();
+      } else {
+        toast.error(data.error?.message ?? "删除失败");
+      }
+    } catch {
+      toast.error("删除失败");
+    }
+    setDeleteDialogOpen(false);
+  }, [selectedIds, router]);
+
+  const handleBatchStatus = useCallback(async () => {
+    try {
+      const res = await fetch("/api/templates/batch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "updateStatus", ids: [...selectedIds], payload: { status: targetStatus } }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        toast.success(`已更新 ${data.data.updated} 个模板状态`);
+        setSelectedIds(new Set());
+        router.refresh();
+      } else {
+        toast.error(data.error?.message ?? "更新失败");
+      }
+    } catch {
+      toast.error("更新失败");
+    }
+    setStatusDialogOpen(false);
+  }, [selectedIds, targetStatus, router]);
+
+  const handleBatchCategory = useCallback(async () => {
+    try {
+      const res = await fetch("/api/templates/batch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "updateCategory",
+          ids: [...selectedIds],
+          payload: { categoryId: targetCategoryId || null },
+        }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        toast.success(`已更新 ${data.data.updated} 个模板分类`);
+        setSelectedIds(new Set());
+        router.refresh();
+      } else {
+        toast.error(data.error?.message ?? "更新失败");
+      }
+    } catch {
+      toast.error("更新失败");
+    }
+    setCategoryDialogOpen(false);
+  }, [selectedIds, targetCategoryId, router]);
+
+  return (
+    <>
+      {/* Select all checkbox */}
+      <div className="flex items-center gap-2 px-2">
+        <Checkbox
+          checked={allSelected}
+          onCheckedChange={toggleAll}
+          aria-label="全选"
+        />
+        {someSelected && (
+          <SharedBatchActionBar
+            selectedCount={selectedIds.size}
+            onClearSelection={() => setSelectedIds(new Set())}
+            actions={
+              isAdmin
+                ? [
+                    {
+                      label: "删除",
+                      icon: <Trash2 className="h-3 w-3" />,
+                      onClick: () => setDeleteDialogOpen(true),
+                      variant: "destructive" as const,
+                    },
+                    {
+                      label: "更改状态",
+                      icon: <ArrowRight className="h-3 w-3" />,
+                      onClick: () => setStatusDialogOpen(true),
+                    },
+                    {
+                      label: "更改分类",
+                      icon: <Pencil className="h-3 w-3" />,
+                      onClick: () => setCategoryDialogOpen(true),
+                    },
+                  ]
+                : []
+            }
+          />
+        )}
+      </div>
+
+      {/* Per-row checkboxes - rendered as a separate overlay */}
+      {templates.map((template) => (
+        <div key={template.id} className="contents" data-template-checkbox={template.id}>
+          <Checkbox
+            checked={selectedIds.has(template.id)}
+            onCheckedChange={() => toggleOne(template.id)}
+            aria-label={`选择 ${template.name}`}
+            className="hidden"
+          />
+        </div>
+      ))}
+
+      {/* Delete confirmation */}
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>确认删除</AlertDialogTitle>
+            <AlertDialogDescription>
+              确定要删除选中的 {selectedIds.size} 个模板吗？此操作不可撤销。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>取消</AlertDialogCancel>
+            <AlertDialogAction onClick={handleBatchDelete}>确认删除</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Status change dialog */}
+      <AlertDialog open={statusDialogOpen} onOpenChange={setStatusDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>更改状态</AlertDialogTitle>
+            <AlertDialogDescription>
+              将选中的 {selectedIds.size} 个模板的状态更改为：
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <Select value={targetStatus} onValueChange={setTargetStatus}>
+            <SelectTrigger>
+              <SelectValue placeholder="选择状态" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="DRAFT">草稿</SelectItem>
+              <SelectItem value="PUBLISHED">已发布</SelectItem>
+              <SelectItem value="ARCHIVED">已归档</SelectItem>
+            </SelectContent>
+          </Select>
+          <AlertDialogFooter>
+            <AlertDialogCancel>取消</AlertDialogCancel>
+            <AlertDialogAction onClick={handleBatchStatus}>确认更改</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Category change dialog */}
+      <AlertDialog open={categoryDialogOpen} onOpenChange={setCategoryDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>更改分类</AlertDialogTitle>
+            <AlertDialogDescription>
+              将选中的 {selectedIds.size} 个模板的分类更改为：
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <Select value={targetCategoryId} onValueChange={setTargetCategoryId}>
+            <SelectTrigger>
+              <SelectValue placeholder="选择分类" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__none__">无分类</SelectItem>
+              {categories.map((cat) => (
+                <SelectItem key={cat.id} value={cat.id}>
+                  {cat.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <AlertDialogFooter>
+            <AlertDialogCancel>取消</AlertDialogCancel>
+            <AlertDialogAction onClick={handleBatchCategory}>确认更改</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: 修改模板列表页集成批量操作**
+
+在 `src/app/(dashboard)/templates/page.tsx` 中：
+
+添加导入：
+```typescript
+import { Checkbox } from "@/components/ui/checkbox";
+import { TemplateListClient } from "@/components/templates/template-list-client";
+```
+
+在 `TableHeader` 的 `TableRow` 中最前面添加一个空的 `TableHead`：
+```tsx
+<TableHead className="w-[40px]">{/* checkbox column */}</TableHead>
+```
+
+在每个数据行的 `TableRow` 内最前面添加：
+```tsx
+<TableCell>
+  <Checkbox
+    // controlled by TemplateListClient via context
+    aria-label={`选择 ${template.name}`}
+  />
+</TableCell>
+```
+
+**注意**：由于模板页是 Server Component，需要一种方式将 Checkbox 与客户端状态关联。更简洁的方案是将整个表格区域抽成客户端组件。具体做法是：
+
+在模板页中，将 `<ContentCard>` 内的 `<Table>` 部分替换为引用一个客户端组件，传入 templates 数据：
+
+```tsx
+<ContentCard className="!p-0">
+  <TemplateTableWithBatch
+    templates={templates}
+    categories={categories}
+    isAdmin={isAdmin}
+    buildUrl={buildUrl}
+    status={status}
+    categoryId={categoryId}
+  />
+</ContentCard>
+```
+
+创建 `TemplateTableWithBatch` 组件将原有的 Table JSX 和批量选择逻辑合并到一个客户端组件中。这比上面分散的方式更干净。
+
+**实际实现建议**：将 `TemplateListClient` 重新设计为包含完整表格的客户端组件，接收 templates 数据和 admin 标志，自行管理 Checkbox 状态。原有 Server Component 只负责数据获取和传递。
+
+- [ ] **Step 3: 类型检查**
+
+Run: `npx tsc --noEmit`
+Expected: 无错误
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/templates/template-list-client.tsx src/app/\(dashboard\)/templates/page.tsx
+git commit -m "feat(templates): add batch selection and operations
+
+Template list supports multi-select, batch delete, status change, and category change."
+```
+
+---
+
+## Task 8: 记录列表页批量操作前端
+
+**Files:**
+- Create: `src/components/records/record-list-client.tsx`
+- Modify: `src/app/(dashboard)/records/page.tsx`
+
+- [ ] **Step 1: 创建记录列表客户端组件**
+
+创建 `src/components/records/record-list-client.tsx`：
+
+```typescript
+"use client";
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { Trash2, Download } from "lucide-react";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { SharedBatchActionBar } from "@/components/shared/batch-action-bar";
+import { toast } from "sonner";
+import * as XLSX from "xlsx";
+
+interface RecordItem {
+  id: string;
+  templateName: string;
+  fileName: string | null;
+  status: string;
+  createdAt: string;
+}
+
+interface RecordListClientProps {
+  records: RecordItem[];
+  isAdmin: boolean;
+}
+
+export function RecordListClient({ records, isAdmin }: RecordListClientProps) {
+  const router = useRouter();
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+
+  const allSelected = records.length > 0 && selectedIds.size === records.length;
+  const someSelected = selectedIds.size > 0;
+
+  const toggleAll = useCallback(() => {
+    if (allSelected) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(records.map((r) => r.id)));
+    }
+  }, [allSelected, records]);
+
+  const toggleOne = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const handleBatchDelete = useCallback(async () => {
+    try {
+      const res = await fetch("/api/records/batch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "delete", ids: [...selectedIds] }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        toast.success(`已删除 ${data.data.deleted} 条记录`);
+        setSelectedIds(new Set());
+        router.refresh();
+      } else {
+        toast.error(data.error?.message ?? "删除失败");
+      }
+    } catch {
+      toast.error("删除失败");
+    }
+    setDeleteDialogOpen(false);
+  }, [selectedIds, router]);
+
+  const handleBatchExport = useCallback(async () => {
+    try {
+      const res = await fetch("/api/records/batch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "export", ids: [...selectedIds] }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        const records = data.data;
+        const headers = ["模板名称", "文件名", "状态", "生成时间"];
+        const rows = records.map((r: RecordItem) => [
+          r.templateName,
+          r.fileName ?? "",
+          r.status,
+          new Date(r.createdAt).toLocaleDateString("zh-CN"),
+        ]);
+        const ws = XLSX.utils.aoa_to_sheet([headers, ...rows]);
+        const wb = XLSX.utils.book_new();
+        XLSX.utils.book_append_sheet(wb, ws, "生成记录");
+        XLSX.writeFile(wb, `生成记录_${selectedIds.size}条.xlsx`);
+        toast.success(`已导出 ${selectedIds.size} 条记录`);
+      } else {
+        toast.error(data.error?.message ?? "导出失败");
+      }
+    } catch {
+      toast.error("导出失败");
+    }
+  }, [selectedIds]);
+
+  return (
+    <>
+      {someSelected && (
+        <div className="px-2">
+          <SharedBatchActionBar
+            selectedCount={selectedIds.size}
+            onClearSelection={() => setSelectedIds(new Set())}
+            actions={[
+              {
+                label: "导出",
+                icon: <Download className="h-3 w-3" />,
+                onClick: handleBatchExport,
+              },
+              {
+                label: "删除",
+                icon: <Trash2 className="h-3 w-3" />,
+                onClick: () => setDeleteDialogOpen(true),
+                variant: "destructive" as const,
+              },
+            ]}
+          />
+        </div>
+      )}
+
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>确认删除</AlertDialogTitle>
+            <AlertDialogDescription>
+              确定要删除选中的 {selectedIds.size} 条记录吗？此操作不可撤销。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>取消</AlertDialogCancel>
+            <AlertDialogAction onClick={handleBatchDelete}>确认删除</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: 修改记录页集成**
+
+与模板页类似的策略：将表格部分抽为客户端组件，或以最小改动添加 Checkbox 列。
+
+**最小改动方案**：在记录页 Server Component 中传递数据给一个客户端 wrapper，wrapper 负责在现有表格结构中添加 Checkbox 列和批量操作栏。
+
+具体做法参考 Task 7 的说明，将表格区域替换为客户端组件渲染。
+
+- [ ] **Step 3: 类型检查**
+
+Run: `npx tsc --noEmit`
+Expected: 无错误
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/records/record-list-client.tsx src/app/\(dashboard\)/records/page.tsx
+git commit -m "feat(records): add batch selection, delete and export
+
+Record list supports multi-select, batch delete, and Excel export."
+```
+
+---
+
+## Task 9: 模板导出 API
+
+**Files:**
+- Create: `src/app/api/templates/export/route.ts`
+
+- [ ] **Step 1: 创建模板导出 API**
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import type { Role } from "@/generated/prisma/enums";
+import * as XLSX from "xlsx";
+
+export async function GET(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: { code: "UNAUTHORIZED", message: "未登录" } }, { status: 401 });
+  }
+
+  const isAdmin = (session.user.role as Role) === "ADMIN";
+
+  try {
+    const where = isAdmin
+      ? {}
+      : { status: "PUBLISHED" as const };
+
+    const templates = await db.template.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      select: {
+        name: true,
+        status: true,
+        createdAt: true,
+        createdBy: { select: { name: true } },
+        category: { select: { name: true } },
+        tags: { select: { tag: { select: { name: true } } } },
+      },
+    });
+
+    const statusLabels: Record<string, string> = { DRAFT: "草稿", PUBLISHED: "已发布", ARCHIVED: "已归档" };
+
+    const headers = ["模板名称", "状态", "分类", "标签", "创建者", "创建时间"];
+    const rows = templates.map((t) => [
+      t.name,
+      statusLabels[t.status] ?? t.status,
+      t.category?.name ?? "",
+      t.tags.map((tg) => tg.tag.name).join(", "),
+      t.createdBy.name,
+      t.createdAt.toLocaleDateString("zh-CN"),
+    ]);
+
+    const ws = XLSX.utils.aoa_to_sheet([headers, ...rows]);
+    ws["!cols"] = headers.map((h) => ({ wch: Math.max(h.length * 2, 12) }));
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, "模板列表");
+
+    const buffer = XLSX.write(wb, { type: "buffer", bookType: "xlsx" });
+
+    return new Response(buffer, {
+      headers: {
+        "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "Content-Disposition": `attachment; filename*=UTF-8''${encodeURIComponent("模板列表.xlsx")}`,
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: { code: "EXPORT_ERROR", message: error instanceof Error ? error.message : "导出失败" } },
+      { status: 500 }
+    );
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/api/templates/export/route.ts
+git commit -m "feat(templates): add Excel export API for template list"
+```
+
+---
+
+## Task 10: 记录导出 API
+
+**Files:**
+- Create: `src/app/api/records/export/route.ts`
+
+- [ ] **Step 1: 创建记录导出 API**
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import type { Role } from "@/generated/prisma/enums";
+import * as XLSX from "xlsx";
+
+export async function GET(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: { code: "UNAUTHORIZED", message: "未登录" } }, { status: 401 });
+  }
+
+  const isAdmin = (session.user.role as Role) === "ADMIN";
+  const statusParam = request.nextUrl.searchParams.get("status");
+
+  try {
+    const where: Record<string, unknown> = {};
+    if (!isAdmin && session.user.id) {
+      where.userId = session.user.id;
+    }
+    if (statusParam && ["PENDING", "COMPLETED", "FAILED"].includes(statusParam)) {
+      where.status = statusParam;
+    }
+
+    const records = await db.record.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      include: {
+        template: { select: { name: true } },
+        user: { select: { name: true } },
+      },
+    });
+
+    const statusLabels: Record<string, string> = { PENDING: "待生成", COMPLETED: "已完成", FAILED: "失败" };
+
+    const headers = ["模板名称", "文件名", "状态", "生成者", "生成时间"];
+    const rows = records.map((r) => [
+      r.template.name,
+      r.fileName ?? "",
+      statusLabels[r.status] ?? r.status,
+      r.user.name,
+      r.createdAt.toLocaleDateString("zh-CN"),
+    ]);
+
+    const ws = XLSX.utils.aoa_to_sheet([headers, ...rows]);
+    ws["!cols"] = headers.map((h) => ({ wch: Math.max(h.length * 2, 12) }));
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, "生成记录");
+
+    const buffer = XLSX.write(wb, { type: "buffer", bookType: "xlsx" });
+
+    return new Response(buffer, {
+      headers: {
+        "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "Content-Disposition": `attachment; filename*=UTF-8''${encodeURIComponent("生成记录.xlsx")}`,
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: { code: "EXPORT_ERROR", message: error instanceof Error ? error.message : "导出失败" } },
+      { status: 500 }
+    );
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/api/records/export/route.ts
+git commit -m "feat(records): add Excel export API for record list"
+```
+
+---
+
+## Task 11: 列表页导出按钮前端
+
+**Files:**
+- Modify: `src/app/(dashboard)/templates/page.tsx`
+- Modify: `src/app/(dashboard)/records/page.tsx`
+
+- [ ] **Step 1: 在模板页 PageHeader 添加导出按钮**
+
+在模板页 `PageHeader` 的 actions 区域添加导出按钮（仅管理员可见）：
+
+```tsx
+import { Download } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+```
+
+在 `actions` 中，与上传按钮并列添加：
+```tsx
+<DropdownMenu>
+  <DropdownMenuTrigger asChild>
+    <Button variant="outline" size="sm">
+      <Download className="h-4 w-4" />
+      导出
+    </Button>
+  </DropdownMenuTrigger>
+  <DropdownMenuContent>
+    <DropdownMenuItem onClick={() => { window.location.href = "/api/templates/export"; }}>
+      导出为 Excel
+    </DropdownMenuItem>
+  </DropdownMenuContent>
+</DropdownMenu>
+```
+
+由于 Server Component 不能用 onClick，需要创建一个小的客户端组件 `ExportButton`：
+
+```typescript
+"use client";
+
+export function ExportButton({ url, label }: { url: string; label: string }) {
+  return (
+    <button
+      className="relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground"
+      onClick={() => { window.location.href = url; }}
+    >
+      {label}
+    </button>
+  );
+}
+```
+
+或者更简单地，直接使用 `<a href="/api/templates/export">` 链接，因为 GET 请求不需要 JS。
+
+- [ ] **Step 2: 在记录页添加类似导出按钮**
+
+同上，在记录页的 PageHeader actions 中添加导出按钮。
+
+- [ ] **Step 3: 类型检查**
+
+Run: `npx tsc --noEmit`
+Expected: 无错误
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/\(dashboard\)/templates/page.tsx src/app/\(dashboard\)/records/page.tsx
+git commit -m "feat: add export buttons to template and record list pages"
+```
+
+---
+
+## Task 12: 数据表选中记录导出
+
+**Files:**
+- Modify: `src/lib/services/export.service.ts`
+- Modify: `src/components/data/views/grid-view.tsx` (批量操作栏添加导出按钮)
+
+- [ ] **Step 1: 在 export.service.ts 添加 selectedIds 支持**
+
+修改 `getTableExportData` 函数，添加可选的 `selectedIds` 参数：
+
+```typescript
+export async function getTableExportData(
+  tableId: string,
+  selectedIds?: string[]
+): Promise<ServiceResult<TableExportData>> {
+  const tableResult = await getTable(tableId);
+  if (!tableResult.success) {
+    return { success: false, error: tableResult.error };
+  }
+
+  const table = tableResult.data;
+
+  const records = await db.dataRecord.findMany({
+    where: {
+      tableId,
+      ...(selectedIds ? { id: { in: selectedIds } } : {}),
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+  // ... rest unchanged
+}
+```
+
+修改 `exportToExcel` 和 `exportToJSON` 传递 `selectedIds`：
+
+```typescript
+export async function exportToExcel(
+  tableId: string,
+  options?: ExcelExportOptions,
+  selectedIds?: string[]
+): Promise<ServiceResult<Buffer>> {
+  try {
+    const dataResult = await getTableExportData(tableId, selectedIds);
+    // ... rest unchanged
+  }
+}
+```
+
+- [ ] **Step 2: 在 grid-view 批量操作栏添加"导出选中"**
+
+在 `grid-view.tsx` 的批量操作区域，添加导出按钮。在现有的 `BatchActionBar` 旁边增加一个"导出选中"按钮，点击后调用现有的导出 API 并传入 selectedIds。
+
+- [ ] **Step 3: 类型检查**
+
+Run: `npx tsc --noEmit`
+Expected: 无错误
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/services/export.service.ts src/components/data/views/grid-view.tsx
+git commit -m "feat(data-table): add export selected records support
+
+Export service now accepts optional selectedIds for filtered export."
+```
+
+---
+
+## Task 13: 集成测试与最终验证
+
+- [ ] **Step 1: 启动开发服务器**
+
+Run: `npm run dev`
+
+- [ ] **Step 2: 验证命令面板**
+
+- 按 `Ctrl/Cmd + K` 打开命令面板
+- 输入模板名搜索，验证多数据源结果
+- 输入 `>` 进入命令模式，验证导航命令
+- 无输入时检查最近搜索历史
+- 关闭后重新打开，验证搜索历史持久化
+
+- [ ] **Step 3: 验证全局快捷键**
+
+- `Ctrl/Cmd + 1` 跳转模板库
+- `Ctrl/Cmd + 2` 跳转数据表
+- `Ctrl/Cmd + 3` 跳转生成记录
+- `Ctrl/Cmd + 4` 跳转文档收集
+- `Ctrl/Cmd + 5` 跳转报告
+
+- [ ] **Step 4: 验证批量操作**
+
+- 模板页：多选 → 批量删除/更改状态/更改分类
+- 记录页：多选 → 批量删除/导出
+- 数据表：已有批量操作 + 新增导出选中
+
+- [ ] **Step 5: 验证导出**
+
+- 模板页导出 Excel
+- 记录页导出 Excel
+- 数据表选中记录导出
+
+- [ ] **Step 6: 运行类型检查**
+
+Run: `npx tsc --noEmit`
+Expected: 无错误
+
+- [ ] **Step 7: 运行 lint**
+
+Run: `npm run lint`
+Expected: 无错误
+
+- [ ] **Step 8: Final commit**
+
+```bash
+git add -A
+git commit -m "feat: complete UX polish - command palette, shortcuts, batch ops, export
+
+Issue #154"
+```

--- a/docs/superpowers/specs/2026-05-05-ux-polish-design.md
+++ b/docs/superpowers/specs/2026-05-05-ux-polish-design.md
@@ -1,0 +1,203 @@
+# Issue 154: 功能体验打磨 — 搜索、快捷键、批量操作、导出
+
+## 概述
+
+完善系统功能细节，提升日常操作效率。包含四个子功能：命令面板（整合全局搜索）、快捷键体系、批量操作、导出优化。
+
+## Part 1: 命令面板 + 全局搜索增强
+
+### 1.1 命令面板（Command Palette）
+
+**入口**: `Ctrl/Cmd + K`（保持不变）
+
+**三种模式**:
+
+1. **搜索模式**（默认）— 输入关键词
+   - 数据源：数据表记录、模板、文档记录、文档收集任务、报告模板
+   - 每个数据源独立分组显示，每组最多 5 条结果
+   - 点击结果跳转对应详情页
+
+2. **命令模式** — 输入 `>` 前缀
+   - 全局导航命令：`> 模板管理`、`> 数据表`、`> 文档记录`、`> 文档收集`、`> 报告`、`> 设置`
+   - 页面级命令：根据当前页面上下文显示（`> 新建模板`、`> 导出 Excel`、`> 导入数据` 等）
+   - 每个命令右侧显示关联快捷键（如有）
+
+3. **最近搜索** — 无输入时显示
+   - 最近 10 条搜索词，存储在 localStorage
+   - 可逐条删除或清除全部
+
+### 1.2 技术实现
+
+**前端**:
+- 使用 cmdk（已有 `src/components/ui/command.tsx`）重构 `src/components/data/global-search-dialog.tsx`
+- 新文件：`src/components/layout/command-palette.tsx`
+- 命令注册机制：`src/hooks/use-commands.ts`（自定义 Hook，收集当前页面可用命令）
+
+**后端搜索 API**:
+- 扩展 `GET /api/search?q=xxx` 为多数据源搜索
+- 扩展 `src/lib/services/search.service.ts` 新增搜索函数：
+  - `searchTemplates(query)` — 搜模板名称/描述/标签
+  - `searchRecords(query)` — 搜文档记录（文件名/模板名）
+  - `searchCollectionTasks(query)` — 搜文档收集任务（标题/描述）
+  - `searchReportTemplates(query)` — 搜报告模板（名称/描述）
+- 保留现有 `globalSearch()` 搜数据表记录
+- 统一返回格式：`{ templates: [], records: [], dataRecords: [], collectionTasks: [], reportTemplates: [] }`
+
+**搜索结果类型**:
+```typescript
+interface UnifiedSearchResult {
+  templates: TemplateSearchItem[];
+  records: RecordSearchItem[];
+  dataRecords: SearchTableResult[];      // 现有
+  collectionTasks: CollectionTaskSearchItem[];
+  reportTemplates: ReportTemplateSearchItem[];
+}
+
+interface TemplateSearchItem {
+  id: string;
+  name: string;
+  description: string | null;
+  status: string;
+  categoryName: string | null;
+}
+
+interface RecordSearchItem {
+  id: string;
+  fileName: string | null;
+  templateName: string;
+  status: string;
+  createdAt: string;
+}
+
+interface CollectionTaskSearchItem {
+  id: string;
+  title: string;
+  description: string | null;
+  status: string;
+}
+
+interface ReportTemplateSearchItem {
+  id: string;
+  name: string;
+  description: string | null;
+}
+```
+
+## Part 2: 快捷键体系
+
+### 2.1 全局导航快捷键
+
+| 快捷键 | 功能 |
+|--------|------|
+| `Ctrl/Cmd + K` | 打开命令面板 |
+| `Ctrl/Cmd + 1` | 跳转模板管理 (`/templates`) |
+| `Ctrl/Cmd + 2` | 跳转数据表 (`/data`) |
+| `Ctrl/Cmd + 3` | 跳转文档记录 (`/records`) |
+| `Ctrl/Cmd + 4` | 跳转文档收集 (`/collections`) |
+| `Ctrl/Cmd + 5` | 跳转报告 (`/reports`) |
+| `Ctrl/Cmd + /` | 显示快捷键帮助 |
+
+### 2.2 实现方式
+
+- 在 `src/components/layout/header.tsx` 中绑定全局快捷键（扩展现有 Ctrl+K 绑定位置）
+- 导航快捷键通过 `router.push()` 实现
+- 输入框/文本域中不触发快捷键（现有 `isTypingElement` 检测逻辑）
+- 快捷键帮助对话框：扩展现有 `keyboard-shortcuts-dialog.tsx`，增加全局快捷键部分
+
+## Part 3: 批量操作
+
+### 3.1 通用批量操作组件
+
+从现有 `src/components/data/batch-action-bar.tsx` 抽取通用版本：
+- `src/components/shared/batch-action-bar.tsx` — 通用批量操作栏
+- Props 支持自定义操作按钮配置
+
+```typescript
+interface BatchAction {
+  label: string;
+  icon?: React.ReactNode;
+  onClick: () => void;
+  variant?: "default" | "destructive";
+}
+
+interface SharedBatchActionBarProps {
+  selectedCount: number;
+  actions: BatchAction[];
+  onClearSelection: () => void;
+}
+```
+
+### 3.2 各页面批量操作
+
+**模板列表页** (`src/app/(dashboard)/templates/page.tsx`):
+- 保持 Server Component 做数据获取，新增 Client Component wrapper 管理批量选择状态
+- 批量操作：删除、更改状态（发布/归档/草稿）、更改分类、导出
+- 后端 API：`POST /api/templates/batch` 支持 `{ action: "delete" | "updateStatus" | "updateCategory", ids: string[], payload?: {...} }`
+
+**文档记录列表页** (`src/app/(dashboard)/records/page.tsx`):
+- 同上，Server Component + Client Component wrapper
+- 批量操作：删除、重新生成、导出（ZIP 下载）
+- 后端 API：`POST /api/records/batch` 支持 `{ action: "delete" | "regenerate" | "export", ids: string[] }`
+
+**数据表列表页**:
+- 在现有导出功能基础上增加"导出选中"选项
+- 已有批量操作（删除、编辑），增加"导出选中"按钮
+
+### 3.3 列表页批量选择模式
+
+三个列表页统一的选择模式：
+- 表头 Checkbox：全选/取消全选（当前页）
+- 行 Checkbox：单选
+- 底部浮动批量操作栏：选中后自动显示
+- 权限：普通用户只能操作自己的记录，管理员可操作所有
+
+## Part 4: 导出体验优化
+
+### 4.1 选中记录导出（数据表）
+
+- 在批量操作栏中增加"导出选中"按钮
+- 支持 Excel 和 JSON 格式
+- 扩展 `src/lib/services/export.service.ts`，增加 `selectedIds` 参数
+
+### 4.2 列表页导出
+
+三个列表页的工具栏中增加导出按钮（DropdownMenu）：
+
+**模板列表导出**:
+- 导出为 Excel：模板名称、状态、分类、标签、创建者、创建时间
+- API：`GET /api/templates/export`
+
+**文档记录列表导出**:
+- 导出为 Excel：文档名、模板名、状态、创建者、创建时间
+- API：`GET /api/records/export`
+
+**数据表列表导出**:
+- 在现有导出下拉菜单中增加"导出选中"选项
+
+### 4.3 后端实现
+
+- 复用/扩展 `src/lib/services/export.service.ts`
+- 新增 `exportTemplates()` 和 `exportRecords()` 函数
+- 选中导出：在现有导出函数中增加 ID 过滤逻辑
+- Excel 生成使用现有 ExcelJS 依赖
+
+## 文件变更预估
+
+### 新增文件
+- `src/components/layout/command-palette.tsx` — 命令面板组件
+- `src/hooks/use-commands.ts` — 命令注册 Hook
+- `src/components/shared/batch-action-bar.tsx` — 通用批量操作栏
+- `src/app/api/templates/batch/route.ts` — 模板批量操作 API
+- `src/app/api/records/batch/route.ts` — 记录批量操作 API
+- `src/app/api/templates/export/route.ts` — 模板导出 API
+- `src/app/api/records/export/route.ts` — 记录导出 API
+
+### 修改文件
+- `src/components/layout/header.tsx` — 绑定全局快捷键、引用命令面板
+- `src/lib/services/search.service.ts` — 扩展多数据源搜索
+- `src/app/api/search/route.ts` — 返回统一搜索结果
+- `src/components/data/batch-action-bar.tsx` — 可选：重构为通用版本或保留
+- `src/app/(dashboard)/templates/page.tsx` — 增加批量选择/导出
+- `src/app/(dashboard)/records/page.tsx` — 增加批量选择/导出
+- `src/lib/services/export.service.ts` — 增加模板/记录导出 + 选中导出
+- `src/components/data/views/grid-view.tsx` — 批量操作栏增加导出

--- a/src/app/(dashboard)/records/page.tsx
+++ b/src/app/(dashboard)/records/page.tsx
@@ -1,46 +1,15 @@
 import Link from "next/link";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-import { Badge } from "@/components/ui/badge";
 import { Button, LinkButton } from "@/components/ui/button";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
 import {
   ChevronLeft,
   ChevronRight,
-  Eye,
   Download,
-  History,
 } from "lucide-react";
-import type { Role, RecordStatus } from "@/generated/prisma/enums";
-import { PageHeader, ContentCard, EmptyState } from "@/components/shared";
-
-const STATUS_LABELS: Record<RecordStatus, string> = {
-  PENDING: "待生成",
-  COMPLETED: "已完成",
-  FAILED: "失败",
-};
-
-const STATUS_VARIANTS: Record<
-  RecordStatus,
-  "secondary" | "default" | "destructive"
-> = {
-  PENDING: "secondary",
-  COMPLETED: "default",
-  FAILED: "destructive",
-};
-
-const STATUS_BADGE_CLASS: Record<RecordStatus, string> = {
-  PENDING: "border-border bg-muted text-foreground",
-  COMPLETED: "bg-primary text-primary-foreground",
-  FAILED: "bg-destructive text-destructive-foreground",
-};
+import type { Role } from "@/generated/prisma/enums";
+import { PageHeader, ContentCard } from "@/components/shared";
+import { RecordTableWithBatch } from "@/components/records/record-table-with-batch";
 
 const STATUS_TABS: { label: string; value: string }[] = [
   { label: "全部", value: "" },
@@ -83,6 +52,14 @@ export default async function RecordsPage({
   ]);
 
   const totalPages = Math.ceil(total / pageSize);
+
+  const serializedRecords = records.map((r) => ({
+    id: r.id,
+    templateName: r.template.name,
+    fileName: r.fileName,
+    status: r.status,
+    createdAt: r.createdAt.toISOString(),
+  }));
 
   function buildUrl(pageNum: number, statusFilter: string) {
     const searchParams = new URLSearchParams();
@@ -128,82 +105,7 @@ export default async function RecordsPage({
       </div>
 
       <ContentCard className="!p-0">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="w-[30%]">模板名称</TableHead>
-              <TableHead className="w-[160px]">生成时间</TableHead>
-              <TableHead className="w-[100px]">状态</TableHead>
-              <TableHead>文件名</TableHead>
-              <TableHead className="w-[160px] text-right">操作</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {records.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={5}>
-                  <EmptyState
-                    icon={History}
-                    title="暂无生成记录"
-                    description="填写模板表单即可生成文档"
-                    action={
-                      <LinkButton variant="link" size="sm" href="/templates">
-                        前往模板列表填写表单
-                      </LinkButton>
-                    }
-                  />
-                </TableCell>
-              </TableRow>
-            ) : (
-              records.map((record) => (
-                <TableRow key={record.id}>
-                  <TableCell className="font-[510] text-foreground">
-                    {record.template.name}
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">
-                    {record.createdAt.toLocaleDateString("zh-CN", {
-                      year: "numeric",
-                      month: "2-digit",
-                      day: "2-digit",
-                    })}
-                  </TableCell>
-                  <TableCell>
-                    <Badge
-                      variant={STATUS_VARIANTS[record.status as RecordStatus]}
-                      className={STATUS_BADGE_CLASS[record.status as RecordStatus]}
-                    >
-                      {STATUS_LABELS[record.status as RecordStatus]}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">
-                    {record.fileName || "-"}
-                  </TableCell>
-                  <TableCell className="text-right">
-                    <div className="flex items-center justify-end gap-1">
-                      {record.status === "COMPLETED" && record.fileName && (
-                        <a
-                          href={`/api/records/${record.id}/download`}
-                          className="inline-flex items-center gap-1 px-2 py-1 text-xs font-[510] text-foreground/90 transition-colors hover:text-foreground"
-                        >
-                          <Download className="h-3.5 w-3.5" />
-                        </a>
-                      )}
-                      <LinkButton
-                        variant="ghost"
-                        size="sm"
-                        className="text-foreground hover:text-foreground"
-                        href={`/records/${record.id}`}
-                      >
-                        <Eye className="h-3.5 w-3.5" />
-                        查看
-                      </LinkButton>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
+        <RecordTableWithBatch records={serializedRecords} isAdmin={isAdmin} />
       </ContentCard>
 
       {totalPages > 1 && (

--- a/src/app/(dashboard)/records/page.tsx
+++ b/src/app/(dashboard)/records/page.tsx
@@ -97,6 +97,15 @@ export default async function RecordsPage({
       <PageHeader
         title="生成记录"
         description={`共 ${total} 条记录`}
+        actions={
+          <a
+            href="/api/records/export"
+            className="inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 h-9 text-sm font-medium hover:bg-accent hover:text-accent-foreground"
+          >
+            <Download className="h-4 w-4" />
+            导出
+          </a>
+        }
       />
 
       <div className="flex gap-1 overflow-x-auto rounded-lg border border-border bg-card p-1">

--- a/src/app/(dashboard)/templates/page.tsx
+++ b/src/app/(dashboard)/templates/page.tsx
@@ -11,7 +11,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Upload, ChevronLeft, ChevronRight, Pencil, Eye, FileText } from "lucide-react";
+import { Upload, ChevronLeft, ChevronRight, Pencil, Eye, FileText, Download } from "lucide-react";
 import type { Role, TemplateStatus } from "@/generated/prisma/enums";
 import { TemplateListDeleteButton } from "./template-list-delete-button";
 import { CategoryTagManagerButton } from "@/components/templates/category-tag-manager-button";
@@ -115,15 +115,24 @@ export default async function TemplatesPage({
         title="模板管理"
         description={`共 ${total} 个模板`}
         actions={
-          isAdmin ? (
-            <div className="flex items-center gap-2">
-              <CategoryTagManagerButton />
-              <LinkButton href="/templates/new">
-                <Upload className="h-4 w-4" />
-                上传模板
-              </LinkButton>
-            </div>
-          ) : undefined
+          <div className="flex items-center gap-2">
+            <a
+              href="/api/templates/export"
+              className="inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 h-9 text-sm font-medium hover:bg-accent hover:text-accent-foreground"
+            >
+              <Download className="h-4 w-4" />
+              导出
+            </a>
+            {isAdmin && (
+              <>
+                <CategoryTagManagerButton />
+                <LinkButton href="/templates/new">
+                  <Upload className="h-4 w-4" />
+                  上传模板
+                </LinkButton>
+              </>
+            )}
+          </div>
         }
       />
 

--- a/src/app/(dashboard)/templates/page.tsx
+++ b/src/app/(dashboard)/templates/page.tsx
@@ -1,36 +1,12 @@
 import Link from "next/link";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-import { Badge } from "@/components/ui/badge";
 import { Button, LinkButton } from "@/components/ui/button";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { Upload, ChevronLeft, ChevronRight, Pencil, Eye, FileText, Download } from "lucide-react";
+import { Upload, ChevronLeft, ChevronRight, Download } from "lucide-react";
 import type { Role, TemplateStatus } from "@/generated/prisma/enums";
-import { TemplateListDeleteButton } from "./template-list-delete-button";
 import { CategoryTagManagerButton } from "@/components/templates/category-tag-manager-button";
-import { PageHeader, ContentCard, EmptyState } from "@/components/shared";
-
-const STATUS_LABELS: Record<TemplateStatus, string> = {
-  DRAFT: "草稿",
-  PUBLISHED: "已发布",
-  ARCHIVED: "已归档",
-};
-
-const STATUS_VARIANTS: Record<
-  TemplateStatus,
-  "secondary" | "default" | "destructive"
-> = {
-  DRAFT: "secondary",
-  PUBLISHED: "default",
-  ARCHIVED: "destructive",
-};
+import { TemplateTableWithBatch } from "@/components/templates/template-table-with-batch";
+import { PageHeader, ContentCard } from "@/components/shared";
 
 const STATUS_TABS: { label: string; value: string }[] = [
   { label: "全部", value: "" },
@@ -184,119 +160,11 @@ export default async function TemplatesPage({
       )}
 
       <ContentCard className="!p-0">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="w-[100px]">分类</TableHead>
-              <TableHead className="w-[30%]">名称</TableHead>
-              <TableHead>版本</TableHead>
-              <TableHead className="w-[150px]">标签</TableHead>
-              <TableHead className="w-[100px]">状态</TableHead>
-              <TableHead className="w-[100px]">创建者</TableHead>
-              <TableHead className="w-[160px]">创建时间</TableHead>
-              <TableHead className="w-[160px] text-right">操作</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {templates.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={8}>
-                  <EmptyState
-                    icon={FileText}
-                    title="暂无模板数据"
-                    description={isAdmin ? "上传第一个模板来开始管理您的文档" : undefined}
-                    action={
-                      isAdmin ? (
-                        <LinkButton variant="link" size="sm" href="/templates/new">
-                          上传第一个模板
-                        </LinkButton>
-                      ) : undefined
-                    }
-                  />
-                </TableCell>
-              </TableRow>
-            ) : (
-              templates.map((template) => (
-                <TableRow key={template.id}>
-                  <TableCell>
-                    {template.category ? (
-                      <Badge variant="secondary">{template.category.name}</Badge>
-                    ) : (
-                      <span className="text-muted-foreground text-xs">—</span>
-                    )}
-                  </TableCell>
-                  <TableCell className="font-[510] text-foreground">{template.name}</TableCell>
-                  <TableCell className="text-muted-foreground">
-                    {template.currentVersion ? `v${template.currentVersion.version}` : "—"}
-                  </TableCell>
-                  <TableCell>
-                    <div className="flex flex-wrap gap-1">
-                      {template.tags.length === 0 ? (
-                        <span className="text-xs text-muted-foreground">—</span>
-                      ) : (
-                        <>
-                          {template.tags.slice(0, 3).map((t) => (
-                            <Badge key={t.tag.id} variant="outline" className="text-xs">
-                              {t.tag.name}
-                            </Badge>
-                          ))}
-                          {template.tags.length > 3 && (
-                            <span className="text-xs text-muted-foreground">+{template.tags.length - 3}</span>
-                          )}
-                        </>
-                      )}
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant={STATUS_VARIANTS[template.status]}>
-                      {STATUS_LABELS[template.status]}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">
-                    {template.createdBy.name}
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">
-                    {template.createdAt.toLocaleDateString("zh-CN", {
-                      year: "numeric",
-                      month: "2-digit",
-                      day: "2-digit",
-                    })}
-                  </TableCell>
-                  <TableCell className="text-right">
-                    <div className="flex items-center justify-end gap-1">
-                      <LinkButton
-                        variant="ghost"
-                        size="icon-xs"
-                        className="text-muted-foreground hover:text-foreground"
-                        href={`/templates/${template.id}`}
-                      >
-                        <Eye className="h-3.5 w-3.5" />
-                        <span className="sr-only">查看</span>
-                      </LinkButton>
-                      {isAdmin && (
-                        <>
-                          <LinkButton
-                            variant="ghost"
-                            size="icon-xs"
-                            className="text-muted-foreground hover:text-foreground"
-                            href={`/templates/${template.id}/edit`}
-                          >
-                            <Pencil className="h-3.5 w-3.5" />
-                            <span className="sr-only">编辑</span>
-                          </LinkButton>
-                          <TemplateListDeleteButton
-                            templateId={template.id}
-                            templateName={template.name}
-                          />
-                        </>
-                      )}
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
+        <TemplateTableWithBatch
+          templates={templates}
+          categories={categories}
+          isAdmin={isAdmin}
+        />
       </ContentCard>
 
       {totalPages > 1 && (

--- a/src/app/api/data-tables/[id]/export/json/route.ts
+++ b/src/app/api/data-tables/[id]/export/json/route.ts
@@ -23,7 +23,9 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
     );
   }
 
-  const result = await exportToJSON(tableId);
+  const { searchParams } = new URL(_request.url);
+  const selectedIds = searchParams.getAll("selectedId");
+  const result = await exportToJSON(tableId, selectedIds.length > 0 ? selectedIds : undefined);
   if (!result.success) {
     return NextResponse.json(
       { error: result.error.message },

--- a/src/app/api/data-tables/[id]/export/route.ts
+++ b/src/app/api/data-tables/[id]/export/route.ts
@@ -28,10 +28,11 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
   const { searchParams } = new URL(_request.url);
   const visibleFields = searchParams.getAll("visibleField");
   const fieldOrder = searchParams.getAll("fieldOrder");
+  const selectedIds = searchParams.getAll("selectedId");
   const result = await exportToExcel(tableId, {
     visibleFields: visibleFields.length > 0 ? visibleFields : undefined,
     fieldOrder: fieldOrder.length > 0 ? fieldOrder : undefined,
-  });
+  }, selectedIds.length > 0 ? selectedIds : undefined);
 
   if (!result.success) {
     return NextResponse.json(

--- a/src/app/api/records/batch/route.ts
+++ b/src/app/api/records/batch/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import type { Role } from "@/generated/prisma/enums";
+
+export async function POST(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: { code: "UNAUTHORIZED", message: "未登录" } }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { action, ids } = body as {
+    action: "delete" | "export";
+    ids: string[];
+  };
+
+  if (!ids || !Array.isArray(ids) || ids.length === 0) {
+    return NextResponse.json({ error: { code: "INVALID_INPUT", message: "请选择至少一条记录" } }, { status: 400 });
+  }
+
+  const isAdmin = (session.user.role as Role) === "ADMIN";
+
+  try {
+    switch (action) {
+      case "delete": {
+        const where = isAdmin ? { id: { in: ids } } : { id: { in: ids }, userId: session.user.id };
+        const result = await db.record.deleteMany({ where });
+        return NextResponse.json({ success: true, data: { deleted: result.count } });
+      }
+      case "export": {
+        const where = isAdmin ? { id: { in: ids } } : { id: { in: ids }, userId: session.user.id };
+        const records = await db.record.findMany({
+          where,
+          include: { template: { select: { name: true } }, user: { select: { name: true } } },
+          orderBy: { createdAt: "desc" },
+        });
+        return NextResponse.json({ success: true, data: records });
+      }
+      default:
+        return NextResponse.json({ error: { code: "INVALID_ACTION", message: "不支持的操作" } }, { status: 400 });
+    }
+  } catch (error) {
+    return NextResponse.json(
+      { error: { code: "BATCH_ERROR", message: error instanceof Error ? error.message : "批量操作失败" } },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/records/export/route.ts
+++ b/src/app/api/records/export/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import type { Role } from "@/generated/prisma/enums";
+import * as XLSX from "xlsx";
+
+export async function GET(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: { code: "UNAUTHORIZED", message: "未登录" } }, { status: 401 });
+  }
+
+  const isAdmin = (session.user.role as Role) === "ADMIN";
+  const statusParam = request.nextUrl.searchParams.get("status");
+
+  try {
+    const where: Record<string, unknown> = {};
+    if (!isAdmin && session.user.id) {
+      where.userId = session.user.id;
+    }
+    if (statusParam && ["PENDING", "COMPLETED", "FAILED"].includes(statusParam)) {
+      where.status = statusParam;
+    }
+
+    const records = await db.record.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      include: {
+        template: { select: { name: true } },
+        user: { select: { name: true } },
+      },
+    });
+
+    const statusLabels: Record<string, string> = { PENDING: "待生成", COMPLETED: "已完成", FAILED: "失败" };
+
+    const headers = ["模板名称", "文件名", "状态", "生成者", "生成时间"];
+    const rows = records.map((r) => [
+      r.template.name,
+      r.fileName ?? "",
+      statusLabels[r.status] ?? r.status,
+      r.user.name,
+      r.createdAt.toLocaleDateString("zh-CN"),
+    ]);
+
+    const ws = XLSX.utils.aoa_to_sheet([headers, ...rows]);
+    ws["!cols"] = headers.map((h) => ({ wch: Math.max(h.length * 2, 12) }));
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, "生成记录");
+
+    const buffer = XLSX.write(wb, { type: "buffer", bookType: "xlsx" });
+
+    return new Response(buffer, {
+      headers: {
+        "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "Content-Disposition": `attachment; filename*=UTF-8''${encodeURIComponent("生成记录.xlsx")}`,
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: { code: "EXPORT_ERROR", message: error instanceof Error ? error.message : "导出失败" } },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { unifiedSearch } from "@/lib/services/search.service";
+import type { Role } from "@/generated/prisma/enums";
 
 export async function GET(request: NextRequest) {
   const session = await auth();
@@ -10,6 +11,8 @@ export async function GET(request: NextRequest) {
       { status: 401 }
     );
   }
+
+  const isAdmin = (session.user.role as Role) === "ADMIN";
 
   const q = request.nextUrl.searchParams.get("q")?.trim();
   if (!q) {
@@ -21,7 +24,7 @@ export async function GET(request: NextRequest) {
     20
   );
 
-  const result = await unifiedSearch(q, limit);
+  const result = await unifiedSearch(q, limit, session.user.id, isAdmin);
 
   if (!result.success) {
     return NextResponse.json(

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
-import { globalSearch } from "@/lib/services/search.service";
+import { unifiedSearch } from "@/lib/services/search.service";
 
 export async function GET(request: NextRequest) {
   const session = await auth();
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
 
   const q = request.nextUrl.searchParams.get("q")?.trim();
   if (!q) {
-    return NextResponse.json({ success: true, data: [] });
+    return NextResponse.json({ success: true, data: { templates: [], records: [], dataRecords: [], collectionTasks: [], reportTemplates: [] } });
   }
 
   const limit = Math.min(
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest) {
     20
   );
 
-  const result = await globalSearch(q, limit);
+  const result = await unifiedSearch(q, limit);
 
   if (!result.success) {
     return NextResponse.json(

--- a/src/app/api/templates/batch/route.ts
+++ b/src/app/api/templates/batch/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import type { Role } from "@/generated/prisma/enums";
+import { TemplateStatus } from "@/generated/prisma/enums";
+
+export async function POST(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: { code: "UNAUTHORIZED", message: "未登录" } }, { status: 401 });
+  }
+
+  const isAdmin = (session.user.role as Role) === "ADMIN";
+  if (!isAdmin) {
+    return NextResponse.json({ error: { code: "FORBIDDEN", message: "仅管理员可执行批量操作" } }, { status: 403 });
+  }
+
+  const body = await request.json();
+  const { action, ids, payload } = body as {
+    action: "delete" | "updateStatus" | "updateCategory";
+    ids: string[];
+    payload?: { status?: string; categoryId?: string | null };
+  };
+
+  if (!ids || !Array.isArray(ids) || ids.length === 0) {
+    return NextResponse.json({ error: { code: "INVALID_INPUT", message: "请选择至少一条记录" } }, { status: 400 });
+  }
+
+  try {
+    switch (action) {
+      case "delete": {
+        await db.template.deleteMany({ where: { id: { in: ids } } });
+        return NextResponse.json({ success: true, data: { deleted: ids.length } });
+      }
+      case "updateStatus": {
+        if (!payload?.status || !Object.values(TemplateStatus).includes(payload.status as TemplateStatus)) {
+          return NextResponse.json({ error: { code: "INVALID_INPUT", message: "无效的状态值" } }, { status: 400 });
+        }
+        await db.template.updateMany({
+          where: { id: { in: ids } },
+          data: { status: payload.status as TemplateStatus },
+        });
+        return NextResponse.json({ success: true, data: { updated: ids.length } });
+      }
+      case "updateCategory": {
+        await db.template.updateMany({
+          where: { id: { in: ids } },
+          data: { categoryId: payload?.categoryId === "__none__" ? null : (payload?.categoryId ?? null) },
+        });
+        return NextResponse.json({ success: true, data: { updated: ids.length } });
+      }
+      default:
+        return NextResponse.json({ error: { code: "INVALID_ACTION", message: "不支持的操作" } }, { status: 400 });
+    }
+  } catch (error) {
+    return NextResponse.json(
+      { error: { code: "BATCH_ERROR", message: error instanceof Error ? error.message : "批量操作失败" } },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/templates/export/route.ts
+++ b/src/app/api/templates/export/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import type { Role } from "@/generated/prisma/enums";
+import * as XLSX from "xlsx";
+
+export async function GET(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: { code: "UNAUTHORIZED", message: "未登录" } }, { status: 401 });
+  }
+
+  const isAdmin = (session.user.role as Role) === "ADMIN";
+
+  try {
+    const where = isAdmin ? {} : { status: "PUBLISHED" as const };
+
+    const templates = await db.template.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      select: {
+        name: true,
+        status: true,
+        createdAt: true,
+        createdBy: { select: { name: true } },
+        category: { select: { name: true } },
+        tags: { select: { tag: { select: { name: true } } } },
+      },
+    });
+
+    const statusLabels: Record<string, string> = { DRAFT: "草稿", PUBLISHED: "已发布", ARCHIVED: "已归档" };
+
+    const headers = ["模板名称", "状态", "分类", "标签", "创建者", "创建时间"];
+    const rows = templates.map((t) => [
+      t.name,
+      statusLabels[t.status] ?? t.status,
+      t.category?.name ?? "",
+      t.tags.map((tg) => tg.tag.name).join(", "),
+      t.createdBy.name,
+      t.createdAt.toLocaleDateString("zh-CN"),
+    ]);
+
+    const ws = XLSX.utils.aoa_to_sheet([headers, ...rows]);
+    ws["!cols"] = headers.map((h) => ({ wch: Math.max(h.length * 2, 12) }));
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, "模板列表");
+
+    const buffer = XLSX.write(wb, { type: "buffer", bookType: "xlsx" });
+
+    return new Response(buffer, {
+      headers: {
+        "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "Content-Disposition": `attachment; filename*=UTF-8''${encodeURIComponent("模板列表.xlsx")}`,
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: { code: "EXPORT_ERROR", message: error instanceof Error ? error.message : "导出失败" } },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/data/views/grid-view.tsx
+++ b/src/components/data/views/grid-view.tsx
@@ -3,7 +3,7 @@
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { ChevronDown, ChevronRight, Expand, GripVertical, Loader2, MessageSquare, Plus, Redo2, Search, Trash2, Undo2 } from "lucide-react";
+import { ChevronDown, ChevronRight, Download, Expand, GripVertical, Loader2, MessageSquare, Plus, Redo2, Search, Trash2, Undo2 } from "lucide-react";
 import { BatchActionBar } from "@/components/data/batch-action-bar";
 import { BatchEditDialog } from "@/components/data/batch-edit-dialog";
 import { FindReplaceBar } from "@/components/data/views/find-replace-bar";
@@ -1982,12 +1982,29 @@ export function GridView({
   return (
     <div className="rounded-md border flex-1 min-h-0 flex flex-col overflow-hidden gap-0">
       {selectedIdsSet.size > 0 && (
-        <BatchActionBar
-          selectedCount={selectedIdsSet.size}
-          onBatchDelete={handleBatchDelete}
-          onBatchEdit={() => setBatchEditOpen(true)}
-          onClearSelection={() => setSelectedIdsSet(new Set())}
-        />
+        <div className="flex items-center gap-2">
+          <BatchActionBar
+            selectedCount={selectedIdsSet.size}
+            onBatchDelete={handleBatchDelete}
+            onBatchEdit={() => setBatchEditOpen(true)}
+            onClearSelection={() => setSelectedIdsSet(new Set())}
+          />
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 text-xs gap-1"
+            onClick={() => {
+              const params = new URLSearchParams();
+              for (const id of selectedIdsSet) {
+                params.append("selectedId", id);
+              }
+              window.location.href = `/api/data-tables/${tableId}/export?${params.toString()}`;
+            }}
+          >
+            <Download className="h-3 w-3" />
+            导出选中
+          </Button>
+        </div>
       )}
       <BatchEditDialog
         open={batchEditOpen}

--- a/src/components/layout/command-palette.tsx
+++ b/src/components/layout/command-palette.tsx
@@ -252,12 +252,6 @@ export function CommandPalette({
     [handleClose]
   );
 
-  const handleSearchSubmit = useCallback(() => {
-    if (searchQuery.trim()) {
-      addRecentSearch(searchQuery.trim());
-    }
-  }, [searchQuery]);
-
   // Filter commands in command mode
   const filteredCommands = isCommandMode
     ? commands.filter((cmd) => {

--- a/src/components/layout/command-palette.tsx
+++ b/src/components/layout/command-palette.tsx
@@ -15,6 +15,7 @@ import { toast } from "sonner";
 import { useCommands } from "@/hooks/use-command-palette";
 import type { CommandItem } from "@/hooks/use-command-palette";
 import {
+  Command,
   CommandDialog,
   CommandInput,
   CommandList,
@@ -283,6 +284,11 @@ export function CommandPalette({
         if (!v) handleClose();
       }}
     >
+      <Command filter={(value, search) => {
+        // In command mode, cmdk should not filter — we handle it ourselves
+        if (search.startsWith(">")) return 1;
+        return value.toLowerCase().includes(search.toLowerCase()) ? 1 : 0;
+      }}>
       <CommandInput
         placeholder={
           isCommandMode ? "输入命令名称..." : "搜索模板、记录、数据... 输入 > 切换命令模式"
@@ -485,6 +491,7 @@ export function CommandPalette({
             </CommandGroup>
           )}
       </CommandList>
+      </Command>
     </CommandDialog>
   );
 }

--- a/src/components/layout/command-palette.tsx
+++ b/src/components/layout/command-palette.tsx
@@ -187,10 +187,13 @@ export function CommandPalette({
   }, [searchQuery, isCommandMode, open]);
 
   const handleClose = useCallback(() => {
+    if (query.trim() && !query.startsWith(">")) {
+      addRecentSearch(query.trim());
+    }
     setQuery("");
     setSearchData(null);
     onClose();
-  }, [onClose]);
+  }, [onClose, query]);
 
   const handleSelectTemplate = useCallback(
     (id: string) => {

--- a/src/components/layout/command-palette.tsx
+++ b/src/components/layout/command-palette.tsx
@@ -1,0 +1,496 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  LayoutGrid,
+  FileText,
+  Table2,
+  Inbox,
+  BookOpen,
+  Clock,
+  X,
+} from "lucide-react";
+import { toast } from "sonner";
+import { useCommands } from "@/hooks/use-command-palette";
+import type { CommandItem } from "@/hooks/use-command-palette";
+import {
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem as CmdItem,
+  CommandShortcut,
+} from "@/components/ui/command";
+
+/* ---------- Types ---------- */
+
+interface TemplateSearchItem {
+  id: string;
+  name: string;
+  description: string | null;
+  status: string;
+  categoryName: string | null;
+}
+
+interface RecordSearchItem {
+  id: string;
+  fileName: string | null;
+  templateName: string;
+  status: string;
+  createdAt: string;
+}
+
+interface DataRecordSearchResult {
+  tableId: string;
+  tableName: string;
+  tableIcon: string | null;
+  records: Array<{
+    id: string;
+    data: Record<string, unknown>;
+    matchedFields: string[];
+  }>;
+  hasMore: boolean;
+}
+
+interface CollectionTaskSearchItem {
+  id: string;
+  title: string;
+  description: string | null;
+  status: string;
+}
+
+interface ReportTemplateSearchItem {
+  id: string;
+  name: string;
+  originalFilename: string;
+}
+
+interface UnifiedSearchData {
+  templates: TemplateSearchItem[];
+  records: RecordSearchItem[];
+  dataRecords: DataRecordSearchResult[];
+  collectionTasks: CollectionTaskSearchItem[];
+  reportTemplates: ReportTemplateSearchItem[];
+}
+
+/* ---------- Recent searches helpers ---------- */
+
+const RECENT_KEY = "recent-searches";
+const MAX_RECENT = 10;
+
+function getRecentSearches(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(RECENT_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function addRecentSearch(query: string) {
+  if (!query.trim()) return;
+  const list = getRecentSearches().filter((s) => s !== query);
+  list.unshift(query);
+  localStorage.setItem(RECENT_KEY, JSON.stringify(list.slice(0, MAX_RECENT)));
+}
+
+function removeRecentSearch(query: string) {
+  const list = getRecentSearches().filter((s) => s !== query);
+  localStorage.setItem(RECENT_KEY, JSON.stringify(list));
+}
+
+/* ---------- Data record label helper ---------- */
+
+function getRecordLabel(
+  data: Record<string, unknown>,
+  matchedFields: string[]
+): string {
+  for (const key of matchedFields) {
+    const val = data[key];
+    if (typeof val === "string" && val.trim()) return val;
+  }
+  for (const val of Object.values(data)) {
+    if (typeof val === "string" && val.trim()) return val;
+  }
+  return "未命名记录";
+}
+
+/* ---------- Component ---------- */
+
+export function CommandPalette({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
+  const router = useRouter();
+  const commands = useCommands();
+  const [query, setQuery] = useState("");
+  const [searchData, setSearchData] = useState<UnifiedSearchData | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [recentSearches, setRecentSearches] = useState<string[]>([]);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const isCommandMode = query.startsWith(">");
+  const searchQuery = isCommandMode ? "" : query;
+  const commandFilter = isCommandMode ? query.slice(1).trim() : "";
+
+  // Load recent searches when dialog opens
+  useEffect(() => {
+    if (open) {
+      setRecentSearches(getRecentSearches());
+    } else {
+      setQuery("");
+      setSearchData(null);
+    }
+  }, [open]);
+
+  // Debounced search
+  useEffect(() => {
+    if (!open || isCommandMode) {
+      setSearchData(null);
+      return;
+    }
+    if (!searchQuery.trim()) {
+      setSearchData(null);
+      return;
+    }
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      setIsLoading(true);
+      try {
+        const res = await fetch(
+          `/api/search?q=${encodeURIComponent(searchQuery)}`
+        );
+        if (res.ok) {
+          const json = await res.json();
+          setSearchData(json.data ?? null);
+        } else {
+          toast.error("搜索失败");
+          setSearchData(null);
+        }
+      } catch {
+        toast.error("搜索失败，请检查网络连接");
+        setSearchData(null);
+      } finally {
+        setIsLoading(false);
+      }
+    }, 300);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [searchQuery, isCommandMode, open]);
+
+  const handleClose = useCallback(() => {
+    setQuery("");
+    setSearchData(null);
+    onClose();
+  }, [onClose]);
+
+  const handleSelectTemplate = useCallback(
+    (id: string) => {
+      handleClose();
+      router.push(`/templates/${id}`);
+    },
+    [router, handleClose]
+  );
+
+  const handleSelectRecord = useCallback(
+    (id: string) => {
+      handleClose();
+      router.push(`/records/${id}`);
+    },
+    [router, handleClose]
+  );
+
+  const handleSelectDataRecord = useCallback(
+    (tableId: string, recordId: string) => {
+      handleClose();
+      router.push(`/data/${tableId}?recordId=${recordId}`);
+    },
+    [router, handleClose]
+  );
+
+  const handleSelectCollectionTask = useCallback(
+    (id: string) => {
+      handleClose();
+      router.push(`/collections/${id}`);
+    },
+    [router, handleClose]
+  );
+
+  const handleSelectReportTemplate = useCallback(
+    (id: string) => {
+      handleClose();
+      router.push(`/reports/templates/${id}`);
+    },
+    [router, handleClose]
+  );
+
+  const handleSelectRecentSearch = useCallback((q: string) => {
+    setQuery(q);
+  }, []);
+
+  const handleRemoveRecentSearch = useCallback(
+    (q: string, e: React.MouseEvent) => {
+      e.stopPropagation();
+      removeRecentSearch(q);
+      setRecentSearches(getRecentSearches());
+    },
+    []
+  );
+
+  const handleCommandSelect = useCallback(
+    (cmd: CommandItem) => {
+      handleClose();
+      cmd.onSelect();
+    },
+    [handleClose]
+  );
+
+  const handleSearchSubmit = useCallback(() => {
+    if (searchQuery.trim()) {
+      addRecentSearch(searchQuery.trim());
+    }
+  }, [searchQuery]);
+
+  // Filter commands in command mode
+  const filteredCommands = isCommandMode
+    ? commands.filter((cmd) => {
+        if (!commandFilter) return true;
+        const lower = commandFilter.toLowerCase();
+        return (
+          cmd.label.toLowerCase().includes(lower) ||
+          cmd.id.toLowerCase().includes(lower) ||
+          (cmd.keywords?.some((k) => k.toLowerCase().includes(lower)) ?? false)
+        );
+      })
+    : [];
+
+  // Check if there are any search results
+  const hasResults =
+    searchData &&
+    ((searchData.templates?.length ?? 0) > 0 ||
+      (searchData.records?.length ?? 0) > 0 ||
+      (searchData.dataRecords?.length ?? 0) > 0 ||
+      (searchData.collectionTasks?.length ?? 0) > 0 ||
+      (searchData.reportTemplates?.length ?? 0) > 0);
+
+  return (
+    <CommandDialog
+      title="命令面板"
+      description="搜索或输入命令"
+      open={open}
+      onOpenChange={(v) => {
+        if (!v) handleClose();
+      }}
+    >
+      <CommandInput
+        placeholder={
+          isCommandMode ? "输入命令名称..." : "搜索模板、记录、数据... 输入 > 切换命令模式"
+        }
+        value={query}
+        onValueChange={setQuery}
+      />
+      <CommandList>
+        {/* Command mode */}
+        {isCommandMode && (
+          <>
+            {filteredCommands.length === 0 && (
+              <CommandEmpty>未找到匹配命令</CommandEmpty>
+            )}
+            <CommandGroup heading="导航">
+              {filteredCommands.map((cmd) => (
+                <CmdItem
+                  key={cmd.id}
+                  value={`${cmd.label} ${cmd.id} ${(cmd.keywords ?? []).join(" ")}`}
+                  onSelect={() => handleCommandSelect(cmd)}
+                >
+                  {cmd.icon}
+                  <span>{cmd.label}</span>
+                  {cmd.shortcut && <CommandShortcut>{cmd.shortcut}</CommandShortcut>}
+                </CmdItem>
+              ))}
+            </CommandGroup>
+          </>
+        )}
+
+        {/* Search mode: recent searches */}
+        {!isCommandMode && !searchQuery.trim() && !isLoading && (
+          <>
+            {recentSearches.length === 0 && (
+              <CommandEmpty>输入关键词开始搜索</CommandEmpty>
+            )}
+            {recentSearches.length > 0 && (
+              <CommandGroup heading="最近搜索">
+                {recentSearches.map((q) => (
+                  <CmdItem
+                    key={q}
+                    value={`recent-${q}`}
+                    onSelect={() => handleSelectRecentSearch(q)}
+                  >
+                    <Clock className="h-4 w-4 text-muted-foreground" />
+                    <span className="flex-1 truncate">{q}</span>
+                    <button
+                      className="ml-auto p-0.5 rounded hover:bg-muted"
+                      onClick={(e) => handleRemoveRecentSearch(q, e)}
+                    >
+                      <X className="h-3 w-3 text-muted-foreground" />
+                    </button>
+                  </CmdItem>
+                ))}
+              </CommandGroup>
+            )}
+          </>
+        )}
+
+        {/* Search mode: loading */}
+        {!isCommandMode && searchQuery.trim() && isLoading && (
+          <CommandEmpty>搜索中...</CommandEmpty>
+        )}
+
+        {/* Search mode: no results */}
+        {!isCommandMode &&
+          searchQuery.trim() &&
+          !isLoading &&
+          !hasResults && (
+            <CommandEmpty>未找到匹配结果</CommandEmpty>
+          )}
+
+        {/* Search mode: results */}
+        {!isCommandMode &&
+          searchData &&
+          searchData.templates.length > 0 && (
+            <CommandGroup heading="模板">
+              {searchData.templates.map((t) => (
+                <CmdItem
+                  key={`tpl-${t.id}`}
+                  value={`template-${t.id}-${t.name}`}
+                  onSelect={() => handleSelectTemplate(t.id)}
+                >
+                  <LayoutGrid className="h-4 w-4 text-muted-foreground" />
+                  <span className="flex-1 truncate">
+                    <span className="font-medium">{t.name}</span>
+                    {t.categoryName && (
+                      <span className="ml-2 text-muted-foreground text-xs">
+                        {t.categoryName}
+                      </span>
+                    )}
+                  </span>
+                </CmdItem>
+              ))}
+            </CommandGroup>
+          )}
+
+        {!isCommandMode &&
+          searchData &&
+          searchData.records.length > 0 && (
+            <CommandGroup heading="生成记录">
+              {searchData.records.map((r) => (
+                <CmdItem
+                  key={`rec-${r.id}`}
+                  value={`record-${r.id}-${r.fileName ?? r.templateName}`}
+                  onSelect={() => handleSelectRecord(r.id)}
+                >
+                  <FileText className="h-4 w-4 text-muted-foreground" />
+                  <span className="flex-1 truncate">
+                    <span className="font-medium">
+                      {r.fileName ?? r.templateName}
+                    </span>
+                    {r.fileName && (
+                      <span className="ml-2 text-muted-foreground text-xs">
+                        {r.templateName}
+                      </span>
+                    )}
+                  </span>
+                </CmdItem>
+              ))}
+            </CommandGroup>
+          )}
+
+        {!isCommandMode &&
+          searchData &&
+          searchData.dataRecords.length > 0 &&
+          searchData.dataRecords.map((table) => (
+            <CommandGroup
+              key={`data-${table.tableId}`}
+              heading={table.tableName}
+            >
+              {table.records.map((record) => {
+                const label = getRecordLabel(
+                  record.data,
+                  record.matchedFields
+                );
+                return (
+                  <CmdItem
+                    key={`datarec-${table.tableId}-${record.id}`}
+                    value={`datarecord-${record.id}-${label}`}
+                    onSelect={() =>
+                      handleSelectDataRecord(table.tableId, record.id)
+                    }
+                  >
+                    <Table2 className="h-4 w-4 text-muted-foreground" />
+                    <span className="flex-1 truncate">
+                      <span className="font-medium">{label}</span>
+                      {record.matchedFields.length > 0 && (
+                        <span className="ml-2 text-muted-foreground text-xs">
+                          {record.matchedFields.join(", ")}
+                        </span>
+                      )}
+                    </span>
+                  </CmdItem>
+                );
+              })}
+            </CommandGroup>
+          ))}
+
+        {!isCommandMode &&
+          searchData &&
+          searchData.collectionTasks.length > 0 && (
+            <CommandGroup heading="文档收集">
+              {searchData.collectionTasks.map((t) => (
+                <CmdItem
+                  key={`col-${t.id}`}
+                  value={`collection-${t.id}-${t.title}`}
+                  onSelect={() => handleSelectCollectionTask(t.id)}
+                >
+                  <Inbox className="h-4 w-4 text-muted-foreground" />
+                  <span className="flex-1 truncate">
+                    <span className="font-medium">{t.title}</span>
+                  </span>
+                </CmdItem>
+              ))}
+            </CommandGroup>
+          )}
+
+        {!isCommandMode &&
+          searchData &&
+          searchData.reportTemplates.length > 0 && (
+            <CommandGroup heading="报告模板">
+              {searchData.reportTemplates.map((t) => (
+                <CmdItem
+                  key={`rpt-${t.id}`}
+                  value={`report-${t.id}-${t.name}`}
+                  onSelect={() => handleSelectReportTemplate(t.id)}
+                >
+                  <BookOpen className="h-4 w-4 text-muted-foreground" />
+                  <span className="flex-1 truncate">
+                    <span className="font-medium">{t.name}</span>
+                    {t.originalFilename && (
+                      <span className="ml-2 text-muted-foreground text-xs">
+                        {t.originalFilename}
+                      </span>
+                    )}
+                  </span>
+                </CmdItem>
+              ))}
+            </CommandGroup>
+          )}
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { Search } from "lucide-react";
 import { MobileNav } from "@/components/layout/mobile-nav";
 import { isRouteActive } from "@/components/layout/navigation/matcher";
@@ -9,7 +9,7 @@ import { NAV_ITEMS } from "@/components/layout/navigation/schema";
 import { NotificationBell } from "@/components/layout/notification-bell";
 import { ThemeToggle } from "@/components/layout/theme-toggle";
 import { UserNav } from "@/components/layout/user-nav";
-import { GlobalSearchDialog } from "@/components/data/global-search-dialog";
+import { CommandPalette } from "@/components/layout/command-palette";
 
 const routeTitleOverrides: Record<string, string> = {
   "/ai-agent2": "智能助手",
@@ -41,6 +41,7 @@ function isTypingElement(target: EventTarget | null): boolean {
 
 export function Header() {
   const pathname = usePathname();
+  const router = useRouter();
   const [searchOpen, setSearchOpen] = useState(false);
 
   const title = getHeaderTitle(pathname);
@@ -85,7 +86,7 @@ export function Header() {
         <NotificationBell />
         <UserNav />
       </header>
-      <GlobalSearchDialog open={searchOpen} onClose={() => setSearchOpen(false)} />
+      <CommandPalette open={searchOpen} onClose={() => setSearchOpen(false)} />
     </>
   );
 }

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -47,15 +47,40 @@ export function Header() {
   const title = getHeaderTitle(pathname);
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
-    if (isTypingElement(e.target)) {
+    if (isTypingElement(e.target)) return;
+
+    const mod = e.metaKey || e.ctrlKey;
+    if (!mod) return;
+
+    const key = e.key;
+
+    if (key.toLowerCase() === "k") {
+      e.preventDefault();
+      setSearchOpen((v) => !v);
       return;
     }
 
-    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+    // Navigation shortcuts
+    const navMap: Record<string, string> = {
+      "1": "/templates",
+      "2": "/data",
+      "3": "/records",
+      "4": "/collections",
+      "5": "/reports/drafts",
+    };
+
+    if (navMap[key]) {
       e.preventDefault();
-      setSearchOpen((v) => !v);
+      router.push(navMap[key]);
+      return;
     }
-  }, []);
+
+    // Help shortcut
+    if (key === "/") {
+      e.preventDefault();
+      setSearchOpen(true);
+    }
+  }, [router]);
 
   useEffect(() => {
     document.addEventListener("keydown", handleKeyDown);

--- a/src/components/records/record-table-with-batch.tsx
+++ b/src/components/records/record-table-with-batch.tsx
@@ -63,7 +63,7 @@ export function RecordTableWithBatch({ records, isAdmin }: RecordTableProps) {
 
   const allSelected =
     records.length > 0 && selectedIds.size === records.length;
-  const someSelected = selectedIds.size > 0 && !allSelected;
+  const hasSelection = selectedIds.size > 0;
 
   function toggleAll() {
     if (allSelected) {
@@ -158,7 +158,7 @@ export function RecordTableWithBatch({ records, isAdmin }: RecordTableProps) {
 
   return (
     <>
-      {someSelected && (
+      {hasSelection && (
         <div className="px-4 pt-4">
           <SharedBatchActionBar
             selectedCount={selectedIds.size}
@@ -174,7 +174,7 @@ export function RecordTableWithBatch({ records, isAdmin }: RecordTableProps) {
             <TableHead className="w-[40px]">
               <Checkbox
                 checked={allSelected}
-                {...(someSelected ? { indeterminate: true } : {})}
+                {...(hasSelection && !allSelected ? { indeterminate: true } : {})}
                 onCheckedChange={toggleAll}
               />
             </TableHead>

--- a/src/components/records/record-table-with-batch.tsx
+++ b/src/components/records/record-table-with-batch.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import Link from "next/link";
 import * as XLSX from "xlsx";
 import { toast } from "sonner";
 import { Download, Eye, History, Trash2, FileDown } from "lucide-react";

--- a/src/components/records/record-table-with-batch.tsx
+++ b/src/components/records/record-table-with-batch.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import Link from "next/link";
+import * as XLSX from "xlsx";
+import { toast } from "sonner";
+import { Download, Eye, History, Trash2, FileDown } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button, LinkButton } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { SharedBatchActionBar } from "@/components/shared/batch-action-bar";
+import { EmptyState } from "@/components/shared";
+
+const STATUS_LABELS: Record<string, string> = {
+  PENDING: "待生成",
+  COMPLETED: "已完成",
+  FAILED: "失败",
+};
+
+const STATUS_VARIANTS: Record<string, "secondary" | "default" | "destructive"> = {
+  PENDING: "secondary",
+  COMPLETED: "default",
+  FAILED: "destructive",
+};
+
+const STATUS_BADGE_CLASS: Record<string, string> = {
+  PENDING: "border-border bg-muted text-foreground",
+  COMPLETED: "bg-primary text-primary-foreground",
+  FAILED: "bg-destructive text-destructive-foreground",
+};
+
+interface RecordTableProps {
+  records: Array<{
+    id: string;
+    templateName: string;
+    fileName: string | null;
+    status: string;
+    createdAt: string;
+  }>;
+  isAdmin: boolean;
+}
+
+export function RecordTableWithBatch({ records, isAdmin }: RecordTableProps) {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+
+  const allSelected =
+    records.length > 0 && selectedIds.size === records.length;
+  const someSelected = selectedIds.size > 0 && !allSelected;
+
+  function toggleAll() {
+    if (allSelected) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(records.map((r) => r.id)));
+    }
+  }
+
+  function toggleOne(id: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
+  function clearSelection() {
+    setSelectedIds(new Set());
+  }
+
+  const handleBatchDelete = useCallback(async () => {
+    try {
+      const res = await fetch("/api/records/batch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "delete", ids: [...selectedIds] }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        toast.success(`已删除 ${data.data.deleted} 条记录`);
+        clearSelection();
+        // Refresh the page to reflect changes
+        window.location.reload();
+      } else {
+        toast.error(data.error?.message || "删除失败");
+      }
+    } catch {
+      toast.error("删除失败");
+    } finally {
+      setDeleteDialogOpen(false);
+    }
+  }, [selectedIds]);
+
+  const handleBatchExport = useCallback(async () => {
+    try {
+      const res = await fetch("/api/records/batch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "export", ids: [...selectedIds] }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        const exportedRecords = data.data;
+        const headers = ["模板名称", "文件名", "状态", "生成时间"];
+        const rows = exportedRecords.map((r: any) => [
+          r.templateName ?? r.template?.name ?? "",
+          r.fileName ?? "",
+          STATUS_LABELS[r.status] ?? r.status,
+          new Date(r.createdAt).toLocaleDateString("zh-CN"),
+        ]);
+        const ws = XLSX.utils.aoa_to_sheet([headers, ...rows]);
+        const wb = XLSX.utils.book_new();
+        XLSX.utils.book_append_sheet(wb, ws, "生成记录");
+        XLSX.writeFile(wb, `生成记录_${selectedIds.size}条.xlsx`);
+        toast.success(`已导出 ${selectedIds.size} 条记录`);
+      } else {
+        toast.error(data.error?.message || "导出失败");
+      }
+    } catch {
+      toast.error("导出失败");
+    }
+  }, [selectedIds]);
+
+  const batchActions = [
+    {
+      label: "导出 Excel",
+      icon: <FileDown className="h-3.5 w-3.5" />,
+      onClick: handleBatchExport,
+    },
+    {
+      label: "批量删除",
+      icon: <Trash2 className="h-3.5 w-3.5" />,
+      onClick: () => setDeleteDialogOpen(true),
+      variant: "destructive" as const,
+    },
+  ];
+
+  return (
+    <>
+      {someSelected && (
+        <div className="px-4 pt-4">
+          <SharedBatchActionBar
+            selectedCount={selectedIds.size}
+            actions={batchActions}
+            onClearSelection={clearSelection}
+          />
+        </div>
+      )}
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[40px]">
+              <Checkbox
+                checked={allSelected}
+                {...(someSelected ? { indeterminate: true } : {})}
+                onCheckedChange={toggleAll}
+              />
+            </TableHead>
+            <TableHead className="w-[30%]">模板名称</TableHead>
+            <TableHead className="w-[160px]">生成时间</TableHead>
+            <TableHead className="w-[100px]">状态</TableHead>
+            <TableHead>文件名</TableHead>
+            <TableHead className="w-[160px] text-right">操作</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {records.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={6}>
+                <EmptyState
+                  icon={History}
+                  title="暂无生成记录"
+                  description="填写模板表单即可生成文档"
+                  action={
+                    <LinkButton variant="link" size="sm" href="/templates">
+                      前往模板列表填写表单
+                    </LinkButton>
+                  }
+                />
+              </TableCell>
+            </TableRow>
+          ) : (
+            records.map((record) => (
+              <TableRow key={record.id}>
+                <TableCell>
+                  <Checkbox
+                    checked={selectedIds.has(record.id)}
+                    onCheckedChange={() => toggleOne(record.id)}
+                  />
+                </TableCell>
+                <TableCell className="font-[510] text-foreground">
+                  {record.templateName}
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {new Date(record.createdAt).toLocaleDateString("zh-CN", {
+                    year: "numeric",
+                    month: "2-digit",
+                    day: "2-digit",
+                  })}
+                </TableCell>
+                <TableCell>
+                  <Badge
+                    variant={
+                      STATUS_VARIANTS[record.status] as
+                        | "secondary"
+                        | "default"
+                        | "destructive"
+                    }
+                    className={STATUS_BADGE_CLASS[record.status] ?? ""}
+                  >
+                    {STATUS_LABELS[record.status] ?? record.status}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {record.fileName || "-"}
+                </TableCell>
+                <TableCell className="text-right">
+                  <div className="flex items-center justify-end gap-1">
+                    {record.status === "COMPLETED" && record.fileName && (
+                      <a
+                        href={`/api/records/${record.id}/download`}
+                        className="inline-flex items-center gap-1 px-2 py-1 text-xs font-[510] text-foreground/90 transition-colors hover:text-foreground"
+                      >
+                        <Download className="h-3.5 w-3.5" />
+                      </a>
+                    )}
+                    <LinkButton
+                      variant="ghost"
+                      size="sm"
+                      className="text-foreground hover:text-foreground"
+                      href={`/records/${record.id}`}
+                    >
+                      <Eye className="h-3.5 w-3.5" />
+                      查看
+                    </LinkButton>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>确认删除</AlertDialogTitle>
+            <AlertDialogDescription>
+              确定要删除选中的 {selectedIds.size} 条记录吗？此操作不可撤销。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>取消</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={handleBatchDelete}
+            >
+              删除
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/components/shared/batch-action-bar.tsx
+++ b/src/components/shared/batch-action-bar.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { X } from "lucide-react";
+
+export interface BatchAction {
+  label: string;
+  icon?: React.ReactNode;
+  onClick: () => void;
+  variant?: "default" | "destructive";
+}
+
+interface SharedBatchActionBarProps {
+  selectedCount: number;
+  actions: BatchAction[];
+  onClearSelection: () => void;
+}
+
+export function SharedBatchActionBar({
+  selectedCount,
+  actions,
+  onClearSelection,
+}: SharedBatchActionBarProps) {
+  return (
+    <div className="flex items-center gap-2 px-3 py-1.5 bg-primary/10 border rounded-md text-sm">
+      <span className="font-medium">已选择 {selectedCount} 条</span>
+      <div className="h-4 w-px bg-border" />
+      {actions.map((action) => (
+        <Button
+          key={action.label}
+          variant="ghost"
+          size="sm"
+          className={`h-7 text-xs gap-1 ${action.variant === "destructive" ? "text-destructive hover:text-destructive" : ""}`}
+          onClick={action.onClick}
+        >
+          {action.icon}
+          {action.label}
+        </Button>
+      ))}
+      <div className="h-4 w-px bg-border" />
+      <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={onClearSelection}>
+        <X className="h-3 w-3" />
+      </Button>
+    </div>
+  );
+}

--- a/src/components/templates/template-table-with-batch.tsx
+++ b/src/components/templates/template-table-with-batch.tsx
@@ -1,0 +1,479 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Trash2, Pencil, Eye, FileText, ArrowRight } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button, LinkButton } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { SharedBatchActionBar, type BatchAction } from "@/components/shared/batch-action-bar";
+import { EmptyState } from "@/components/shared";
+import { TemplateListDeleteButton } from "@/app/(dashboard)/templates/template-list-delete-button";
+
+const STATUS_LABELS: Record<string, string> = {
+  DRAFT: "草稿",
+  PUBLISHED: "已发布",
+  ARCHIVED: "已归档",
+};
+
+const STATUS_VARIANTS: Record<string, "secondary" | "default" | "destructive"> = {
+  DRAFT: "secondary",
+  PUBLISHED: "default",
+  ARCHIVED: "destructive",
+};
+
+interface TemplateTableProps {
+  templates: Array<{
+    id: string;
+    name: string;
+    status: string;
+    createdAt: Date;
+    createdBy: { name: string };
+    category: { name: string } | null;
+    tags: Array<{ tag: { id: string; name: string } }>;
+    currentVersion: { version: number } | null;
+  }>;
+  categories: Array<{ id: string; name: string }>;
+  isAdmin: boolean;
+}
+
+export function TemplateTableWithBatch({
+  templates,
+  categories,
+  isAdmin,
+}: TemplateTableProps) {
+  const router = useRouter();
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  // Dialog state
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [statusDialogOpen, setStatusDialogOpen] = useState(false);
+  const [categoryDialogOpen, setCategoryDialogOpen] = useState(false);
+
+  // Status/category selection
+  const [targetStatus, setTargetStatus] = useState<string>("");
+  const [targetCategoryId, setTargetCategoryId] = useState<string>("");
+
+  // Loading state
+  const [loading, setLoading] = useState(false);
+
+  // Selection handlers
+  const toggleSelect = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleSelectAll = useCallback(() => {
+    if (selectedIds.size === templates.length) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(templates.map((t) => t.id)));
+    }
+  }, [selectedIds.size, templates]);
+
+  const clearSelection = useCallback(() => {
+    setSelectedIds(new Set());
+  }, []);
+
+  // Batch operations
+  const handleBatchDelete = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/templates/batch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "delete", ids: Array.from(selectedIds) }),
+      });
+      if (res.ok) {
+        toast.success(`已删除 ${selectedIds.size} 个模板`);
+        clearSelection();
+        setDeleteDialogOpen(false);
+        router.refresh();
+      } else {
+        const data = await res.json().catch(() => null);
+        toast.error(data?.error?.message || "批量删除失败");
+      }
+    } catch {
+      toast.error("批量删除失败，请重试");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleBatchUpdateStatus = async () => {
+    if (!targetStatus) return;
+    setLoading(true);
+    try {
+      const res = await fetch("/api/templates/batch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "updateStatus",
+          ids: Array.from(selectedIds),
+          payload: { status: targetStatus },
+        }),
+      });
+      if (res.ok) {
+        toast.success(`已将 ${selectedIds.size} 个模板状态更新为「${STATUS_LABELS[targetStatus]}」`);
+        clearSelection();
+        setStatusDialogOpen(false);
+        setTargetStatus("");
+        router.refresh();
+      } else {
+        const data = await res.json().catch(() => null);
+        toast.error(data?.error?.message || "批量更新状态失败");
+      }
+    } catch {
+      toast.error("批量更新状态失败，请重试");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleBatchUpdateCategory = async () => {
+    if (!targetCategoryId) return;
+    setLoading(true);
+    try {
+      const res = await fetch("/api/templates/batch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "updateCategory",
+          ids: Array.from(selectedIds),
+          payload: { categoryId: targetCategoryId },
+        }),
+      });
+      if (res.ok) {
+        const categoryName =
+          targetCategoryId === "__none__"
+            ? "无分类"
+            : categories.find((c) => c.id === targetCategoryId)?.name ?? "";
+        toast.success(`已将 ${selectedIds.size} 个模板分类更新为「${categoryName}」`);
+        clearSelection();
+        setCategoryDialogOpen(false);
+        setTargetCategoryId("");
+        router.refresh();
+      } else {
+        const data = await res.json().catch(() => null);
+        toast.error(data?.error?.message || "批量更新分类失败");
+      }
+    } catch {
+      toast.error("批量更新分类失败，请重试");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Batch action bar actions (admin only)
+  const batchActions: BatchAction[] = isAdmin
+    ? [
+        {
+          label: "修改状态",
+          icon: <Pencil className="h-3.5 w-3.5" />,
+          onClick: () => setStatusDialogOpen(true),
+        },
+        {
+          label: "修改分类",
+          icon: <ArrowRight className="h-3.5 w-3.5" />,
+          onClick: () => setCategoryDialogOpen(true),
+        },
+        {
+          label: "批量删除",
+          icon: <Trash2 className="h-3.5 w-3.5" />,
+          onClick: () => setDeleteDialogOpen(true),
+          variant: "destructive",
+        },
+      ]
+    : [];
+
+  const allSelected = templates.length > 0 && selectedIds.size === templates.length;
+
+  return (
+    <>
+      {/* Batch action bar */}
+      {selectedIds.size > 0 && (
+        <div className="border-b px-4 pt-3 pb-2">
+          <SharedBatchActionBar
+            selectedCount={selectedIds.size}
+            actions={batchActions}
+            onClearSelection={clearSelection}
+          />
+        </div>
+      )}
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[40px]">
+              <Checkbox
+                checked={allSelected}
+                onCheckedChange={toggleSelectAll}
+              />
+            </TableHead>
+            <TableHead className="w-[100px]">分类</TableHead>
+            <TableHead className="w-[30%]">名称</TableHead>
+            <TableHead>版本</TableHead>
+            <TableHead className="w-[150px]">标签</TableHead>
+            <TableHead className="w-[100px]">状态</TableHead>
+            <TableHead className="w-[100px]">创建者</TableHead>
+            <TableHead className="w-[160px]">创建时间</TableHead>
+            <TableHead className="w-[160px] text-right">操作</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {templates.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={9}>
+                <EmptyState
+                  icon={FileText}
+                  title="暂无模板数据"
+                  description={isAdmin ? "上传第一个模板来开始管理您的文档" : undefined}
+                  action={
+                    isAdmin ? (
+                      <LinkButton variant="link" size="sm" href="/templates/new">
+                        上传第一个模板
+                      </LinkButton>
+                    ) : undefined
+                  }
+                />
+              </TableCell>
+            </TableRow>
+          ) : (
+            templates.map((template) => (
+              <TableRow key={template.id}>
+                <TableCell>
+                  <Checkbox
+                    checked={selectedIds.has(template.id)}
+                    onCheckedChange={() => toggleSelect(template.id)}
+                  />
+                </TableCell>
+                <TableCell>
+                  {template.category ? (
+                    <Badge variant="secondary">{template.category.name}</Badge>
+                  ) : (
+                    <span className="text-muted-foreground text-xs">—</span>
+                  )}
+                </TableCell>
+                <TableCell className="font-[510] text-foreground">
+                  {template.name}
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {template.currentVersion ? `v${template.currentVersion.version}` : "—"}
+                </TableCell>
+                <TableCell>
+                  <div className="flex flex-wrap gap-1">
+                    {template.tags.length === 0 ? (
+                      <span className="text-xs text-muted-foreground">—</span>
+                    ) : (
+                      <>
+                        {template.tags.slice(0, 3).map((t) => (
+                          <Badge key={t.tag.id} variant="outline" className="text-xs">
+                            {t.tag.name}
+                          </Badge>
+                        ))}
+                        {template.tags.length > 3 && (
+                          <span className="text-xs text-muted-foreground">
+                            +{template.tags.length - 3}
+                          </span>
+                        )}
+                      </>
+                    )}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <Badge variant={STATUS_VARIANTS[template.status]}>
+                    {STATUS_LABELS[template.status]}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {template.createdBy.name}
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {template.createdAt.toLocaleDateString("zh-CN", {
+                    year: "numeric",
+                    month: "2-digit",
+                    day: "2-digit",
+                  })}
+                </TableCell>
+                <TableCell className="text-right">
+                  <div className="flex items-center justify-end gap-1">
+                    <LinkButton
+                      variant="ghost"
+                      size="icon-xs"
+                      className="text-muted-foreground hover:text-foreground"
+                      href={`/templates/${template.id}`}
+                    >
+                      <Eye className="h-3.5 w-3.5" />
+                      <span className="sr-only">查看</span>
+                    </LinkButton>
+                    {isAdmin && (
+                      <>
+                        <LinkButton
+                          variant="ghost"
+                          size="icon-xs"
+                          className="text-muted-foreground hover:text-foreground"
+                          href={`/templates/${template.id}/edit`}
+                        >
+                          <Pencil className="h-3.5 w-3.5" />
+                          <span className="sr-only">编辑</span>
+                        </LinkButton>
+                        <TemplateListDeleteButton
+                          templateId={template.id}
+                          templateName={template.name}
+                        />
+                      </>
+                    )}
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+
+      {/* Batch delete confirmation dialog */}
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>确认批量删除</AlertDialogTitle>
+            <AlertDialogDescription>
+              确定要删除选中的 {selectedIds.size} 个模板吗？此操作不可撤销，所有关联的占位符、草稿和生成记录将被永久删除。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>取消</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={handleBatchDelete}
+              disabled={loading}
+            >
+              {loading ? "删除中..." : "确认删除"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Batch update status dialog */}
+      <Dialog open={statusDialogOpen} onOpenChange={setStatusDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>批量修改状态</DialogTitle>
+            <DialogDescription>
+              将选中的 {selectedIds.size} 个模板状态修改为：
+            </DialogDescription>
+          </DialogHeader>
+          <Select value={targetStatus} onValueChange={(v) => v && setTargetStatus(v)}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="选择目标状态" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="DRAFT">草稿</SelectItem>
+              <SelectItem value="PUBLISHED">已发布</SelectItem>
+              <SelectItem value="ARCHIVED">已归档</SelectItem>
+            </SelectContent>
+          </Select>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setStatusDialogOpen(false);
+                setTargetStatus("");
+              }}
+              disabled={loading}
+            >
+              取消
+            </Button>
+            <Button onClick={handleBatchUpdateStatus} disabled={loading || !targetStatus}>
+              {loading ? "更新中..." : "确认修改"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Batch update category dialog */}
+      <Dialog open={categoryDialogOpen} onOpenChange={setCategoryDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>批量修改分类</DialogTitle>
+            <DialogDescription>
+              将选中的 {selectedIds.size} 个模板分类修改为：
+            </DialogDescription>
+          </DialogHeader>
+          <Select value={targetCategoryId} onValueChange={(v) => v && setTargetCategoryId(v)}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="选择目标分类" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__none__">无分类</SelectItem>
+              {categories.map((cat) => (
+                <SelectItem key={cat.id} value={cat.id}>
+                  {cat.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setCategoryDialogOpen(false);
+                setTargetCategoryId("");
+              }}
+              disabled={loading}
+            >
+              取消
+            </Button>
+            <Button
+              onClick={handleBatchUpdateCategory}
+              disabled={loading || !targetCategoryId}
+            >
+              {loading ? "更新中..." : "确认修改"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/hooks/use-command-palette.tsx
+++ b/src/hooks/use-command-palette.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useMemo } from "react";
+import {
+  LayoutGrid,
+  Database,
+  FileText,
+  Upload,
+  FilePenLine,
+  Calculator,
+  Zap,
+  BookOpen,
+  Bot,
+} from "lucide-react";
+
+export interface CommandItem {
+  id: string;
+  label: string;
+  icon?: React.ReactNode;
+  shortcut?: string;
+  onSelect: () => void;
+  group: string;
+  keywords?: string[];
+}
+
+const NAV_COMMANDS = [
+  { id: "nav-templates", label: "模板库", href: "/templates", icon: LayoutGrid, shortcut: "⌘1", keywords: ["moban", "模板"] },
+  { id: "nav-generate", label: "我要填表", href: "/generate", icon: Upload, keywords: ["tianbiao", "填表", "生成"] },
+  { id: "nav-records", label: "生成记录", href: "/records", icon: FileText, shortcut: "⌘3", keywords: ["jilu", "记录"] },
+  { id: "nav-drafts", label: "我的草稿", href: "/drafts", icon: FilePenLine, keywords: ["caogao", "草稿"] },
+  { id: "nav-data", label: "数据表", href: "/data", icon: Database, shortcut: "⌘2", keywords: ["shuju", "数据"] },
+  { id: "nav-reports", label: "撰写报告", href: "/reports/drafts", icon: BookOpen, keywords: ["baogao", "报告"] },
+  { id: "nav-report-templates", label: "报告模板", href: "/reports/templates", icon: LayoutGrid, keywords: ["baogao", "报告", "模板"] },
+  { id: "nav-budget", label: "预算报告", href: "/budget", icon: Calculator, keywords: ["yusuan", "预算"] },
+  { id: "nav-automations", label: "自动化", href: "/automations", icon: Zap, keywords: ["zidonghua", "自动"] },
+  { id: "nav-collections", label: "文档收集", href: "/collections", icon: FileText, shortcut: "⌘4", keywords: ["shouji", "收集"] },
+  { id: "nav-ai", label: "智能助手", href: "/ai-agent2", icon: Bot, keywords: ["zhineng", "助手", "AI"] },
+];
+
+export function useCommands() {
+  const router = useRouter();
+
+  const commands = useMemo<CommandItem[]>(() => {
+    const navItems: CommandItem[] = NAV_COMMANDS.map((cmd) => ({
+      id: cmd.id,
+      label: cmd.label,
+      icon: <cmd.icon className="h-4 w-4" />,
+      shortcut: cmd.shortcut,
+      keywords: cmd.keywords,
+      group: "导航",
+      onSelect: () => router.push(cmd.href),
+    }));
+
+    return navItems;
+  }, [router]);
+
+  return commands;
+}

--- a/src/lib/services/export.service.ts
+++ b/src/lib/services/export.service.ts
@@ -26,7 +26,8 @@ export interface TableExportData {
 // ── Shared Data Fetcher ──
 
 export async function getTableExportData(
-  tableId: string
+  tableId: string,
+  selectedIds?: string[]
 ): Promise<ServiceResult<TableExportData>> {
   const tableResult = await getTable(tableId);
   if (!tableResult.success) {
@@ -36,7 +37,10 @@ export async function getTableExportData(
   const table = tableResult.data;
 
   const records = await db.dataRecord.findMany({
-    where: { tableId },
+    where: {
+      tableId,
+      ...(selectedIds ? { id: { in: selectedIds } } : {}),
+    },
     orderBy: { createdAt: "asc" },
   });
 
@@ -137,10 +141,11 @@ export function exportRecordToExcel(
 
 export async function exportToExcel(
   tableId: string,
-  options?: ExcelExportOptions
+  options?: ExcelExportOptions,
+  selectedIds?: string[]
 ): Promise<ServiceResult<Buffer>> {
   try {
-    const dataResult = await getTableExportData(tableId);
+    const dataResult = await getTableExportData(tableId, selectedIds);
     if (!dataResult.success) {
       return { success: false, error: dataResult.error };
     }
@@ -193,10 +198,11 @@ export interface ExportJSON {
 }
 
 export async function exportToJSON(
-  tableId: string
+  tableId: string,
+  selectedIds?: string[]
 ): Promise<ServiceResult<ExportJSON>> {
   try {
-    const dataResult = await getTableExportData(tableId);
+    const dataResult = await getTableExportData(tableId, selectedIds);
     if (!dataResult.success) {
       return { success: false, error: dataResult.error };
     }

--- a/src/lib/services/search.service.ts
+++ b/src/lib/services/search.service.ts
@@ -79,3 +79,219 @@ export async function globalSearch(
     };
   }
 }
+
+export interface TemplateSearchItem {
+  id: string;
+  name: string;
+  description: string | null;
+  status: string;
+  categoryName: string | null;
+}
+
+export async function searchTemplates(
+  query: string,
+  limit: number = 5
+): Promise<ServiceResult<TemplateSearchItem[]>> {
+  try {
+    const templates = await db.template.findMany({
+      where: {
+        OR: [
+          { name: { contains: query, mode: "insensitive" } },
+          { description: { contains: query, mode: "insensitive" } },
+          { tags: { some: { tag: { name: { contains: query, mode: "insensitive" } } } } },
+        ],
+      },
+      take: limit,
+      orderBy: { updatedAt: "desc" },
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        status: true,
+        category: { select: { name: true } },
+      },
+    });
+    return {
+      success: true,
+      data: templates.map((t) => ({
+        id: t.id,
+        name: t.name,
+        description: t.description,
+        status: t.status,
+        categoryName: t.category?.name ?? null,
+      })),
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: { code: "SEARCH_TEMPLATES_ERROR", message: error instanceof Error ? error.message : "搜索模板失败" },
+    };
+  }
+}
+
+export interface RecordSearchItem {
+  id: string;
+  fileName: string | null;
+  templateName: string;
+  status: string;
+  createdAt: string;
+}
+
+export async function searchRecords(
+  query: string,
+  limit: number = 5
+): Promise<ServiceResult<RecordSearchItem[]>> {
+  try {
+    const records = await db.record.findMany({
+      where: {
+        OR: [
+          { fileName: { contains: query, mode: "insensitive" } },
+          { template: { name: { contains: query, mode: "insensitive" } } },
+        ],
+      },
+      take: limit,
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        fileName: true,
+        status: true,
+        createdAt: true,
+        template: { select: { name: true } },
+      },
+    });
+    return {
+      success: true,
+      data: records.map((r) => ({
+        id: r.id,
+        fileName: r.fileName,
+        templateName: r.template.name,
+        status: r.status,
+        createdAt: r.createdAt.toISOString(),
+      })),
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: { code: "SEARCH_RECORDS_ERROR", message: error instanceof Error ? error.message : "搜索记录失败" },
+    };
+  }
+}
+
+export interface CollectionTaskSearchItem {
+  id: string;
+  title: string;
+  description: string | null;
+  status: string;
+}
+
+export async function searchCollectionTasks(
+  query: string,
+  limit: number = 5
+): Promise<ServiceResult<CollectionTaskSearchItem[]>> {
+  try {
+    const tasks = await db.documentCollectionTask.findMany({
+      where: {
+        OR: [
+          { title: { contains: query, mode: "insensitive" } },
+          { instruction: { contains: query, mode: "insensitive" } },
+        ],
+      },
+      take: limit,
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        title: true,
+        instruction: true,
+        status: true,
+      },
+    });
+    return {
+      success: true,
+      data: tasks.map((t) => ({
+        id: t.id,
+        title: t.title,
+        description: t.instruction,
+        status: t.status,
+      })),
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: { code: "SEARCH_COLLECTIONS_ERROR", message: error instanceof Error ? error.message : "搜索收集任务失败" },
+    };
+  }
+}
+
+export interface ReportTemplateSearchItem {
+  id: string;
+  name: string;
+  originalFilename: string;
+}
+
+export async function searchReportTemplates(
+  query: string,
+  limit: number = 5
+): Promise<ServiceResult<ReportTemplateSearchItem[]>> {
+  try {
+    const templates = await db.reportTemplate.findMany({
+      where: {
+        OR: [
+          { name: { contains: query, mode: "insensitive" } },
+          { originalFilename: { contains: query, mode: "insensitive" } },
+        ],
+      },
+      take: limit,
+      orderBy: { updatedAt: "desc" },
+      select: {
+        id: true,
+        name: true,
+        originalFilename: true,
+      },
+    });
+    return {
+      success: true,
+      data: templates.map((t) => ({
+        id: t.id,
+        name: t.name,
+        originalFilename: t.originalFilename,
+      })),
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: { code: "SEARCH_REPORTS_ERROR", message: error instanceof Error ? error.message : "搜索报告模板失败" },
+    };
+  }
+}
+
+export interface UnifiedSearchResult {
+  templates: TemplateSearchItem[];
+  records: RecordSearchItem[];
+  dataRecords: SearchTableResult[];
+  collectionTasks: CollectionTaskSearchItem[];
+  reportTemplates: ReportTemplateSearchItem[];
+}
+
+export async function unifiedSearch(
+  query: string,
+  limit: number = 5
+): Promise<ServiceResult<UnifiedSearchResult>> {
+  const [templatesRes, recordsRes, dataRecordsRes, collectionsRes, reportsRes] = await Promise.all([
+    searchTemplates(query, limit),
+    searchRecords(query, limit),
+    globalSearch(query, limit),
+    searchCollectionTasks(query, limit),
+    searchReportTemplates(query, limit),
+  ]);
+
+  return {
+    success: true,
+    data: {
+      templates: templatesRes.success ? templatesRes.data : [],
+      records: recordsRes.success ? recordsRes.data : [],
+      dataRecords: dataRecordsRes.success ? dataRecordsRes.data : [],
+      collectionTasks: collectionsRes.success ? collectionsRes.data : [],
+      reportTemplates: reportsRes.success ? reportsRes.data : [],
+    },
+  };
+}

--- a/src/lib/services/search.service.ts
+++ b/src/lib/services/search.service.ts
@@ -90,11 +90,13 @@ export interface TemplateSearchItem {
 
 export async function searchTemplates(
   query: string,
-  limit: number = 5
+  limit: number = 5,
+  isAdmin: boolean = false
 ): Promise<ServiceResult<TemplateSearchItem[]>> {
   try {
     const templates = await db.template.findMany({
       where: {
+        ...(!isAdmin ? { status: "PUBLISHED" } : {}),
         OR: [
           { name: { contains: query, mode: "insensitive" } },
           { description: { contains: query, mode: "insensitive" } },
@@ -139,11 +141,14 @@ export interface RecordSearchItem {
 
 export async function searchRecords(
   query: string,
-  limit: number = 5
+  limit: number = 5,
+  userId?: string,
+  isAdmin: boolean = false
 ): Promise<ServiceResult<RecordSearchItem[]>> {
   try {
     const records = await db.record.findMany({
       where: {
+        ...(!isAdmin && userId ? { userId } : {}),
         OR: [
           { fileName: { contains: query, mode: "insensitive" } },
           { template: { name: { contains: query, mode: "insensitive" } } },
@@ -274,11 +279,13 @@ export interface UnifiedSearchResult {
 
 export async function unifiedSearch(
   query: string,
-  limit: number = 5
+  limit: number = 5,
+  userId?: string,
+  isAdmin: boolean = false
 ): Promise<ServiceResult<UnifiedSearchResult>> {
   const [templatesRes, recordsRes, dataRecordsRes, collectionsRes, reportsRes] = await Promise.all([
-    searchTemplates(query, limit),
-    searchRecords(query, limit),
+    searchTemplates(query, limit, isAdmin),
+    searchRecords(query, limit, userId, isAdmin),
     globalSearch(query, limit),
     searchCollectionTasks(query, limit),
     searchReportTemplates(query, limit),


### PR DESCRIPTION
## Summary

- **命令面板**：用 cmdk 替换原有全局搜索，支持多数据源搜索（模板、记录、数据表、收集任务、报告模板）、`>` 命令模式、最近搜索历史
- **全局快捷键**：`⌘1~5` 快速导航到各页面，`⌘/` 打开命令面板
- **批量操作**：模板页（多选/删除/更改状态/更改分类）、记录页（多选/删除/导出 Excel）、数据表（导出选中记录）
- **导出优化**：模板/记录列表页增加 Excel 导出按钮，数据表支持选中记录导出

## Test plan
- [x] Ctrl+K 打开命令面板，搜索返回多数据源结果
- [x] 输入 `>` 进入命令模式，过滤导航命令
- [x] 无输入时显示最近搜索历史
- [x] Ctrl+1~5 全局导航快捷键正常
- [x] 模板页 checkbox 批量选择 + 批量操作（删除/状态/分类）
- [x] 记录页 checkbox 批量选择 + 批量导出/删除
- [x] 模板/记录页导出按钮可点击
- [x] 数据表批量操作栏增加"导出选中"
- [x] `tsc --noEmit` 通过
- [x] `lint` 无新增错误

Closes #154

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)