### PR TITLE
[Feature] 配置项说明文字 Tooltip

### DIFF
--- a/src/components/automations/automation-config-panel.tsx
+++ b/src/components/automations/automation-config-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Input } from "@/components/ui/input";
+import { HelpTooltip } from "@/components/shared/help-tooltip";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type {
@@ -110,7 +111,7 @@ export function AutomationConfigPanel({
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-2">
-            <label className="text-sm font-[520] text-foreground">触发类型</label>
+            <label className="text-sm font-[520] text-foreground">触发类型 <HelpTooltip text="选择什么事件触发自动化：记录创建/更新/删除、字段变更、定时或手动" /></label>
             <select
               className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm text-foreground"
               value={trigger.type}
@@ -145,7 +146,7 @@ export function AutomationConfigPanel({
 
           {trigger.type === "field_changed" && (
             <div className="space-y-2">
-              <label className="text-sm font-[520] text-foreground">监听字段</label>
+              <label className="text-sm font-[520] text-foreground">监听字段 <HelpTooltip text="选择要监听变更的字段，仅该字段值变化时触发" /></label>
               <Input
                 value={trigger.fieldKey}
                 onChange={(event) =>
@@ -158,7 +159,7 @@ export function AutomationConfigPanel({
           {trigger.type === "schedule" && (
             <div className="grid gap-3">
               <div className="space-y-2">
-                <label className="text-sm font-[520] text-foreground">执行频率</label>
+                <label className="text-sm font-[520] text-foreground">执行频率 <HelpTooltip text="定时触发的执行间隔：每小时、每天、每周、每月" /></label>
                 <select
                   className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm text-foreground"
                   value={trigger.schedule.mode}
@@ -178,7 +179,7 @@ export function AutomationConfigPanel({
                 </select>
               </div>
               <div className="space-y-2">
-                <label className="text-sm font-[520] text-foreground">时间</label>
+                <label className="text-sm font-[520] text-foreground">时间 <HelpTooltip text="定时触发的具体执行时间" /></label>
                 <Input
                   value={trigger.schedule.time}
                   onChange={(event) =>
@@ -217,7 +218,7 @@ export function AutomationConfigPanel({
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-2">
-            <label className="text-sm font-[520] text-foreground">逻辑关系</label>
+            <label className="text-sm font-[520] text-foreground">逻辑关系 <HelpTooltip text="多个条件之间的逻辑关系：AND（全部满足）或 OR（任一满足）" /></label>
             <select
               className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm text-foreground"
               value={condition.operator}
@@ -237,7 +238,7 @@ export function AutomationConfigPanel({
             </select>
           </div>
           <div className="space-y-2">
-            <label className="text-sm font-[520] text-foreground">字段路径</label>
+            <label className="text-sm font-[520] text-foreground">字段路径 <HelpTooltip text="要检查的字段标识，如 `status`、`amount`" /></label>
             <Input
               value={firstLeaf.field}
               onChange={(event) =>
@@ -252,7 +253,7 @@ export function AutomationConfigPanel({
             />
           </div>
           <div className="space-y-2">
-            <label className="text-sm font-[520] text-foreground">操作符</label>
+            <label className="text-sm font-[520] text-foreground">操作符 <HelpTooltip text="字段值与比较值之间的关系：等于、不等于、包含、大于、小于等" /></label>
             <select
               className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm text-foreground"
               value={firstLeaf.op}
@@ -279,7 +280,7 @@ export function AutomationConfigPanel({
             </select>
           </div>
           <div className="space-y-2">
-            <label className="text-sm font-[520] text-foreground">比较值</label>
+            <label className="text-sm font-[520] text-foreground">比较值 <HelpTooltip text="与字段值进行比较的目标值" /></label>
             <Input
               value={String(firstLeaf.value ?? "")}
               onChange={(event) =>
@@ -313,7 +314,7 @@ export function AutomationConfigPanel({
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="space-y-2">
-          <label className="text-sm font-[520] text-foreground">动作类型</label>
+          <label className="text-sm font-[520] text-foreground">动作类型 <HelpTooltip text="触发后执行的操作类型" /></label>
           <select
             className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm text-foreground"
             value={action.type}
@@ -336,7 +337,7 @@ export function AutomationConfigPanel({
         {action.type === "update_field" && (
           <>
             <div className="space-y-2">
-              <label className="text-sm font-[520] text-foreground">字段 Key</label>
+              <label className="text-sm font-[520] text-foreground">字段 Key <HelpTooltip text="要更新的字段标识，对应数据表中的字段" /></label>
               <Input
                 value={(action as UpdateFieldAction).fieldKey}
                 onChange={(event) =>
@@ -350,7 +351,7 @@ export function AutomationConfigPanel({
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-[520] text-foreground">写入值</label>
+              <label className="text-sm font-[520] text-foreground">写入值 <HelpTooltip text="更新为的新值，支持模板变量如 {{字段名}}" /></label>
               <Input
                 value={String((action as UpdateFieldAction).value ?? "")}
                 onChange={(event) =>
@@ -369,7 +370,7 @@ export function AutomationConfigPanel({
         {action.type === "create_record" && (
           <>
             <div className="space-y-2">
-              <label className="text-sm font-[520] text-foreground">目标数据表 ID</label>
+              <label className="text-sm font-[520] text-foreground">目标数据表 ID <HelpTooltip text="在哪个数据表中创建新记录" /></label>
               <Input
                 value={(action as CreateRecordAction).tableId}
                 onChange={(event) =>
@@ -383,7 +384,7 @@ export function AutomationConfigPanel({
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-[520] text-foreground">字段值 JSON</label>
+              <label className="text-sm font-[520] text-foreground">字段值 JSON <HelpTooltip text='新记录的字段值，JSON 格式。如 {"name": "测试", "status": "待处理"}' /></label>
               <Textarea
                 value={JSON.stringify((action as CreateRecordAction).values, null, 2)}
                 onChange={(event) => {
@@ -407,7 +408,7 @@ export function AutomationConfigPanel({
         {action.type === "update_related_records" && (
           <>
             <div className="space-y-2">
-              <label className="text-sm font-[520] text-foreground">关系字段 Key</label>
+              <label className="text-sm font-[520] text-foreground">关系字段 Key <HelpTooltip text="用于定位关联记录的关系字段标识" /></label>
               <Input
                 value={(action as UpdateRelatedRecordsAction).relationFieldKey}
                 onChange={(event) =>
@@ -421,7 +422,7 @@ export function AutomationConfigPanel({
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-[520] text-foreground">作用范围</label>
+              <label className="text-sm font-[520] text-foreground">作用范围 <HelpTooltip text="first：仅更新第一条关联记录；all：更新所有关联记录" /></label>
               <select
                 className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm text-foreground"
                 value={(action as UpdateRelatedRecordsAction).targetScope}
@@ -439,7 +440,7 @@ export function AutomationConfigPanel({
               </select>
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-[520] text-foreground">更新值 JSON</label>
+              <label className="text-sm font-[520] text-foreground">更新值 JSON <HelpTooltip text="关联记录更新的字段值，JSON 格式" /></label>
               <Textarea
                 value={JSON.stringify((action as UpdateRelatedRecordsAction).values, null, 2)}
                 onChange={(event) => {
@@ -463,7 +464,7 @@ export function AutomationConfigPanel({
         {action.type === "call_webhook" && (
           <>
             <div className="space-y-2">
-              <label className="text-sm font-[520] text-foreground">Webhook URL</label>
+              <label className="text-sm font-[520] text-foreground">Webhook URL <HelpTooltip text="接收请求的外部服务地址" /></label>
               <Input
                 value={(action as CallWebhookAction).url}
                 onChange={(event) =>
@@ -477,7 +478,7 @@ export function AutomationConfigPanel({
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-[520] text-foreground">请求方法</label>
+              <label className="text-sm font-[520] text-foreground">请求方法 <HelpTooltip text="HTTP 请求方法：GET、POST、PUT、DELETE" /></label>
               <select
                 className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm text-foreground"
                 value={(action as CallWebhookAction).method}
@@ -499,7 +500,7 @@ export function AutomationConfigPanel({
 
         {action.type === "add_comment" && (
           <div className="space-y-2">
-            <label className="text-sm font-[520] text-foreground">评论内容</label>
+            <label className="text-sm font-[520] text-foreground">评论内容 <HelpTooltip text="添加到记录上的评论文本，支持模板变量" /></label>
             <Textarea
               value={(action as AddCommentAction).content}
               onChange={(event) =>
@@ -517,7 +518,7 @@ export function AutomationConfigPanel({
         {action.type === "send_email" && (
           <>
             <div className="space-y-2">
-              <label className="text-sm font-[520] text-foreground">收件人</label>
+              <label className="text-sm font-[520] text-foreground">收件人 <HelpTooltip text="邮件接收者，支持模板变量如 {{email}}" /></label>
               <Input
                 value={(action as SendEmailAction).to}
                 onChange={(event) =>
@@ -531,7 +532,7 @@ export function AutomationConfigPanel({
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-[520] text-foreground">邮件主题</label>
+              <label className="text-sm font-[520] text-foreground">邮件主题 <HelpTooltip text="邮件标题，支持模板变量" /></label>
               <Input
                 value={(action as SendEmailAction).subject}
                 onChange={(event) =>
@@ -545,7 +546,7 @@ export function AutomationConfigPanel({
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-[520] text-foreground">邮件内容</label>
+              <label className="text-sm font-[520] text-foreground">邮件内容 <HelpTooltip text="邮件正文，支持模板变量和换行" /></label>
               <Textarea
                 value={(action as SendEmailAction).body}
                 onChange={(event) =>

--- a/src/components/automations/automation-editor.tsx
+++ b/src/components/automations/automation-editor.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { CircleAlert, Loader2, Save } from "lucide-react";
+import { HelpTooltip } from "@/components/shared/help-tooltip";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
@@ -226,7 +227,7 @@ export function AutomationEditor({
             <div className="space-y-4">
               {mode === "create" ? (
                 <div className="space-y-2">
-                  <label className="text-sm font-[520] text-foreground">目标数据表</label>
+                  <label className="text-sm font-[520] text-foreground">目标数据表 <HelpTooltip text="自动化操作的数据表，创建后不可修改" /></label>
                   <Select value={tableId} onValueChange={(nextValue) => setTableId(nextValue ?? "")}>
                     <SelectTrigger className="h-9 w-full" data-testid="automation-table-select-trigger">
                       <SelectValue placeholder="请选择数据表">
@@ -250,11 +251,11 @@ export function AutomationEditor({
                 </div>
               ) : null}
               <div className="space-y-2">
-                <label className="text-sm font-[520] text-foreground">自动化名称</label>
+                <label className="text-sm font-[520] text-foreground">自动化名称 <HelpTooltip text="为自动化规则命名，便于识别和管理" /></label>
                 <Input value={name} onChange={(event) => setName(event.target.value)} />
               </div>
               <div className="space-y-2">
-                <label className="text-sm font-[520] text-foreground">描述</label>
+                <label className="text-sm font-[520] text-foreground">描述 <HelpTooltip text="可选，描述自动化的用途和逻辑" /></label>
                 <Textarea
                   value={description}
                   onChange={(event) => setDescription(event.target.value)}
@@ -264,7 +265,7 @@ export function AutomationEditor({
 
             <div className="space-y-4 rounded-2xl border border-border/70 bg-background/70 p-4">
               <div className="space-y-2">
-                <p className="text-sm font-[520] text-foreground">启用状态</p>
+                <p className="text-sm font-[520] text-foreground">启用状态 <HelpTooltip text="开启后自动化规则立即生效，关闭则暂停" /></p>
                 <div className="flex items-center justify-between gap-3">
                   <span className="text-sm text-muted-foreground">
                     {enabled ? "当前自动生效" : "当前已停用"}

--- a/src/components/collections/collection-attachments-upload.tsx
+++ b/src/components/collections/collection-attachments-upload.tsx
@@ -3,6 +3,7 @@
 import { useRef } from "react";
 import { Paperclip } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { HelpTooltip } from "@/components/shared/help-tooltip";
 
 export function CollectionAttachmentsUpload({
   files,
@@ -17,7 +18,7 @@ export function CollectionAttachmentsUpload({
     <div className="space-y-3 rounded-lg border border-dashed p-4">
       <div className="flex items-center justify-between gap-3">
         <div>
-          <p className="text-sm font-medium">参考附件</p>
+          <p className="text-sm font-medium">参考附件 <HelpTooltip text="供提交人参考的示例文件或模板" /></p>
           <p className="text-xs text-muted-foreground">创建任务时会一并上传，供提交人查看和下载。</p>
         </div>
         <Button type="button" variant="outline" size="sm" onClick={() => inputRef.current?.click()}>

--- a/src/components/collections/collection-rename-rule-editor.tsx
+++ b/src/components/collections/collection-rename-rule-editor.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { HelpTooltip } from "@/components/shared/help-tooltip";
 
 const BUILTIN_VARIABLES = [
   "任务标题",
@@ -50,7 +51,7 @@ export function CollectionRenameRuleEditor({
   return (
     <div className="space-y-3">
       <div className="space-y-2">
-        <Label htmlFor="renameRule">文件命名规则</Label>
+        <Label htmlFor="renameRule">文件命名规则 <HelpTooltip text="提交文件的自动命名规则。支持变量：{姓名}、{任务标题}、自定义变量名" /></Label>
         <Input
           id="renameRule"
           aria-label="文件命名规则"

--- a/src/components/collections/collection-task-form.tsx
+++ b/src/components/collections/collection-task-form.tsx
@@ -13,6 +13,7 @@ import {
 } from "./collection-assignee-picker";
 import { CollectionAttachmentsUpload } from "./collection-attachments-upload";
 import { CollectionRenameRuleEditor } from "./collection-rename-rule-editor";
+import { HelpTooltip } from "@/components/shared/help-tooltip";
 
 interface CustomVariableRow {
   key: string;
@@ -109,7 +110,7 @@ export function CollectionTaskForm({
         <form className="space-y-6" onSubmit={handleSubmit}>
           <div className="grid gap-4 md:grid-cols-2">
             <div className="space-y-2 md:col-span-2">
-              <Label htmlFor="collection-title">任务标题</Label>
+              <Label htmlFor="collection-title">任务标题 <HelpTooltip text="文档收集任务的名称，也用于默认的文件命名" /></Label>
               <Input
                 id="collection-title"
                 value={title}
@@ -120,7 +121,7 @@ export function CollectionTaskForm({
             </div>
 
             <div className="space-y-2 md:col-span-2">
-              <Label htmlFor="collection-instruction">提交说明</Label>
+              <Label htmlFor="collection-instruction">提交说明 <HelpTooltip text="提交人看到的填写说明，如文件格式要求、注意事项" /></Label>
               <Textarea
                 id="collection-instruction"
                 value={instruction}
@@ -132,7 +133,7 @@ export function CollectionTaskForm({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="collection-due-at">截止时间</Label>
+              <Label htmlFor="collection-due-at">截止时间 <HelpTooltip text="提交的截止日期，过期后提交人无法提交" /></Label>
               <Input
                 id="collection-due-at"
                 type="datetime-local"
@@ -143,7 +144,7 @@ export function CollectionTaskForm({
             </div>
 
             <div className="space-y-2">
-              <Label>提交人</Label>
+              <Label>提交人 <HelpTooltip text="可以提交文档的人员列表" /></Label>
               <CollectionAssigneePicker
                 options={assigneeOptions}
                 value={assigneeIds}
@@ -154,7 +155,7 @@ export function CollectionTaskForm({
 
           <div className="space-y-3">
             <div className="flex items-center justify-between">
-              <Label>自定义变量</Label>
+              <Label>自定义变量 <HelpTooltip text="在文件命名规则中使用的额外变量。内置变量：{姓名}、{任务标题}；自定义变量可自行定义名称和预设值" /></Label>
               <Button
                 type="button"
                 variant="outline"

--- a/src/components/data/field-config-form.tsx
+++ b/src/components/data/field-config-form.tsx
@@ -35,6 +35,7 @@ import type { DataFieldInput } from "@/validators/data-table";
 import { FormulaEditor } from "@/components/data/formula-editor";
 import { parseFormula, evaluateFormula, detectCircularRefs } from "@/lib/formula";
 import { FieldTypeIcon } from "./field-type-icon";
+import { HelpTooltip } from "@/components/shared/help-tooltip";
 
 interface FieldConfigFormProps {
   open: boolean;
@@ -733,7 +734,7 @@ export function FieldConfigForm({
           <div className="grid gap-4 py-4 overflow-y-auto flex-1 min-h-0 px-4">
             <div className="grid gap-2">
               <Label htmlFor="key">
-                字段标识 <span className="text-red-500">*</span>
+                字段标识 <span className="text-red-500">*</span> <HelpTooltip text="字段在数据库中的唯一标识符，创建后不可修改。英文字母开头，仅支持小写字母、数字、下划线" />
               </Label>
               <Input
                 id="key"
@@ -747,7 +748,7 @@ export function FieldConfigForm({
 
             <div className="grid gap-2">
               <Label htmlFor="label">
-                显示名称 <span className="text-red-500">*</span>
+                显示名称 <span className="text-red-500">*</span> <HelpTooltip text="填表和列表中展示的字段名称，支持中文" />
               </Label>
               <Input
                 id="label"
@@ -758,7 +759,7 @@ export function FieldConfigForm({
             </div>
 
             <div className="grid gap-2">
-              <Label htmlFor="field-type-select">字段类型</Label>
+              <Label htmlFor="field-type-select">字段类型 <HelpTooltip text="选择字段存储的数据类型。创建后部分类型不可修改" /></Label>
               <Select
                 value={fieldType}
                 onValueChange={(value) => setFieldType(value as FieldType)}
@@ -789,14 +790,14 @@ export function FieldConfigForm({
               fieldType !== FieldType.AUTO_NUMBER && fieldType !== FieldType.SYSTEM_TIMESTAMP &&
               fieldType !== FieldType.SYSTEM_USER && (
               <div className="flex items-center justify-between">
-                <Label htmlFor="required">是否必填</Label>
+                <Label htmlFor="required">是否必填 <HelpTooltip text="开启后，填写表单时该字段不能为空" /></Label>
                 <Switch id="required" checked={required} onCheckedChange={setRequired} />
               </div>
             )}
 
             {(fieldType === FieldType.SELECT || fieldType === FieldType.MULTISELECT) && (
               <div className="grid gap-2">
-                <Label>选项列表</Label>
+                <Label>选项列表 <HelpTooltip text="单选/多选字段的可选值列表。可设置每个选项的颜色" /></Label>
                 <div className="space-y-2">
                   {selectOptions.map((opt, i) => (
                     <div key={i} className="flex items-center gap-2">
@@ -862,7 +863,7 @@ export function FieldConfigForm({
 
             {fieldType === FieldType.FORMULA && (
               <div className="grid gap-2">
-                <Label>公式表达式</Label>
+                <Label>公式表达式 <HelpTooltip text="根据 Excel 风格公式自动计算字段值，支持引用其他字段" /></Label>
                 <FormulaEditor
                   initialValue={formulaExpression}
                   fields={allFields}
@@ -875,7 +876,7 @@ export function FieldConfigForm({
 
             {fieldType === FieldType.COUNT && (
               <div className="grid gap-2">
-                <Label>计数字段</Label>
+                <Label>计数字段 <HelpTooltip text="自动统计关联记录数量，当关联记录增删时自动更新" /></Label>
                 {allFields.filter(
                   (f) => f.type === FieldType.RELATION || f.type === FieldType.RELATION_SUBTABLE
                 ).length === 0 ? (
@@ -915,7 +916,7 @@ export function FieldConfigForm({
 
             {fieldType === FieldType.LOOKUP && (
               <div className="grid gap-2">
-                <Label>源关联字段</Label>
+                <Label>源关联字段 <HelpTooltip text="选择一个关联当前表的关联字段，作为数据来源" /></Label>
                 {allFields.filter(
                   (f) => f.type === FieldType.RELATION || f.type === FieldType.RELATION_SUBTABLE
                 ).length === 0 ? (
@@ -964,7 +965,7 @@ export function FieldConfigForm({
                   if (targetTableFields.length === 0) return null;
                   return (
                     <>
-                      <Label>拉取字段</Label>
+                      <Label>拉取字段 <HelpTooltip text="从关联记录中拉取指定字段的值，只读展示" /></Label>
                       <Select
                         value={lookupTargetFieldKey}
                         onValueChange={(value) => setLookupTargetFieldKey(value ?? "")}
@@ -997,7 +998,7 @@ export function FieldConfigForm({
 
             {fieldType === FieldType.ROLLUP && (
               <div className="grid gap-2">
-                <Label>源关联字段</Label>
+                <Label>源关联字段 <HelpTooltip text="选择一个关联当前表的关联字段，作为数据来源" /></Label>
                 <Select value={rollupSourceFieldId} onValueChange={(value) => {
                   setRollupSourceFieldId(value ?? "");
                   setRollupTargetFieldKey("");
@@ -1037,7 +1038,7 @@ export function FieldConfigForm({
                   );
                   return (
                     <>
-                      <Label>汇总字段</Label>
+                      <Label>汇总字段 <HelpTooltip text="对关联记录的指定字段进行聚合计算" /></Label>
                       <Select value={rollupTargetFieldKey} onValueChange={(value) => {
                         setRollupTargetFieldKey(value ?? "");
                         setRollupAggregateType("");
@@ -1067,7 +1068,7 @@ export function FieldConfigForm({
                   const aggs = getAvailableRollupAggregates(targetField.type as FieldType);
                   return (
                     <>
-                      <Label>聚合方式</Label>
+                      <Label>聚合方式 <HelpTooltip text="选择聚合函数：求和、平均值、最大值、最小值、计数等" /></Label>
                       <Select value={rollupAggregateType} onValueChange={(v) => setRollupAggregateType(v as RollupAggregateType)}>
                         <SelectTrigger>
                           <SelectValue placeholder="选择聚合方式" />
@@ -1099,7 +1100,7 @@ export function FieldConfigForm({
                   if (condTargetFields.length === 0) return null;
                   return (
                     <>
-                      <Label>筛选条件（可选）</Label>
+                      <Label>筛选条件（可选） <HelpTooltip text="仅对满足条件的关联记录进行汇总计算" /></Label>
                       <p className="text-xs text-muted-foreground -mt-1">仅汇总满足条件的关联记录</p>
                       {rollupConditions.map((group, gi) => (
                         <div key={gi} className="border rounded-md p-2 space-y-2">
@@ -1264,7 +1265,7 @@ export function FieldConfigForm({
             {fieldType === FieldType.RATING && (
               <div className="grid gap-3">
                 <div className="grid gap-2">
-                  <Label htmlFor="rating-max">最大星数</Label>
+                  <Label htmlFor="rating-max">最大星数 <HelpTooltip text="评分字段的最大星星数量（1-10）" /></Label>
                   <Input
                     id="rating-max"
                     type="number"
@@ -1276,7 +1277,7 @@ export function FieldConfigForm({
                   />
                 </div>
                 <div className="flex items-center justify-between">
-                  <Label htmlFor="rating-half">允许半星</Label>
+                  <Label htmlFor="rating-half">允许半星 <HelpTooltip text="允许用户选择半颗星评分" /></Label>
                   <Switch id="rating-half" checked={ratingAllowHalf} onCheckedChange={setRatingAllowHalf} />
                 </div>
               </div>
@@ -1285,7 +1286,7 @@ export function FieldConfigForm({
             {fieldType === FieldType.CURRENCY && (
               <div className="grid gap-3">
                 <div className="grid gap-2">
-                  <Label htmlFor="currency-code">币种</Label>
+                  <Label htmlFor="currency-code">币种 <HelpTooltip text="货币字段的币种单位" /></Label>
                   <Select value={currencyCode} onValueChange={(value) => setCurrencyCode(value ?? "CNY")}>
                     <SelectTrigger id="currency-code">
                       <SelectValue />
@@ -1298,7 +1299,7 @@ export function FieldConfigForm({
                   </Select>
                 </div>
                 <div className="grid gap-2">
-                  <Label htmlFor="currency-decimals">小数位数</Label>
+                  <Label htmlFor="currency-decimals">小数位数 <HelpTooltip text="货币值保留的小数位数（0-6）" /></Label>
                   <Input
                     id="currency-decimals"
                     type="number"
@@ -1314,7 +1315,7 @@ export function FieldConfigForm({
 
             {fieldType === FieldType.PERCENTAGE && (
               <div className="grid gap-2">
-                <Label htmlFor="percentage-decimals">小数位数</Label>
+                <Label htmlFor="percentage-decimals">小数位数 <HelpTooltip text="百分比值保留的小数位数（0-4）" /></Label>
                 <Input
                   id="percentage-decimals"
                   type="number"
@@ -1329,7 +1330,7 @@ export function FieldConfigForm({
 
             {fieldType === FieldType.DURATION && (
               <div className="grid gap-2">
-                <Label htmlFor="duration-format">显示格式</Label>
+                <Label htmlFor="duration-format">显示格式 <HelpTooltip text="时长字段的显示格式" /></Label>
                 <Select value={durationFormat} onValueChange={(value) => setDurationFormat(value ?? "hh:mm")}>
                   <SelectTrigger id="duration-format">
                     <SelectValue />
@@ -1346,7 +1347,7 @@ export function FieldConfigForm({
             {isRelationType && (
               <>
                 <div className="grid gap-2">
-                  <Label htmlFor="relation-table-select">关联到表</Label>
+                  <Label htmlFor="relation-table-select">关联到表 <HelpTooltip text="选择要关联的目标数据表" /></Label>
                   <Select
                     value={selectedTableId}
                     onValueChange={(value) => {
@@ -1374,7 +1375,7 @@ export function FieldConfigForm({
 
                 {selectedTableId && (
                   <div className="grid gap-2">
-                    <Label htmlFor="relation-display-field-select">显示字段</Label>
+                    <Label htmlFor="relation-display-field-select">显示字段 <HelpTooltip text="在下拉列表中展示关联记录的哪个字段" /></Label>
                     <Select
                       value={selectedDisplayField}
                       onValueChange={(value) => setSelectedDisplayField(value ?? "")}
@@ -1412,7 +1413,7 @@ export function FieldConfigForm({
                 {fieldType === FieldType.RELATION_SUBTABLE && (
                   <>
                     <div className="grid gap-2">
-                      <Label htmlFor="relation-cardinality-select">本侧基数</Label>
+                      <Label htmlFor="relation-cardinality-select">本侧基数 <HelpTooltip text="当前表中每条记录可以关联几条目标记录：单条（1:1/1:N）或多条（N:N/N:1）" /></Label>
                       <Select
                         value={relationCardinality}
                         onValueChange={(value) => {
@@ -1439,7 +1440,7 @@ export function FieldConfigForm({
                     </div>
 
                     <div className="grid gap-2">
-                      <Label htmlFor="inverse-relation-cardinality-select">反向侧基数</Label>
+                      <Label htmlFor="inverse-relation-cardinality-select">反向侧基数 <HelpTooltip text="目标表中每条记录可以被几条当前记录关联" /></Label>
                       <Select
                         value={inverseRelationCardinality}
                         onValueChange={(value) =>
@@ -1472,7 +1473,7 @@ export function FieldConfigForm({
                     <div className="rounded-md border p-3" data-testid="relation-schema-editor">
                       <div className="flex items-center justify-between gap-2">
                         <div>
-                          <p className="font-medium">边属性</p>
+                          <p className="font-medium">边属性 <HelpTooltip text="在关联记录上附加的额外字段，用于存储关系本身的属性" /></p>
                           <p className="text-xs text-zinc-500">编辑 relationSchema.version = 1 的子字段</p>
                         </div>
                         <Button
@@ -1633,7 +1634,7 @@ export function FieldConfigForm({
               fieldType !== FieldType.AUTO_NUMBER && fieldType !== FieldType.SYSTEM_TIMESTAMP &&
               fieldType !== FieldType.SYSTEM_USER && (
               <div className="grid gap-2">
-                <Label htmlFor="defaultValue">默认值</Label>
+                <Label htmlFor="defaultValue">默认值 <HelpTooltip text="新建记录时自动填入的初始值" /></Label>
                 <Input
                   id="defaultValue"
                   placeholder="可选"

--- a/src/components/shared/help-tooltip.tsx
+++ b/src/components/shared/help-tooltip.tsx
@@ -1,0 +1,29 @@
+import { Info } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface HelpTooltipProps {
+  text: string;
+}
+
+export function HelpTooltip({ text }: HelpTooltipProps) {
+  return (
+    <TooltipProvider delay={300}>
+      <Tooltip>
+        <TooltipTrigger
+          type="button"
+          className="inline-flex items-center text-muted-foreground hover:text-foreground transition-colors ml-1"
+        >
+          <Info className="h-3.5 w-3.5" />
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={4} className="max-w-[280px]">
+          <p className="text-xs leading-relaxed">{text}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/components/templates/placeholder-config-table.tsx
+++ b/src/components/templates/placeholder-config-table.tsx
@@ -31,6 +31,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { getPlaceholderInputTypeLabel } from "@/lib/placeholder-input-type";
+import { HelpTooltip } from "@/components/shared/help-tooltip";
 
 interface TableColumn {
   key: string;
@@ -434,13 +435,13 @@ export const PlaceholderConfigTable = forwardRef<PlaceholderConfigTableHandle, {
             <TableHeader>
               <TableRow>
                 <TableHead className="w-[140px]">键名</TableHead>
-                <TableHead className="min-w-[160px]">标签</TableHead>
-                <TableHead className="min-w-[160px]">备注</TableHead>
-                <TableHead className="w-[130px]">输入类型</TableHead>
-                <TableHead className="w-[70px]">必填</TableHead>
-                <TableHead className="w-[140px]">默认值</TableHead>
-                <TableHead className="w-[80px]">排序</TableHead>
-                <TableHead className="w-[100px]">数据源</TableHead>
+                <TableHead className="min-w-[160px]">标签 <HelpTooltip text="填表时显示的字段名称，替代占位符键名" /></TableHead>
+                <TableHead className="min-w-[160px]">备注 <HelpTooltip text="填表时显示在字段下方的提示说明" /></TableHead>
+                <TableHead className="w-[130px]">输入类型 <HelpTooltip text="单行文本：普通输入框；多行文本：支持换行的文本域；明细表：表格形式录入多行数据" /></TableHead>
+                <TableHead className="w-[70px]">必填 <HelpTooltip text="填表时该占位符必须填写" /></TableHead>
+                <TableHead className="w-[140px]">默认值 <HelpTooltip text="填表时自动填入的初始值" /></TableHead>
+                <TableHead className="w-[80px]">排序 <HelpTooltip text="填表表单中的显示顺序" /></TableHead>
+                <TableHead className="w-[100px]">数据源 <HelpTooltip text="绑定数据表字段后，填表时可从数据表中选择已有数据" /></TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -642,7 +643,7 @@ export const PlaceholderConfigTable = forwardRef<PlaceholderConfigTableHandle, {
                 onCheckedChange={setEnablePicker}
                 id="enable-picker"
               />
-              <Label htmlFor="enable-picker">启用数据选择</Label>
+              <Label htmlFor="enable-picker">启用数据选择 <HelpTooltip text="开启后，填表时该字段可从数据表中搜索选择" /></Label>
             </div>
 
             {/* Data Source Configuration */}
@@ -657,7 +658,7 @@ export const PlaceholderConfigTable = forwardRef<PlaceholderConfigTableHandle, {
                   <>
                     {/* Source Table Select */}
                     <div className="space-y-2">
-                      <Label htmlFor="source-table">数据来源表</Label>
+                      <Label htmlFor="source-table">数据来源表 <HelpTooltip text="选择提供数据的源数据表" /></Label>
                       <Select
                         value={sourceTableId ?? ""}
                         onValueChange={(v) => {
@@ -683,7 +684,7 @@ export const PlaceholderConfigTable = forwardRef<PlaceholderConfigTableHandle, {
                     {/* Source Field Select */}
                     {sourceTableId && (
                       <div className="space-y-2">
-                        <Label htmlFor="source-field">数据字段</Label>
+                        <Label htmlFor="source-field">数据字段 <HelpTooltip text="选择展示给用户的数据表字段" /></Label>
                         <Select
                           value={sourceField ?? ""}
                           onValueChange={setSourceField}

--- a/src/components/templates/template-wizard.tsx
+++ b/src/components/templates/template-wizard.tsx
@@ -19,6 +19,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent } from "@/components/ui/card";
 import { PlaceholderConfigTable, type PlaceholderConfigTableHandle } from "./placeholder-config-table";
 import { CategorySelect } from "./category-select";
+import { HelpTooltip } from "@/components/shared/help-tooltip";
 import { TagMultiSelect } from "./tag-multi-select";
 
 // ── Types ──
@@ -507,7 +508,7 @@ export function TemplateWizard({ templateId }: TemplateWizardProps) {
               {/* File Upload Area */}
               <div className="space-y-2">
                 <label className="text-sm font-medium">
-                  模板文件 {isEditMode ? "(可选，留空则不替换)" : ""}
+                  模板文件 {isEditMode ? "(可选，留空则不替换)" : ""} <HelpTooltip text="上传包含 {{ 占位符 }} 标记的 .docx 文件，系统会自动识别其中的占位符" />
                 </label>
                 <div
                   className={`flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed p-8 transition-colors ${
@@ -559,7 +560,7 @@ export function TemplateWizard({ templateId }: TemplateWizardProps) {
               {/* Name */}
               <div className="space-y-2">
                 <label className="text-sm font-medium">
-                  模板名称 <span className="text-destructive">*</span>
+                  模板名称 <span className="text-destructive">*</span> <HelpTooltip text="模板的显示名称，会出现在模板列表和填表页面" />
                 </label>
                 <Input
                   value={name}
@@ -570,7 +571,7 @@ export function TemplateWizard({ templateId }: TemplateWizardProps) {
 
               {/* Description */}
               <div className="space-y-2">
-                <label className="text-sm font-medium">描述（可选）</label>
+                <label className="text-sm font-medium">描述（可选） <HelpTooltip text="模板的简要说明，帮助用户了解模板用途" /></label>
                 <Textarea
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
@@ -582,20 +583,20 @@ export function TemplateWizard({ templateId }: TemplateWizardProps) {
               {/* Category */}
               <div className="space-y-2">
                 <label className="text-sm font-medium">
-                  分类 <span className="text-destructive">*</span>
+                  分类 <span className="text-destructive">*</span> <HelpTooltip text="将模板归类到不同分类中，便于管理和查找" />
                 </label>
                 <CategorySelect value={categoryId} onChange={setCategoryId} />
               </div>
 
               {/* Tags */}
               <div className="space-y-2">
-                <label className="text-sm font-medium">标签（可选）</label>
+                <label className="text-sm font-medium">标签（可选） <HelpTooltip text="为模板添加标签，支持多标签筛选" /></label>
                 <TagMultiSelect value={tagIds} onChange={setTagIds} />
               </div>
 
               {/* Screenshot Upload */}
               <div className="space-y-2">
-                <label className="text-sm font-medium">模板截图（可选）</label>
+                <label className="text-sm font-medium">模板截图（可选） <HelpTooltip text="上传模板的预览截图，方便用户在列表中识别模板" /></label>
                 <div
                   className={`flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed p-4 transition-colors ${
                     screenshotPreview


### PR DESCRIPTION
## Summary

- 创建可复用 `HelpTooltip` 组件（`ⓘ` 图标 + 悬停显示说明文字）
- 在 5 个配置区域共 75 处 label 旁添加 tooltip 说明，覆盖：数据表字段配置、自动化编辑器与配置面板、占位符配置、文档收集、模板向导
- 帮助用户理解各配置项的含义和用途

## Changes

| 文件 | Tooltip 数量 |
|------|-------------|
| `src/components/shared/help-tooltip.tsx` | 新建组件 |
| `src/components/data/field-config-form.tsx` | 26 |
| `src/components/automations/automation-editor.tsx` | 4 |
| `src/components/automations/automation-config-panel.tsx` | 21 |
| `src/components/templates/placeholder-config-table.tsx` | 10 |
| `src/components/collections/collection-task-form.tsx` | 5 |
| `src/components/collections/collection-rename-rule-editor.tsx` | 1 |
| `src/components/collections/collection-attachments-upload.tsx` | 1 |
| `src/components/templates/template-wizard.tsx` | 6 |

## Test plan

- [x] TypeScript 类型检查通过（`npx tsc --noEmit`）
- [x] ESLint 无新增错误
- [x] 字段配置表单 tooltip 悬停显示正确
- [x] 模板向导 tooltip 悬停显示正确
- [ ] 自动化编辑器 tooltip 验证（需有自动化数据）
- [ ] 占位符配置 tooltip 验证（需进入模板编辑流程）
- [ ] 文档收集表单 tooltip 验证

## Spec

- 设计规格: `docs/superpowers/specs/2026-05-06-config-tooltips.md`

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>